### PR TITLE
ci: fix topic create/produce/consume test

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.2
+version: 2.3.3
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.3
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -384,12 +384,7 @@ IP is required for the advertised address.
 {{ join " " (list $flags.admin $flags.sasl $flags.kafka)}}
 {{- end -}}
 
-{{- define "rpk-produce-flags" -}}
-{{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ join " " (list $flags.sasl $flags.kafka)}}
-{{- end -}}
-
-{{- define "rpk-consume-flags" -}}
+{{- define "rpk-topic-flags" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
 {{ join " " (list $flags.sasl $flags.kafka)}}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -40,9 +40,9 @@ spec:
       - /bin/bash
       - -c
       - >
-        rpk topic create "produce.consume.test" {{ include "rpk-common-flags" . }}
-        echo "Pandas are awesome!" | rpk topic produce {{ include "rpk-produce-flags" . }} || exit 1
-        rpk topic consume {{ include "rpk-consume-flags" . }} | grep "Pandas are awesome!"
+        rpk topic create "produce.consume.test" {{ include "rpk-topic-flags" . }} || exit 1
+        echo "Pandas are awesome!" | rpk topic produce {{ include "rpk-topic-flags" . }} || exit 1
+        rpk topic consume {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
       volumeMounts:
         - name: config
           mountPath: /etc/redpanda


### PR DESCRIPTION
Fix "topic" commands to all use the same set of flags in the test-kafka-produce-consume test.
Fixes #207 