### PR TITLE
increase default persistent volume size

### DIFF
--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
   - name: redpanda-data
     url: https://github.com/orgs/redpanda-data/people
 type: application
-version: 2.2.1
+version: 2.2.2
 appVersion: v22.2.6
 icon: https://images.ctfassets.net/paqvtpyf8rwu/3cYHw5UzhXCbKuR24GDFGO/73fb682e6157d11c10d5b2b5da1d5af0/skate-stand-panda.svg
 sources:

--- a/redpanda/ci/01-one-node-cluster-no-tls-no-sasl.yaml
+++ b/redpanda/ci/01-one-node-cluster-no-tls-no-sasl.yaml
@@ -19,3 +19,6 @@ tls:
 auth:
   sasl:
     enabled: false
+storage:
+  persistentVolume:
+    size: 3Gi

--- a/redpanda/ci/02-one-node-cluster-tls-no-sasl.yaml
+++ b/redpanda/ci/02-one-node-cluster-tls-no-sasl.yaml
@@ -19,3 +19,6 @@ tls:
 auth:
   sasl:
     enabled: false
+storage:
+  persistentVolume:
+    size: 3Gi

--- a/redpanda/ci/03-one-node-cluster-no-tls-sasl.yaml
+++ b/redpanda/ci/03-one-node-cluster-no-tls-sasl.yaml
@@ -19,3 +19,6 @@ tls:
 auth:
   sasl:
     enabled: true
+storage:
+  persistentVolume:
+    size: 3Gi

--- a/redpanda/ci/04-one-node-cluster-tls-sasl.yaml
+++ b/redpanda/ci/04-one-node-cluster-tls-sasl.yaml
@@ -19,3 +19,6 @@ tls:
 auth:
   sasl:
     enabled: true
+storage:
+  persistentVolume:
+    size: 3Gi

--- a/redpanda/templates/configmap.yaml
+++ b/redpanda/templates/configmap.yaml
@@ -49,6 +49,9 @@ data:
   {{- with (dig "tunable" dict .Values.config) }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
+    storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
+  {{- end }}
 {{- end }}
   redpanda.yaml: |
     config_file: /etc/redpanda/redpanda.yaml
@@ -67,10 +70,13 @@ data:
       superusers: {{ toJson $users }}
   {{- end }}
   {{- with (dig "cluster" dict .Values.config) }}
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
   {{- end }}
   {{- with (dig "tunable" dict .Values.config) }}
-    {{- toYaml . | nindent 6 }}
+      {{- toYaml . | nindent 6 }}
+  {{- end }}
+  {{- if not (hasKey "storage_min_free_bytes" .Values.config.cluster) }}
+      storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
   {{- end }}
 {{- end }}
       {{- with dig "node" dict .Values.config }}

--- a/redpanda/templates/post-install-upgrade-job.yaml
+++ b/redpanda/templates/post-install-upgrade-job.yaml
@@ -58,12 +58,12 @@ spec:
           - >
 {{- if .Values.auth.sasl.enabled }}
   {{- range $user := .Values.auth.sasl.users }}
-            rpk acl user create {{ $user.name }} -p {{ $user.password | quote }} {{ template "rpk-flags" $ }} 
+            rpk acl user create {{ $user.name }} -p {{ $user.password | quote }} {{ template "rpk-common-flags" $ }} 
             ;
   {{- end }}
 {{- end }}
 {{- if and (include "redpanda.semver" . | semverCompare ">=22.2.0") (not (empty .Values.license_key)) }}
-            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-flags" $ }} 
+            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-common-flags" $ }} 
             ;
 {{- end }}
         {{- with .Values.post_install_job.resources }}

--- a/redpanda/templates/post-upgrade.yaml
+++ b/redpanda/templates/post-upgrade.yaml
@@ -1,4 +1,5 @@
 {{- if (include "redpanda.semver" . | semverCompare ">=22.1.1") }}
+{{- $rpkFlags := include "rpk-common-flags" . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -36,21 +37,13 @@ spec:
         image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
         command: ["/bin/sh", "-c"]
         args:
-          - >
-            rpk cluster config import -f /tmp/base-config/bootstrap.yaml
-            --api-urls {{ template "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}
-{{- if (include "admin-internal-tls-enabled" . | fromJson).bool }}
-            --admin-api-tls-enabled
-            --admin-api-tls-truststore /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt
+          - |
+            rpk cluster config import -f /tmp/base-config/bootstrap.yaml {{ $rpkFlags }}
+{{- range $key, $value := .Values.config.cluster }}
+            rpk cluster config set {{ $key }} {{ $value }} {{ $rpkFlags }}
 {{- end }}
-{{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
-            --tls-enabled
-            --tls-truststore /etc/tls/certs/{{ .Values.listeners.kafka.tls.cert }}/ca.crt
-{{- end }}
-{{- if (include "sasl-enabled" . | fromJson).bool }}
-            --user {{ (first .Values.auth.sasl.users).name }}
-            --password {{ (first .Values.auth.sasl.users).password }}
-            --sasl-mechanism SCRAM-SHA-256
+{{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
+            rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }} {{ $rpkFlags }}
 {{- end }}
         {{- with .Values.post_upgrade_job.resources }}
         resources:

--- a/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -1,0 +1,78 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "redpanda.fullname" . }}-test-kafka-produce-consume
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "redpanda.chart" . }}
+    app.kubernetes.io/name: {{ template "redpanda.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "redpanda.name" . }}
+  {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  containers:
+    - name: {{ template "redpanda.name" . }}
+      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      command:
+      - /bin/bash
+      - -c
+      - >
+        rpk topic create "produce.consume.test" {{ include "rpk-common-flags" . }}
+        echo "Pandas are awesome!" | rpk topic produce {{ include "rpk-produce-flags" . }} || exit 1
+        rpk topic consume {{ include "rpk-consume-flags" . }} | grep "Pandas are awesome!"
+      volumeMounts:
+        - name: config
+          mountPath: /etc/redpanda
+{{- if (include "tls-enabled" . | fromJson).bool -}}
+  {{- range $name, $cert := .Values.tls.certs }}
+        - name: redpanda-{{ $name }}-cert
+          mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+  {{- end }}
+{{- end }}
+      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
+  volumes:
+    - name: {{ template "redpanda.fullname" . }}
+      configMap:
+        name: {{ template "redpanda.fullname" . }}
+    - name: config
+      emptyDir: {}
+{{- if (include "tls-enabled" . | fromJson).bool }}
+  {{- range $name, $cert := .Values.tls.certs }}
+    - name: redpanda-{{ $name }}-cert
+      secret:
+        defaultMode: 420
+        items:
+        - key: tls.key
+          path: tls.key
+        - key: tls.crt
+          path: tls.crt
+    {{- if $cert.caEnabled }}
+        - key: ca.crt
+          path: ca.crt
+    {{- end }}
+        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+  {{- end }}
+{{- end -}}

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -206,7 +206,7 @@ storage:
   # used to store Redpanda's data, otherwise `hostPath` is used.
   persistentVolume:
     enabled: true
-    size: 3Gi
+    size: 20Gi
     # If defined, then `storageClassName: <storageClass>`.
     # If set to "-", then `storageClassName: ""`, which disables dynamic
     # provisioning.


### PR DESCRIPTION
The default volume size of 3Gi was less than the default storage_min_free_bytes Redpanda configuration. This increases the default storage size to a much more reasonable 20GiB and calculates the minimum free bytes as 5% of the storage capacity.

Added a test to ensure topics can be created, produced to, and consumed.

Fixes #179 