### PR TITLE
Support redpanda-nightly builds

### DIFF
--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.2.7
+version: 2.2.8
 # The app version is the default version of Redpanda to install.
 appVersion: v22.2.7
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/redpanda/templates/_helpers.tpl
+++ b/redpanda/templates/_helpers.tpl
@@ -402,3 +402,11 @@ IP is required for the advertised address.
 {{- $fiveGiB -}}
 {{- end -}}
 {{- end -}}
+
+{{- define "redpanda-atleast-22-1-1" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.1.1"))) -}}
+{{- end -}}
+
+{{- define "redpanda-atleast-22-2-0" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.2.0"))) -}}
+{{- end -}}

--- a/redpanda/templates/configmap.yaml
+++ b/redpanda/templates/configmap.yaml
@@ -37,7 +37,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
 {{- end }}
 data:
-{{- if (include "redpanda.semver" . | semverCompare ">=22.1.1") }}
+{{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
   bootstrap.yaml: |
     enable_sasl: {{ dig "sasl" "enabled" false .Values.auth }}
   {{- if $users }}
@@ -64,7 +64,7 @@ data:
   {{- end }}
 {{- end }}
     redpanda:
-{{- if not (include "redpanda.semver" . | semverCompare ">=22.1.1") }}
+{{- if not (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
       enable_sasl: {{ dig "sasl" "enabled" false .Values.auth }}
   {{- if $users }}
       superusers: {{ toJson $users }}

--- a/redpanda/templates/post-install-upgrade-job.yaml
+++ b/redpanda/templates/post-install-upgrade-job.yaml
@@ -70,7 +70,7 @@ spec:
             ;
   {{- end }}
 {{- end }}
-{{- if (include "redpanda.semver" . | semverCompare ">=22.2.0") }}
+{{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
   {{- if not (empty .Values.license_secret_ref) }}
             rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-common-flags" $ }}
             ;

--- a/redpanda/templates/post-upgrade.yaml
+++ b/redpanda/templates/post-upgrade.yaml
@@ -1,4 +1,4 @@
-{{- if (include "redpanda.semver" . | semverCompare ">=22.1.1") }}
+{{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
 {{- $rpkFlags := include "rpk-common-flags" . }}
 apiVersion: batch/v1
 kind: Job

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -79,7 +79,7 @@ spec:
               CONFIG=/etc/redpanda/redpanda.yaml;
               NODE_ID=${SERVICE_NAME##*-};
               cp /tmp/base-config/redpanda.yaml "$CONFIG";
-              {{- if (include "redpanda.semver" . | semverCompare ">=22.1.1") }}
+              {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
               cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml;
               {{- end }}
               rpk --config "$CONFIG" config set redpanda.node_id $NODE_ID;


### PR DESCRIPTION
Modify `semverCompare` usage to take into account repository. If `redpanda` repo is not used, then assume the latest version.