### PR TITLE
add job to set/update sasl superusers and license

### DIFF
--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
   - name: redpanda-data
     url: https://github.com/orgs/redpanda-data/people
 type: application
-version: 2.1.2
+version: 2.1.3
 appVersion: 22.2.2
 icon: https://redpanda.com/static/skate-panda-9c2e4bc5a1ed0052554e658519a50882.svg
 sources:

--- a/redpanda/templates/NOTES.txt
+++ b/redpanda/templates/NOTES.txt
@@ -49,14 +49,14 @@ Try some sample commands, like creating a topic called test-topic:
   {{ $rpkAdmin = $rpk }}
 {{- end }}
 {{- if $anySASL }}
-  {{ $rpk = printf "%s %s" $rpk "--user admin --password test --sasl-mechanism  SCRAM-SHA-256" }}
-  {{ $rpkAdmin = printf "%s %s" $rpkAdmin "--user admin --password test --sasl-mechanism  SCRAM-SHA-256" }}
+  {{ $rpk = printf "%s --user %s --password $YOUR_PASSWORD --sasl-mechanism SCRAM-SHA-256" $rpk (.Values.auth.sasl.users | first).name }}
+  {{ $rpkAdmin = printf "%s --user %s --password $YOUR_PASSWORD --sasl-mechanism SCRAM-SHA-256" $rpkAdmin (.Values.auth.sasl.users | first).name }}
 {{- end }}
 
 {{- if and $anySASL }}
 Create a user:
 
-  {{ $rpkAdmin }} acl user create admin
+  {{ $rpkAdmin }} acl user create myuser -p changeme
 {{- end }}
 
 Get the api status:

--- a/redpanda/templates/configmap.yaml
+++ b/redpanda/templates/configmap.yaml
@@ -52,9 +52,6 @@ data:
 {{- end }}
   redpanda.yaml: |
     config_file: /etc/redpanda/redpanda.yaml
-{{- with .Values.license_key }}
-    license_key: {{ . }}
-{{- end }}
 {{- if .Values.logging.usageStats.enabled }}
   {{- with (dig "usageStats" "organization" "" .Values.logging) }}
     organization: {{ . }}

--- a/redpanda/templates/post-install-upgrade-job.yaml
+++ b/redpanda/templates/post-install-upgrade-job.yaml
@@ -1,0 +1,102 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "redpanda.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "redpanda.chart" . }}
+    app.kubernetes.io/name: {{ template "redpanda.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "redpanda.name" . }}
+{{- with .Values.commonLabels }}
+  {{- toYaml . | nindent 4 }}
+{{- end }}
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/name: {{ template "redpanda.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        app.kubernetes.io/component: {{ template "redpanda.name" . }}
+{{- with .Values.commonLabels }}
+  {{- toYaml . | nindent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: {{ template "redpanda.name" . }}-post-install
+        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        command:
+            - bash
+            - -c
+        args:
+          - >
+{{- if .Values.auth.sasl.enabled }}
+  {{- range $user := .Values.auth.sasl.users }}
+            {{ template "rpk-command" $ }} acl user create {{ $user.name }} -p {{ $user.password | quote }}
+            ;
+  {{- end }}
+{{- end }}
+{{- if and (include "redpanda.semver" . | semverCompare ">=22.2.0") (not (empty .Values.license_key)) }}
+            {{ template "rpk-command" $ }} cluster license set {{ .Values.license_key | quote }}
+            ;
+{{- end }}
+        volumeMounts:
+          - name: {{ template "redpanda.fullname" . }}
+            mountPath: /tmp/base-config
+          - name: config
+            mountPath: /etc/redpanda
+{{- if (include "tls-enabled" . | fromJson).bool }}
+  {{- range $name, $cert := .Values.tls.certs }}
+          - name: redpanda-{{ $name }}-cert
+            mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+  {{- end }}
+{{- end }}
+      volumes:
+        - name: {{ template "redpanda.fullname" . }}
+          configMap:
+            name: {{ template "redpanda.fullname" . }}
+        - name: config
+          emptyDir: {}
+{{- if (include "tls-enabled" . | fromJson).bool }}
+  {{- range $name, $cert := .Values.tls.certs }}
+        - name: redpanda-{{ $name }}-cert
+          secret:
+            defaultMode: 420
+            items:
+            - key: tls.key
+              path: tls.key
+            - key: tls.crt
+              path: tls.crt
+    {{- if $cert.caEnabled }}
+            - key: ca.crt
+              path: ca.crt
+    {{- end }}
+            secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+  {{- end }}
+{{- end -}}


### PR DESCRIPTION
Remove non-functional license_key from the redpanda.yaml and implement a post-install/post-upgrade job that sets up the superusers and the license.

fixes #154 