### PR TITLE
Helm fixes

### DIFF
--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -83,6 +83,7 @@ spec:
               start
               --
               --default-log-level={{ .Values.config.seastar.default_log_level }}
+              --reserve-memory 0M
           env:
             - name: MY_POD_IP
               valueFrom:


### PR DESCRIPTION
### Improvements here

- [x] Don't mount datadir in init container - it's not used
- [x] Don't reserve memory for the OS - allows 1Gi memory limit

### Future Improvements

- [ ] Pod affinity doesn't have the correct labels - maybe inline it - and use `matchLabels` instead of `matchExpressions` 
- [ ] cpu request/limit and smp should be aligned or have comments cross-referencing them
- [ ] `Values.yaml`is a bit chaotic, possibly not simple enough, laid out well, or documented
  - [ ] Do we need extra labels and annotations for everything individually? Or at all?
  - [ ] Group things around K8s concepts: `pod`, `statefulSet`; e.g., `affinity`, `nodeSelector`, `tolerations`
- [ ] TLS configuration will need certificates mounted from `configMap`s
- [ ] Anything else I've forgotten from the previous reviews