### PR TITLE
Add dedicated parameters for memory flags

### DIFF
--- a/redpanda/ci/01-one-node-cluster-values.yaml
+++ b/redpanda/ci/01-one-node-cluster-values.yaml
@@ -17,3 +17,6 @@ statefulset:
   resources:
     limits:
       memory: 1Gi
+  redpanda:
+    memory: 700M
+    reservedMemory: 200M

--- a/redpanda/templates/_helpers.tpl
+++ b/redpanda/templates/_helpers.tpl
@@ -53,21 +53,6 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Strip out the suffixes on memory to pass to Redpanda
-*/}}
-{{- define "redpanda.parseMemory" -}}
-{{- $type := typeOf .Values.statefulset.resources.limits.memory }}
-{{- if eq $type "float64" }}
-{{- .Values.statefulset.resources.limits.memory | int64 }}
-{{- else if eq $type "int" }}
-{{- .Values.statefulset.resources.limits.memory }}
-{{- else }}
-{{- $string := .Values.statefulset.resources.limits.memory | toString }}
-{{- regexReplaceAll "(\\d+)(\\w?)i?" $string "${1}${2}" }}
-{{- end }}
-{{- end }}
-
-{{/*
 Generate configuration needed for rpk
 */}}
 

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -101,8 +101,8 @@ spec:
               redpanda
               start
               --smp={{ .Values.statefulset.resources.limits.cpu }}
-              --memory={{ template "redpanda.parseMemory" . }}
-              --reserve-memory=0M
+              --memory={{ .Values.statefulset.redpanda.memory }}
+              --reserve-memory={{ .Values.statefulset.redpanda.reservedMemory }}
               {{- if (first .Values.config.redpanda.kafka_api).external.enabled }}
               --advertise-kafka-addr=kafka://{{ template "redpanda.kafka.internal.advertise.address" . }}:{{ template "redpanda.kafka.internal.advertise.port" . }},external://{{ template "redpanda.kafka.external.advertise.address" . }}:{{ template "redpanda.kafka.external.advertise.nodeport.port" . }},
               --kafka-addr=kafka://{{ template "redpanda.kafka.internal.listen.address" . }}:{{ template "redpanda.kafka.internal.listen.port" . }},external://{{ template "redpanda.kafka.external.listen.address" . }}:{{ template "redpanda.kafka.external.listen.port" . }},

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -160,7 +160,19 @@ statefulset:
   resources:
     limits:
       cpu: 1
-      memory: 2Gi
+      memory: 2.5Gi
+
+  # Redpanda memory parameter can not exceed POD resource memory limit
+  # Example calculation:
+  # statefulset.redpanda.memory = 0.8 statefulset.resources.limits.memory
+  #
+  # NOTE: Memory flag does not support float numbers and support only E, P, T, G, M, k suffixes
+  # REF:
+  # https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-memory
+  # https://kubernetes.io/docs/reference/kubernetes-api/common-definitions/quantity/
+  redpanda:
+    memory: 2G
+    reservedMemory: 400k
 
   # Inter-Pod Affinity rules for scheduling Pods of this StatefulSet.
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#inter-pod-affinity-and-anti-affinity


### PR DESCRIPTION
The calculation for memory based on float number in limits memory is too complicated.
Reserved memory flag does not play nice with float number for memory declaration e.g. 0.4G