### PR TITLE
values.yaml cleanup

### DIFF
--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -23,8 +23,8 @@ The pods will rollout in a few seconds. To check the status:
 
 Try some sample commands, like creating a topic called topic1:
 
-  $ kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} rpk -- --brokers={{ include "redpanda.name" . }}:{{ .Values.config.redpanda.advertised_kafka_api.port }} api topic create topic1 --partitions=3 --replicas={{ .Values.statefulset.replicas }}
+  $ kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} rpk -- --brokers={{ include "redpanda.name" . }}:{{ .Values.config.redpanda.kafka_api.port }} api topic create topic1 --partitions=3 --replicas={{ .Values.statefulset.replicas }}
 
 To get the api status:
  
-  $ kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} rpk -- --brokers={{ include "redpanda.name" . }}:{{ .Values.config.redpanda.advertised_kafka_api.port }} api status
+  $ kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} rpk -- --brokers={{ include "redpanda.name" . }}:{{ .Values.config.redpanda.kafka_api.port }} api status

--- a/redpanda/templates/configmap.yaml
+++ b/redpanda/templates/configmap.yaml
@@ -31,7 +31,7 @@ metadata:
   {{- end }}
 data:
   redpanda.yaml: |
-    config_file: {{ .Values.config.config_file }}
+    config_file: /etc/redpanda/redpanda.yaml
     license_key: {{ .Values.config.license_key }}
     organization: {{ .Values.config.organization }}
     redpanda:
@@ -42,7 +42,7 @@ data:
         - node_id: {{ . }}
           host:
             address: {{ template "redpanda.name" $envAll }}-{{ . }}.{{ template "redpanda.name" $envAll }}.{{ $envAll.Release.Namespace }}.svc.{{ $envAll.Values.clusterDomain }}
-            port: {{ $envAll.Values.config.redpanda.advertised_rpc_api.port }}
+            port: {{ $envAll.Values.config.redpanda.rpc_server.port }}
         {{- end }}
     rpk:
 {{ toYaml .Values.config.rpk | indent 6 }}

--- a/redpanda/templates/headless-service.yaml
+++ b/redpanda/templates/headless-service.yaml
@@ -35,8 +35,8 @@ spec:
   ports:
     - name: kafka-tcp
       protocol: TCP
-      port: {{ .Values.config.redpanda.advertised_kafka_api.port }}
-      targetPort: {{ .Values.config.redpanda.advertised_kafka_api.port }}
+      port: {{ .Values.config.redpanda.kafka_api.port }}
+      targetPort: {{ .Values.config.redpanda.kafka_api.port }}
   selector:
     app.kubernetes.io/name: {{ template "redpanda.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -68,7 +68,9 @@ spec:
                 rpk --config $CONFIG config set redpanda.seed_servers '[]' --format yaml;
               fi;
               rpk --config $CONFIG config set redpanda.advertised_rpc_api.address $SERVICE_NAME;
+              rpk --config $CONFIG config set redpanda.advertised_rpc_api.port {{ .Values.config.redpanda.rpc_server.port }};
               rpk --config $CONFIG config set redpanda.advertised_kafka_api.address $SERVICE_NAME;
+              rpk --config $CONFIG config set redpanda.advertised_kafka_api.port  {{ .Values.config.redpanda.kafka_api.port }};
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
               mountPath: /tmp/base-config 
@@ -81,8 +83,6 @@ spec:
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           args:
             - >
-              --rpc-addr $(MY_POD_IP):33145
-              --kafka-addr $(MY_POD_IP):9092
               --check=false
               --smp {{ .Values.statefulset.resources.limits.cpu }}
               --memory {{ template "redpanda.parseMemory" . }}
@@ -90,21 +90,16 @@ spec:
               --
               --default-log-level={{ .Values.config.seastar.default_log_level }}
               --reserve-memory 0M
-          env:
-            - name: MY_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
           ports:
             - containerPort: {{ .Values.config.redpanda.admin.port }}
               name: admin
-            - containerPort: {{ .Values.config.redpanda.advertised_kafka_api.port }}
+            - containerPort: {{ .Values.config.redpanda.kafka_api.port }}
               name: kafka
-            - containerPort: {{ .Values.config.redpanda.advertised_rpc_api.port }}
+            - containerPort: {{ .Values.config.redpanda.rpc_server.port }}
               name: rpc
           volumeMounts:
             - name: datadir
-              mountPath: {{ .Values.config.redpanda.data_directory }}
+              mountPath: /var/lib/redpanda/data
             - name: config
               mountPath: /etc/redpanda
           resources:

--- a/redpanda/templates/tests/test-api-status.yaml
+++ b/redpanda/templates/tests/test-api-status.yaml
@@ -36,7 +36,7 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ .Values.image.tag }} 
-      args: ["api", "status", "--brokers", "{{ include "redpanda.name" . }}:{{ .Values.config.redpanda.advertised_kafka_api.port }}"]
+      args: ["api", "status", "--brokers", "{{ include "redpanda.name" . }}:{{ .Values.config.redpanda.kafka_api.port }}"]
       volumeMounts:
         - name: {{ template "redpanda.fullname" . }}-config 
           mountPath: /tmp/base-config 

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -23,8 +23,6 @@
 # For an explanation of Redpanda configuration values:
 #   https://vectorized.io/docs/advanced-configuration/
 
