### PR TITLE
Update doc k8s version requirement to 1.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ See the [values.yaml](./redpanda/values.yaml) file for all possible properties.
 ### Required software
 
 * Helm >= 3.0
-* Kubernetes >= 1.18
+* Kubernetes >= 1.21
 * Cert-Manager (optional, needed for TLS)
 * MetalLB (optional)
 


### PR DESCRIPTION
- a user tried to use helm v2 in k8s 1.20 but it failed
- it seems that PodDisruptionBudget CRD is only in 1.21+