### PR TITLE
Move empty_seed_starts_cluster to configmap

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.10
+version: 2.3.11
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.3
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -64,6 +64,9 @@ data:
   {{- end }}
 {{- end }}
     redpanda:
+{{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
+      empty_seed_starts_cluster: false
+{{- end }}
 {{- if not (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
       enable_sasl: {{ dig "sasl" "enabled" false .Values.auth }}
   {{- if $users }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -81,13 +81,11 @@ spec:
               {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
               cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml;
               {{- end }}
-              {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
-              rpk --config "$CONFIG" config set redpanda.empty_seed_starts_cluster false;
-              {{- else }}
+              {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
               NODE_ID=${SERVICE_NAME##*-};
-              rpk --config "$CONFIG" config set redpanda.node_id $NODE_ID;
+              rpk --config "$CONFIG" redpanda config set redpanda.node_id $NODE_ID;
               if [ "$NODE_ID" = "0" ]; then
-                rpk --config "$CONFIG" config set redpanda.seed_servers '[]' --format yaml;
+                rpk --config "$CONFIG" redpanda config set redpanda.seed_servers '[]' --format yaml;
               fi;
               {{- end }}
           volumeMounts:


### PR DESCRIPTION
The `rpk config set` should not be used as it is deprecated. Other reason to move the configuration setting to one place (configmap).

The chart version is bumped to `2.3.5` as it is created after https://github.com/redpanda-data/helm-charts/pull/212.