-clusterDomain: cluster.local
-
 image:
   repository: vectorized/redpanda
   # The imagePullPolicy will default to Always when the tag is 'latest'
@@ -34,50 +32,66 @@ image:
 labels: {}
   # app.kubernetes.io/part-of: my-app
 
+clusterDomain: cluster.local
+
 # See https://vectorized.io/docs/configuration/
 config:
-  config_file: /etc/redpanda/redpanda.yaml
+  # If you have a license key please set it here or you can request one
+  # here: https://vectorized.io/redpanda 
   license_key: ""
+
+  # Update with your organization name
   organization: ""
+  
   redpanda:
     admin:
-      address: 0.0.0.0
+      # The port for the admin server. 
+      # 
+      # Metrics are served off of this port at /metrics. 
       port: 9644
-    advertised_kafka_api:
-      address: 0.0.0.0
-      port: 9092
-    advertised_rpc_api:
-      address: 0.0.0.0
-      port: 33145
-    auto_create_topics_enabled: true
-    data_directory: /var/lib/redpanda/data
-    developer_mode: false
     kafka_api:
-      address: 0.0.0.0
+      # The port for the Kafka API.
       port: 9092
-    kafka_api_tls:
-      cert_file: ""
-      enabled: false
-      key_file: ""
-      truststore_file: ""
-    node_id: 0
     rpc_server:
-      address: 0.0.0.0
+      # The port for the internal RPC server.
       port: 33145
+
   rpk:
-    coredump_dir: /var/lib/redpanda/coredump
+    # Enables memory locking. 
     enable_memory_locking: false
+   
+    # Send usage stats back to vectorized
     enable_usage_stats: true
+
+    # This should be set to true unless with have CPU affinity 
+    # https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy
+    # 
+    # Equivalent to passing the following to redpanda
+    # --idle-poll-time-us 0 --thread-affinity 0 --poll-aio 0
     overprovisioned: true
-    tls:
-      cert_file: ""
-      key_file: ""
-      truststore_file: ""
+
+    # Increases the number of allowed asynchronous IO events
     tune_aio_events: false
+
+    # Syncs NTP 
     tune_clocksource: false
+
+    # Installs a custom script to process coredumps and save them to the given directory.
     tune_coredump: false
+
+    # Disables hyper-threading, sets the ACPI-cpufreq governor to 'performance'. Additionaly
+    # if system reboot is allowed: disables Intel P-States, disables Intel C-States,
+    # disables Turbo Boost
+    # 
+    # This is not possible to set to true while running in a container. 
     tune_cpu: false
+    
+    # Distributes IRQs across cores with the method deemed the most appropriate for the
+    # current device type (i.e. NVMe)
+    #
+    # This is not possible to set to true while running in a container. 
     tune_disk_irq: false
+  
   seastar:
     default_log_level: info
 
@@ -110,7 +124,7 @@ statefulset:
   resources:
     limits:
       cpu: 1
-      memory: 3Gi
+      memory: 2Gi
 
   # Inter-Pod Affinity rules for scheduling Pods of this StatefulSet.
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity
@@ -147,9 +161,6 @@ statefulset:
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
 
-nameOverride: ""
-fullnameOverride: ""
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: false
@@ -158,8 +169,6 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
-
-podAnnotations: {}
 
 # When using persistent storage the volume will be mounted as root. In order for redpanda to use the volume
 # we must set the fsGroup to the uid of redpanda, which is 101
@@ -174,7 +183,6 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
-nodeSelector: {}
 
 storage:
   # Absolute path on host to store Redpanda's data.
@@ -201,12 +209,3 @@ storage:
     labels: {}
     # Additional annotations to apply to the created PersistentVolumeClaims.
     annotations: {}
-
-tolerations: []
-
-
-
-pdb:
-  enabled: true
-  maxUnavailable: 1
-  minAvailable:


### PR DESCRIPTION
- Removed a number of configs that should not be set by the user.
- Changed from using the advertised address to listen to addresses.
  There will be more changes here in the future but should be done by the ingress side of things.
- Removed rpc and kafka-addr start flags.
- Removed configs no longer used.
- Added comments to a number of configs.