### PR TITLE
console: move chart from redpanda-data/console

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -54,10 +54,11 @@ jobs:
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
 
+      # we're excluding console from the install test until we have a way to test it with Redpanda
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --excluded-charts console)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
@@ -82,3 +83,4 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --config .github/ct.yaml
+        if: steps.list-changed.outputs.changed == 'true'

--- a/charts/console/.helmignore
+++ b/charts/console/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -1,0 +1,27 @@
+apiVersion: v2
+name: console
+description: Helm chart to deploy Redpanda Console.
+
+maintainers:
+  - name: weeco
+    url: https://github.com/weeco
+
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.3.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v2.0.2"

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -1,27 +1,47 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 apiVersion: v2
 name: console
 description: Helm chart to deploy Redpanda Console.
 
 maintainers:
-  - name: weeco
-    url: https://github.com/weeco
-
-#
-# Application charts are a collection of templates that can be packaged into versioned archives
-# to be deployed.
-#
-# Library charts provide useful utilities or functions for the chart developer. They're included as
-# a dependency of application charts to inject those utilities and functions into the rendering
-# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+  - name: redpanda-data
+    url: https://github.com/orgs/redpanda-data/people
 type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
+
+# Chart versions do not track appVersion
 version: 0.3.1
 
-# This is the version number of the application being deployed. This version number should be
-# incremented each time you make changes to the application. Versions are not expected to
-# follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-appVersion: "v2.0.2"
+# The app version is the version of the Chart application
+appVersion: v2.0.2
+
+icon: https://images.ctfassets.net/paqvtpyf8rwu/3cYHw5UzhXCbKuR24GDFGO/73fb682e6157d11c10d5b2b5da1d5af0/skate-stand-panda.svg
+sources:
+  - https://github.com/redpanda-data/helm-charts
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Documentation
+      url: https://docs.redpanda.com
+    - name: "Helm (>= 3.6.0)"
+      url: https://helm.sh/docs/intro/install/
+  artifacthub.io/images: |
+    - name: redpanda
+      image: vectorized/console:v2.0.2

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.3.1
+version: 0.3.2
 
 # The app version is the version of the Chart application
 appVersion: v2.0.2

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -9,5 +9,5 @@ helm repo update
 helm install redpanda/console -f myvalues.yaml
 ```
 
-Have a look at the [values.yaml](./console/values.yaml) file to see the available options.
+Have a look at the [values.yaml](./values.yaml) file to see the available options.
 Additionally, there is an example configuration in the [examples](./examples) directory.

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -1,0 +1,13 @@
+# Redpanda Console Helm Chart
+
+This Helm chart allows you to deploy Redpanda Console to your Redpanda cluster.
+You can install the chart by running the following commands:
+
+```shell
+helm repo add redpanda 'https://charts.redpanda.com/' 
+helm repo update
+helm install redpanda/console -f myvalues.yaml
+```
+
+Have a look at the [values.yaml](./console/values.yaml) file to see the available options.
+Additionally, there is an example configuration in the [examples](./examples) directory.

--- a/charts/console/examples/console-enterprise.yaml
+++ b/charts/console/examples/console-enterprise.yaml
@@ -1,0 +1,79 @@
+image:
+  tag: master-8fcce39
+
+resources:
+  limits:
+    cpu: 1
+    memory: 2Gi
+  requests:
+    cpu: 100m
+    memory: 512Mi
+
+console:
+  config:
+    kafka:
+      brokers:
+        - bootstrap.mybrokers.com:9092
+      clientId: redpanda-console
+      sasl:
+        enabled: true
+        mechanism: SCRAM-SHA-256
+        username: console
+        # password: set via Helm secret / Env variable
+      tls:
+        enabled: false
+    login:
+      google:
+        enabled: true
+        clientId: redacted.apps.googleusercontent.com
+        # clientSecret: set via Helm secret / Env variable
+        directory:
+          # serviceAccountFilepath: set via Helm secret / Env variable
+          targetPrincipal: admin@mycompany.com
+    enterprise:
+      rbac:
+        enabled: true
+        roleBindingsFilepath: /etc/console/configs/role-bindings.yaml
+  roleBindings:
+    - roleName: viewer
+      metadata:
+        # Metadata properties will be shown in the UI. You can omit it if you want to
+        name: Developers
+      subjects:
+        # You can specify all groups or users from different providers here which shall be bound to the same role
+        - kind: group
+          provider: Google
+          name: engineering@mycompany.com
+        - kind: user
+          provider: Google
+          name: singleuser@mycompany.com
+    - roleName: admin
+      metadata:
+        name: Admin
+      subjects:
+        - kind: user
+          provider: Google
+          name: adminperson@mycompany.com
+
+secret:
+  create: true
+  kafka:
+    saslPassword: "redacted"
+  enterprise:
+    license: "redacted"
+  login:
+    google:
+      clientSecret: "redacted"
+      groupsServiceAccount: |
+        {
+          "type": "service_account",
+          "project_id": "redacted",
+          "private_key_id": "redacted",
+          "private_key": "-----BEGIN PRIVATE KEY-----\nREDACTED\n-----END PRIVATE KEY-----\n",
+          "client_email": "redacted@projectid.iam.gserviceaccount.com",
+          "client_id": "redacted",
+          "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+          "token_uri": "https://oauth2.googleapis.com/token",
+          "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+          "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/redacted.iam.gserviceaccount.com"
+        }

--- a/charts/console/templates/NOTES.txt
+++ b/charts/console/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "console.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "console.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "console.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "console.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -1,0 +1,93 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "console.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "console.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "console.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "console.labels" -}}
+helm.sh/chart: {{ include "console.chart" . }}
+{{ include "console.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "console.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "console.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "console.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "console.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Server Listen Port for Console's HTTP server.
+The port can be overriden in the provided config, but
+it defaults to 8080.
+*/}}
+{{- define "console.server.listenPort" -}}
+{{- if .Values.console.config.server -}}
+{{- .Values.console.config.server.listenPort | default 8080 }}
+{{- else -}}
+8080
+{{- end }}
+{{- end }}
+
+{{/*
+Some umbrella charts may use a global registry variable.
+In order to be compatible with this, we will watch for a global.imageRegistry
+variable or return the imageRegistry as specified via the values.
+*/}}
+{{- define "console.imageRegistry" -}}
+{{- $registryName := .Values.image.registry -}}
+{{- if .Values.global }}
+    {{- if .Values.global.imageRegistry }}
+        {{- printf "%s" .Values.global.imageRegistry -}}
+    {{- else -}}
+        {{- printf "%s" $registryName -}}
+    {{- end -}}
+{{- else -}}
+    {{- printf "%s" $registryName -}}
+{{- end -}}
+{{- end -}}

--- a/charts/console/templates/configmap.yaml
+++ b/charts/console/templates/configmap.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "console.fullname" . }}
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- tpl (toYaml .Values.console.config) $ | nindent 4 }}
+  {{- if .Values.console.roles }}
+  roles.yaml: |
+    roles:
+      {{- tpl (toYaml .Values.console.roles) $ | nindent 6 }}
+  {{- end }}
+
+  {{- if .Values.console.roleBindings }}
+  role-bindings.yaml: |
+    roleBindings:
+      {{- tpl (toYaml .Values.console.roleBindings) $ | nindent 6 }}
+  {{- end }}

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -1,0 +1,254 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "console.fullname" . }}
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "console.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "console.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "console.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      volumes:
+        - name: configs
+          configMap:
+            name: {{ include "console.fullname" . }}
+        {{- if .Values.secret.create }}
+        - name: secrets
+          secret:
+            secretName: {{ include "console.fullname" . }}
+        {{- end }}
+        {{- range .Values.secretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+            {{- if .defaultMode }}
+            defaultMode: {{ .defaultMode }}
+            {{- end }}
+        {{- end }}
+        {{- with .Values.extraVolumes }}
+        {{- tpl . $ | nindent 8 }}
+        {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ include "console.imageRegistry" . }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ include "console.server.listenPort" . }}
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            {{- if .Values.secret.create }}
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            {{- end }}
+            {{- range .Values.secretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .path }}
+              {{- if .subPath }}
+              subPath: {{ .subPath }}
+              {{- end }}
+            {{- end }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          env:
+            {{- with .Values.extraEnv }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+            {{- if .Values.secret.create }}
+            {{- if .Values.secret.kafka.saslPassword }}
+            - name: KAFKA_SASL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: kafka-sasl-password
+            {{- end }}
+            {{- if .Values.secret.kafka.protobufGitBasicAuthPassword }}
+            - name: KAFKA_PROTOBUF_GIT_BASICAUTH_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: kafka-protobuf-git-basicauth-password
+            {{- end }}
+            {{- if .Values.secret.kafka.awsMskIamSecretKey }}
+            - name: KAFKA_SASL_AWSMSKIAM_SECRETKEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: kafka-sasl-aws-msk-iam-secret-key
+            {{- end }}
+            {{- if .Values.secret.kafka.tlsCa }}
+            - name: KAFKA_TLS_CAFILEPATH
+              value: "/etc/console/secrets/kafka-tls-ca"
+            {{- end }}
+            {{- if .Values.secret.kafka.tlsCert }}
+            - name: KAFKA_TLS_CERTFILEPATH
+              value: "/etc/console/secrets/kafka-tls-cert"
+            {{- end }}
+            {{- if .Values.secret.kafka.tlsKey }}
+            - name: KAFKA_TLS_KEYFILEPATH
+              value: "/etc/console/secrets/kafka-tls-key"
+            {{- end }}
+            {{- if .Values.secret.kafka.schemaRegistryTlsCa }}
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: "/etc/console/secrets/kafka-schemaregistry-tls-ca"
+            {{- end }}
+            {{- if .Values.secret.kafka.schemaRegistryTlsCert }}
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CERTFILEPATH
+              value: "/etc/console/secrets/kafka-schemaregistry-tls-cert"
+            {{- end }}
+            {{- if .Values.secret.kafka.schemaRegistryTlsKey }}
+            - name: KAFKA_SCHEMAREGISTRY_TLS_KEYFILEPATH
+              value: "/etc/console/secrets/kafka-schemaregistry-tls-key"
+            {{- end }}
+            {{- if .Values.secret.kafka.schemaRegistryPassword }}
+            - name: KAFKA_SCHEMAREGISTRY_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: kafka-schema-registry-password
+            {{- end }}
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-jwt-secret
+            {{- if .Values.secret.login.google.clientSecret }}
+            - name: LOGIN_GOOGLE_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-google-oauth-client-secret
+            {{- end }}
+            {{- if .Values.secret.login.google.groupsServiceAccount }}
+            - name: LOGIN_GOOGLE_DIRECTORY_SERVICEACCOUNTFILEPATH
+              value: /etc/console/secrets/login-google-groups-service-account.json
+            {{- end }}
+            {{- if .Values.secret.login.github.clientSecret }}
+            - name: LOGIN_GITHUB_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-github-oauth-client-secret
+            {{- end }}
+            {{- if .Values.secret.login.github.personalAccessToken }}
+            - name: LOGIN_GITHUB_DIRECTORY_PERSONALACCESSTOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-github-personal-access-token
+            {{- end }}
+            {{- if .Values.secret.login.okta.clientSecret }}
+            - name: LOGIN_OKTA_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-okta-client-secret
+            {{- end }}
+            {{- if .Values.secret.login.okta.directoryApiToken }}
+            - name: LOGIN_OKTA_DIRECTORY_APITOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-okta-directory-api-token
+            {{- end }}
+            {{- if .Values.secret.login.oidc.clientSecret }}
+            - name: LOGIN_OIDC_CLIENTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: login-oidc-client-secret
+            {{- end }}
+            {{- if .Values.secret.enterprise.license }}
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: enterprise-license
+            {{- end }}
+            {{- if .Values.secret.redpanda.adminApi.password }}
+            - name: REDPANDA_ADMINAPI_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "console.fullname" . }}
+                  key: redpanda-admin-api-password
+            {{- end }}
+            {{- if .Values.secret.redpanda.adminApi.tlsCa }}
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: "/etc/console/secrets/redpanda-admin-api-tls-ca"
+            {{- end }}
+            {{- if .Values.secret.redpanda.adminApi.tlsKey }}
+            - name: REDPANDA_ADMINAPI_TLS_KEYFILEPATH
+              value: "/etc/console/secrets/redpanda-admin-api-tls-key"
+            {{- end }}
+            {{- if .Values.secret.redpanda.adminApi.tlsCert }}
+            - name: REDPANDA_ADMINAPI_TLS_CERTFILEPATH
+              value: "/etc/console/secrets/redpanda-admin-api-tls-cert"
+            {{- end }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.extraEnvFrom }}
+            {{- tpl . $ | nindent 12 }}
+            {{- end }}
+        {{- with .Values.extraContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}           
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/console/templates/hpa.yaml
+++ b/charts/console/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "console.fullname" . }}
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "console.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/console/templates/ingress.yaml
+++ b/charts/console/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "console.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/charts/console/templates/secret.yaml
+++ b/charts/console/templates/secret.yaml
@@ -1,0 +1,42 @@
+{{- if .Values.secret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "console.fullname" . }}
+  labels:
+  {{- include "console.labels" . | nindent 4 }}
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: {{ .Values.secret.kafka.saslPassword | default "" | b64enc | quote }}
+  kafka-protobuf-git-basicauth-password: {{ .Values.secret.kafka.protobufGitBasicAuthPassword | default "" | b64enc | quote }}
+  kafka-sasl-aws-msk-iam-secret-key: {{ .Values.secret.kafka.awsMskIamSecretKey | default "" | b64enc | quote }}
+  kafka-tls-ca: {{ .Values.secret.kafka.tlsCa | default "" | b64enc | quote }}
+  kafka-tls-cert: {{ .Values.secret.kafka.tlsCert | default "" | b64enc | quote }}
+  kafka-tls-key: {{ .Values.secret.kafka.tlsKey | default "" | b64enc | quote }}
+  kafka-schema-registry-password: {{ .Values.secret.kafka.schemaRegistryPassword | default "" | b64enc | quote }}
+  kafka-schemaregistry-tls-ca: {{ .Values.secret.kafka.schemaRegistryTlsCa | default "" | b64enc | quote }}
+  kafka-schemaregistry-tls-cert: {{ .Values.secret.kafka.schemaRegistryTlsCert | default "" | b64enc | quote }}
+  kafka-schemaregistry-tls-key: {{ .Values.secret.kafka.schemaRegistryTlsKey | default "" | b64enc | quote }}
+
+  # Login
+  login-jwt-secret: {{ randAlphaNum 32 | b64enc | quote }}
+  login-google-oauth-client-secret: {{ .Values.secret.login.google.clientSecret | default "" | b64enc | quote }}
+  login-google-groups-service-account.json: {{ .Values.secret.login.google.groupsServiceAccount | default "" | b64enc | quote }}
+  login-github-oauth-client-secret: {{ .Values.secret.login.github.clientSecret | default "" | b64enc | quote }}
+  login-github-personal-access-token: {{ .Values.secret.login.github.personalAccessToken | default "" | b64enc | quote }}
+  login-okta-client-secret: {{ .Values.secret.login.okta.clientSecret | default "" | b64enc | quote }}
+  login-okta-directory-api-token: {{ .Values.secret.login.okta.directoryApiToken | default "" | b64enc | quote }}
+  login-generic-oidc-client-secret: {{ .Values.secret.login.oidc.clientSecret | default "" | b64enc | quote }}
+
+  # Enterprise
+  enterprise-license: {{ .Values.secret.enterprise.license | default "" | b64enc | quote }}
+
+  # Redpanda
+  redpanda-admin-api-password: {{ .Values.secret.redpanda.adminApi.password | default "" | b64enc | quote }}
+  redpanda-admin-api-tls-ca: {{ .Values.secret.redpanda.adminApi.tlsCa | default "" | b64enc | quote }}
+  redpanda-admin-api-tls-cert: {{ .Values.secret.redpanda.adminApi.tlsCert | default "" | b64enc | quote }}
+  redpanda-admin-api-tls-key: {{ .Values.secret.redpanda.adminApi.tlsKey | default "" | b64enc | quote }}
+{{- end }}

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "console.fullname" . }}
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "console.selectorLabels" . | nindent 4 }}

--- a/charts/console/templates/serviceaccount.yaml
+++ b/charts/console/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "console.serviceAccountName" . }}
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/console/templates/tests/test-connection.yaml
+++ b/charts/console/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "console.fullname" . }}-test-connection"
+  labels:
+    {{- include "console.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "console.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -1,0 +1,195 @@
+# Default values for console.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  registry: docker.redpanda.com
+  repository: vectorized/console
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext:
+  runAsUser: 99
+  fsGroup: 99
+
+securityContext:
+  runAsNonRoot: true
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 8080
+  annotations: {}
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+console:
+  # Config.yaml is required for Console
+  # See reference config: https://github.com/redpanda-data/console/blob/master/docs/config/console.yaml)
+  config: {}
+  # roles:
+  # roleBindings:
+
+# Additional environment variables for the Console Deployment
+extraEnv: ""
+  # - name: KAFKA_RACKID
+  #   value: "1"
+
+# Additional environment variables for Console mapped from Secret or ConfigMap
+extraEnvFrom: ""
+# - secretRef:
+#     name: kowl-config-secret
+
+# Add additional volumes, e. g. for tls keys
+extraVolumes: ""
+# - name: kafka-certs
+#   secret:
+#     secretName: kafka-certs
+# - name: config
+#   configMap:
+#     name: console-config
+
+# Add additional volumes mounts, e. g. for tls keys
+extraVolumeMounts: ""
+# - name: kafka-certs # Must match the volume name
+#   mountPath: /etc/kafka/certs
+#   readOnly: true
+
+# Add additional containers, e. g. for oauth2-proxy
+extraContainers: {}
+
+# SecretMounts is an abstraction to make a secret available in the container's filesystem.
+# Under the hood it creates a volume + volume mount for the Console container.
+secretMounts: []
+#  - name: kafka-certs
+#    secretName: kafka-certs
+#    path: /etc/console/certs
+#    defaultMode: 0755
+
+# Secret can be used to create a new Kubernetes secret for all sensitive config inputs.
+# Each provided secret will be mounted automatically and thus made available to the Console
+# pod.
+# If you want to use one or more existing secrets you can use "extraEnvFrom" to mount env
+# variables from string and secretMounts to mount files such as certificates from secrets.
+secret:
+  create: true
+
+  # Secret values in case you want the chart to create a secret. All certificates will be mounted
+  # as a file and the path to that file will be configured via environment variables as well, so
+  # that Console will automatically pick them up.
+  # Kafka secrets
+  kafka: {}
+    # saslPassword:
+    # awsMskIamSecretKey:
+    # tlsCa:
+    # tlsCert:
+    # tlsKey:
+    # tlsPassphrase:
+    # schemaRegistryPassword:
+    # schemaRegistryTlsCa:
+    # schemaRegistryTlsCert:
+    # schemaRegistryTlsKey:
+    # protobufGitBasicAuthPassword
+  # Enterprise version secrets
+  # SSO secrets (enterprise version)
+  login:
+    google: {}
+      # clientSecret:
+      # groupsServiceAccount:
+    github: {}
+      # clientSecret:
+      # personalAccessToken:
+    okta: {}
+      # clientSecret:
+      # directoryApiToken:
+    oidc: {}
+      # clientSecret:
+
+  enterprise: {}
+    # license:
+
+  redpanda:
+    adminApi: {}
+      # password:
+      # tlsCa:
+      # tlsCert:
+      # tlsKey:
+
+## Configure extra options for liveness and readiness probes
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+livenessProbe:
+  initialDelaySeconds: 0
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3
+
+readinessProbe:
+  # Grant 10s time to test connectivity to upstream services (Kafka, Schema Registry, ...)
+  initialDelaySeconds: 10
+  periodSeconds: 10
+  timeoutSeconds: 1
+  successThreshold: 1
+  failureThreshold: 3


### PR DESCRIPTION
Add Redpanda Console helm chart to the official Redpanda charts repository.
New Console chart will be listed in artifacthub. 

## Note

Installation tests are missing.

## REF

https://github.com/redpanda-data/helm-charts/issues/112