### PR TITLE
Change post-install-upgrade-job.yaml and post-upgrade.yaml job names to avoid `RepeatedResourceWarning`

### DIFF
--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -20,7 +20,7 @@ maintainers:
   - name: redpanda-data
     url: https://github.com/orgs/redpanda-data/people
 type: application
-version: 2.2.0
+version: 2.2.1
 appVersion: v22.2.6
 icon: https://images.ctfassets.net/paqvtpyf8rwu/3cYHw5UzhXCbKuR24GDFGO/73fb682e6157d11c10d5b2b5da1d5af0/skate-stand-panda.svg
 sources:

--- a/redpanda/templates/post-install-upgrade-job.yaml
+++ b/redpanda/templates/post-install-upgrade-job.yaml
@@ -18,7 +18,7 @@ limitations under the License.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "redpanda.fullname" . }}
+  name: {{ template "redpanda.fullname" . }}-post-install
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "redpanda.chart" . }}

--- a/redpanda/templates/post-install-upgrade-job.yaml
+++ b/redpanda/templates/post-install-upgrade-job.yaml
@@ -66,6 +66,10 @@ spec:
             rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-flags" $ }} 
             ;
 {{- end }}
+        {{- with .Values.post_install_job.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: {{ template "redpanda.fullname" . }}
             mountPath: /tmp/base-config

--- a/redpanda/templates/post-upgrade.yaml
+++ b/redpanda/templates/post-upgrade.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "redpanda.fullname" . }}
+  name: {{ template "redpanda.fullname" . }}-post-upgrade
   namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "redpanda.chart" . }}

--- a/redpanda/templates/post-upgrade.yaml
+++ b/redpanda/templates/post-upgrade.yaml
@@ -52,6 +52,10 @@ spec:
             --password {{ (first .Values.auth.sasl.users).password }}
             --sasl-mechanism SCRAM-SHA-256
 {{- end }}
+        {{- with .Values.post_upgrade_job.resources }}
+        resources:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: {{ template "redpanda.fullname" . }}
             mountPath: /tmp/base-config

--- a/redpanda/values.schema.json
+++ b/redpanda/values.schema.json
@@ -272,6 +272,74 @@
         }
       }
     },
+    "post_install_job": {
+      "type": "object",
+      "properties": {
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "integer"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(\\.[0-9]){0,1}(k|M|G|Ki|Mi|Gi)$"
+                }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "integer"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(\\.[0-9]){0,1}(k|M|G|Ki|Mi|Gi)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "post_upgrade_job": {
+      "type": "object",
+      "properties": {
+        "resources": {
+          "type": "object",
+          "properties": {
+            "requests": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "integer"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(\\.[0-9]){0,1}(k|M|G|Ki|Mi|Gi)$"
+                }
+              }
+            },
+            "limits": {
+              "type": "object",
+              "properties": {
+                "cpu": {
+                  "type": "integer"
+                },
+                "memory": {
+                  "type": "string",
+                  "pattern": "^[0-9]+(\\.[0-9]){0,1}(k|M|G|Ki|Mi|Gi)$"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "statefulset": {
       "type": "object",
       "required": [

--- a/redpanda/values.yaml
+++ b/redpanda/values.yaml
@@ -219,6 +219,26 @@ storage:
     # Additional annotations to apply to the created PersistentVolumeClaims.
     annotations: {}
 
+post_install_job: {}
+  # Resource requests and limits for the post-install batch job
+  # resources:
+  #   requests:
+  #     cpu: 1
+  #     memory: 512Mi
+  #   limits:
+  #     cpu: 2
+  #     memory: 1024Mi
+
+post_upgrade_job: {}
+  # Resource requests and limits for the post-upgrade batch job
+  # resources:
+  #   requests:
+  #     cpu: 1
+  #     memory: 512Mi
+  #   limits:
+  #     cpu: 2
+  #     memory: 1024Mi
+
 statefulset:
   # Number of Redpanda brokers (recommend setting this to the number of nodes in the cluster)
   replicas: 3


### PR DESCRIPTION
When applying this helm chart the name of these jobs is repeated causing a warning.

This change would allow for both jobs to be created in case both are needed