### PR TITLE
Cleanup storage section

### DIFF
--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -57,6 +57,12 @@ spec:
       securityContext:
 {{- toYaml .Values.statefulset.podSecurityContext | nindent 8 }}
       initContainers:
+        - name: set-datadir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", "chown 101:101 -R /var/lib/redpanda/data"]
+          volumeMounts:
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
         - name: {{ template "redpanda.name" . }}-configurator
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           command: ["/bin/sh", "-c"]

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -168,10 +168,7 @@ listeners:
 logLevel: info
 #
 # Persistence
-# TODO modify to conform to https://github.com/bitnami/charts/blob/master/bitnami/kafka/values.yaml#L888
 storage:
-  # TODO make use of enabled parameter
-  enabled: true
   # Absolute path on host to store Redpanda's data.
   # If not specified, then `emptyDir` will be used instead.
   # If specified, but `persistentVolume.enabled` is `true`, then has no effect.
@@ -179,10 +176,8 @@ storage:
   # If `enabled` is `true` then a PersistentVolumeClaim will be created and
   # used to store Redpanda's data, otherwise `hostPath` is used.
   persistentVolume:
-    # TODO possibly replace with storage.enabled
     enabled: true
-    # TODO lower default size to a more reasonable size (10 - 50 Mi)
-    size: 100Gi
+    size: 3Gi
     # If defined, then `storageClassName: <storageClass>`.
     # If set to "-", then `storageClassName: ""`, which disables dynamic
     # provisioning.


### PR DESCRIPTION
- remove storage.enabled
- lower default PV size to 3Gi
- add initContainer that properly changes ownership on mounted volume

A good side effect of changes in this PR is that minikube now works as expected with persistent volumes (see comments in #79).

closes #79