### PR TITLE
fix readiness probe to only report readiness of itself

### DIFF
--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
   - name: redpanda-data
     url: https://github.com/orgs/redpanda-data/people
 type: application
-version: 2.1.0
+version: 2.1.1
 appVersion: 22.2.2
 icon: https://redpanda.com/static/skate-panda-9c2e4bc5a1ed0052554e658519a50882.svg
 sources:

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -118,11 +118,25 @@ spec:
                 - >
                   curl https://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview
                   -svk --cacert /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt |
-                  grep '"is_healthy": true'
+                  awk '{
+                    id = $0; gsub(/.*"controller_id": /, "", id); gsub(/,.*/, "", id)
+                    nd_str = $0; gsub(/.*"nodes_down": \[/, "", nd_str); gsub(/\].*/, "", nd_str)
+                    FS=","
+                    split(nd_str, nd_list)
+                    for (i in nd_list) nodes_down[nd_list[i]]=""
+                    exit (id in nodes_down)
+                  }'
                 {{- else }}
                 - >
                   curl -sv http://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview |
-                  grep '"is_healthy": true'
+                  awk '{
+                    id = $0; gsub(/.*"controller_id": /, "", id); gsub(/,.*/, "", id)
+                    nd_str = $0; gsub(/.*"nodes_down": \[/, "", nd_str); gsub(/\].*/, "", nd_str)
+                    FS=","
+                    split(nd_str, nd_list)
+                    for (i in nd_list) nodes_down[nd_list[i]]=""
+                    exit (id in nodes_down)
+                  }'
                 {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.startupProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.startupProbe.failureThreshold }}
@@ -135,12 +149,10 @@ spec:
                 {{- if (include "admin-internal-tls-enabled" . |fromJson).bool }}
                 - >
                   curl https://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview
-                  -svk --cacert /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt |
-                  grep '"is_healthy": true'
+                  -svk --cacert /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt
                 {{- else }}
                 - >
-                  curl -sv http://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview |
-                  grep '"is_healthy": true'
+                  curl -sv http://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview
                 {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
@@ -154,11 +166,25 @@ spec:
                 - >
                   curl https://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview
                   -svk --cacert /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt |
-                  grep '"is_healthy": true'
+                  awk '{
+                    id = $0; gsub(/.*"controller_id": /, "", id); gsub(/,.*/, "", id)
+                    nd_str = $0; gsub(/.*"nodes_down": \[/, "", nd_str); gsub(/\].*/, "", nd_str)
+                    FS=","
+                    split(nd_str, nd_list)
+                    for (i in nd_list) nodes_down[nd_list[i]]=""
+                    exit (id in nodes_down)
+                  }'
                 {{- else }}
                 - >
                   curl -sv http://localhost:{{ .Values.listeners.admin.port }}/v1/cluster/health_overview |
-                  grep '"is_healthy": true'
+                  awk '{
+                    id = $0; gsub(/.*"controller_id": /, "", id); gsub(/,.*/, "", id)
+                    nd_str = $0; gsub(/.*"nodes_down": \[/, "", nd_str); gsub(/\].*/, "", nd_str)
+                    FS=","
+                    split(nd_str, nd_list)
+                    for (i in nd_list) nodes_down[nd_list[i]]=""
+                    exit (id in nodes_down)
+                  }'
                 {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -235,11 +235,11 @@ statefulset:
     failureThreshold: 120
     periodSeconds: 10
   livenessProbe:
-    initialDelaySeconds: 30
+    initialDelaySeconds: 10
     failureThreshold: 3
     periodSeconds: 10
   readinessProbe:
-    initialDelaySeconds: 10
+    initialDelaySeconds: 1
     failureThreshold: 3
     periodSeconds: 10
     successThreshold: 1


### PR DESCRIPTION
The liveness probe was checking more than just liveness. Changed it to just report success if it can query an api endpoint.
The readiness probe was failing if any node on the cluster was down. This was causing the entire cluster to become unavailable if a pod was restarted. Changed it to just check for itself being reported as down by the redpanda health overview.