### PR TITLE
reserve memory auto configuration added #49

### DIFF
--- a/redpanda/ci/01-one-node-cluster-values.yaml
+++ b/redpanda/ci/01-one-node-cluster-values.yaml
@@ -16,4 +16,4 @@ statefulset:
   replicas: 1
   resources:
     limits:
-      memory: 1Gi
+      memory: 2Gi

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -101,8 +101,8 @@ spec:
               redpanda
               start
               --smp={{ .Values.statefulset.resources.limits.cpu }}
-              --memory={{ template "redpanda.parseMemory" . }}
-              --reserve-memory=0M
+              --memory={{ .Values.statefulset.resources.limits.memory | include "redpanda.toMBFromQuantity" | include "redpanda.memoryFromMB" }}
+              --reserve-memory={{ .Values.statefulset.resources.limits.memory | include "redpanda.toMBFromQuantity" | include "redpanda.reserveMemoryFromMB" }}
               {{- if (first .Values.config.redpanda.kafka_api).external.enabled }}
               --advertise-kafka-addr=kafka://{{ template "redpanda.kafka.internal.advertise.address" . }}:{{ template "redpanda.kafka.internal.advertise.port" . }},external://{{ template "redpanda.kafka.external.advertise.address" . }}:{{ template "redpanda.kafka.external.advertise.nodeport.port" . }},
               --kafka-addr=kafka://{{ template "redpanda.kafka.internal.listen.address" . }}:{{ template "redpanda.kafka.internal.listen.port" . }},external://{{ template "redpanda.kafka.external.listen.address" . }}:{{ template "redpanda.kafka.external.listen.port" . }},


### PR DESCRIPTION
Reserve memory can be auto configured. It utilises the formula supplied by @travisdowns . There is potentially scope to override these values directly in the config without the automatic configuration though hopefully we can discuss on this PR.

It is related to issue #49 - note the available sprig math functions were not particularly helpful, hence the basic implementation.