### PR TITLE
tweak bootstrapping in v22.3 and above

### DIFF
--- a/redpanda/Chart.yaml
+++ b/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.2.8
+version: 2.3.0
 # The app version is the default version of Redpanda to install.
 appVersion: v22.2.7
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/redpanda/templates/_helpers.tpl
+++ b/redpanda/templates/_helpers.tpl
@@ -410,3 +410,7 @@ IP is required for the advertised address.
 {{- define "redpanda-atleast-22-2-0" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.2.0"))) -}}
 {{- end -}}
+
+{{- define "redpanda-atleast-22-3-0" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.3.0"))) -}}
+{{- end -}}

--- a/redpanda/templates/statefulset.yaml
+++ b/redpanda/templates/statefulset.yaml
@@ -77,15 +77,19 @@ spec:
           args:
             - >
               CONFIG=/etc/redpanda/redpanda.yaml;
-              NODE_ID=${SERVICE_NAME##*-};
               cp /tmp/base-config/redpanda.yaml "$CONFIG";
               {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
               cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml;
               {{- end }}
+              {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
+              rpk --config "$CONFIG" config set redpanda.empty_seed_starts_cluster false;
+              {{- else }}
+              NODE_ID=${SERVICE_NAME##*-};
               rpk --config "$CONFIG" config set redpanda.node_id $NODE_ID;
               if [ "$NODE_ID" = "0" ]; then
                 rpk --config "$CONFIG" config set redpanda.seed_servers '[]' --format yaml;
               fi;
+              {{- end }}
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
               mountPath: /tmp/base-config


### PR DESCRIPTION
Starting with v22.3, Redpanda can automatically assign node IDs to empty nodes as they join the cluster, and there is no longer a requirement to configure a single root node to start the cluster.

This commit updates the statefulset to use seeds-driven bootstrap, where all seed servers are expected to be configured with an identical list of seed servers. Once all seed servers are up they verify with each other that they all agree on the seeds, and collectively start a cluster with all seed servers as the initial set of nodes in the controller Raft group.