### PR TITLE
Change post-install-upgrade-job.yaml and post-upgrade.yaml job names to avoid `RepeatedResourceWarning`

### DIFF
--- a/redpanda/templates/post-install-upgrade-job.yaml
+++ b/redpanda/templates/post-install-upgrade-job.yaml
@@ -18,7 +18,7 @@ limitations under the License.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "redpanda.fullname" . }}
+  name: {{ template "redpanda.fullname" . }}-post-install
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "redpanda.chart" . }}

--- a/redpanda/templates/post-upgrade.yaml
+++ b/redpanda/templates/post-upgrade.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "redpanda.fullname" . }}
+  name: {{ template "redpanda.fullname" . }}-post-upgrade
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "redpanda.chart" . }}


### PR DESCRIPTION
When applying this helm chart the name of these jobs is repeated causing a warning.

This change would allow for both jobs to be created in case both are needed