### PR TITLE
fix name generation when .Release.Name is different from .Chart.Name

### DIFF
--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -53,15 +53,15 @@ CERT=$(kubectl exec -n {{ .Release.Namespace }} {{ template "redpanda.name" . }}
 
 With TLS enabled create a topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic create test-topic --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic create test-topic --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
 
 Describe the topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic describe test-topic --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic describe test-topic --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
 
 Delete the topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic delete test-topic --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic delete test-topic --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
 
 {{- end -}}
 
@@ -69,19 +69,19 @@ Delete the topic:
 
 Create admin user:
 
- kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk acl user create admin --api-urls {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} --user admin --password test --sasl-mechanism  SCRAM-SHA-256"
+ kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk acl user create admin --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} --user admin --password test --sasl-mechanism  SCRAM-SHA-256"
 
 With SASL enabled create a topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic create test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic create test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"
 
 Describe the topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic describe test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic describe test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"
 
 Delete the topic:
 
-  kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic delete test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"
+  kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic delete test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }}"
 
 {{- end -}}
 
@@ -95,19 +95,19 @@ ADMINCERT=$(kubectl exec -n {{ .Release.Namespace }} {{ template "redpanda.name"
 
 Create admin user:
 
- kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk acl user create admin --api-urls {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} --user admin --password test --sasl-mechanism  SCRAM-SHA-256 --admin-api-tls-enabled --admin-api-tls-truststore <(echo '$ADMINCERT')"
+ kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk acl user create admin --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} --user admin --password test --sasl-mechanism  SCRAM-SHA-256 --admin-api-tls-enabled --admin-api-tls-truststore <(echo '$ADMINCERT')"
 
 With TLS enabled create a topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic create test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic create test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
 
 Describe the topic:
 
-  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic describe test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
+  kubectl -n {{ .Release.Namespace }} run rpk -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic describe test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
 
 Delete the topic:
 
-  kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic delete test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
+  kubectl -n {{ .Release.Namespace }} run -ti --rm --restart=Never --image {{ .Values.image.repository }}:{{ .Values.image.tag }} --command -- /bin/bash -c "rpk topic delete test-topic --user admin --password test --sasl-mechanism SCRAM-SHA-256 --brokers {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.kafka.internal.advertise.port" $ }} --tls-enabled --tls-truststore <(echo '$CERT')"
 
 {{- end -}}
 

--- a/redpanda/templates/post-upgrade.yaml
+++ b/redpanda/templates/post-upgrade.yaml
@@ -33,20 +33,20 @@ spec:
     spec:
       restartPolicy: Never
       containers:
-      - name: {{ template "redpanda.name" . }}-post-upgrade
+      - name: {{ template "redpanda.fullname" . }}-post-upgrade
         image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
         command: ["/bin/sh", "-c"]
         args:
           - >
 {{- if and (eq (include "tls-enabled" .) "true")  (eq (include "sasl-enabled" .) "true") }}
-            rpk --api-urls {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml --admin-api-tls-enabled --admin-api-tls-truststore /etc/tls/certs/admin/ca.crt --tls-enabled --tls-truststore /etc/tls/certs/admin/ca.crt --user admin --password test --sasl-mechanism SCRAM-SHA-256;
+            rpk --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml --admin-api-tls-enabled --admin-api-tls-truststore /etc/tls/certs/admin/ca.crt --tls-enabled --tls-truststore /etc/tls/certs/admin/ca.crt --user admin --password test --sasl-mechanism SCRAM-SHA-256;
 
 {{- else if eq (include "tls-enabled" .) "true" }}
-            rpk --api-urls {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml --admin-api-tls-enabled --admin-api-tls-truststore /etc/tls/certs/admin/ca.crt --tls-enabled --tls-truststore /etc/tls/certs/admin/ca.crt;
+            rpk --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml --admin-api-tls-enabled --admin-api-tls-truststore /etc/tls/certs/admin/ca.crt --tls-enabled --tls-truststore /etc/tls/certs/admin/ca.crt;
 {{- else if eq (include "sasl-enabled" .) "true" }}
-            rpk --api-urls {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml --user admin --password test --sasl-mechanism SCRAM-SHA-256;
+            rpk --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml --user admin --password test --sasl-mechanism SCRAM-SHA-256;
 {{- else }}
-            rpk --api-urls {{ template "redpanda.name" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml;
+            rpk --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ template "redpanda.admin.port" $ }} cluster config import -f /tmp/base-config/bootstrap.yaml;
 {{- end }}            
         volumeMounts:
           - name: {{ template "redpanda.fullname" . }}


### PR DESCRIPTION
when i tried deploying the chart with a release name different than `redpanda` then the `post-update.yaml` hooks failed due to `--api-urls` were incorrectly generated.
they always generated `redpanda-{n}` instead of `.Release.Name-{n}`