### PR TITLE
Fix kafka produce consume test

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.4
+version: 2.3.5
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.3
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -14,8 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-apiVersion: v1
-kind: Pod
+apiVersion: batch/v1
+kind: Job
 metadata:
   name: {{ include "redpanda.fullname" . }}-test-kafka-produce-consume
   namespace: {{ .Release.Namespace | quote }}
@@ -32,47 +32,60 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
-  restartPolicy: Never
-  containers:
-    - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
-      command:
-      - /bin/bash
-      - -c
-      - >
-        rpk topic create "produce.consume.test" {{ include "rpk-topic-flags" . }} || exit 1
-        echo "Pandas are awesome!" | rpk topic produce {{ include "rpk-topic-flags" . }} || exit 1
-        rpk topic consume {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
-      volumeMounts:
-        - name: config
-          mountPath: /etc/redpanda
+  backoffLimit: 2
+  completions: 1
+  parallelism: 1
+  ttlSecondsAfterFinished: 120
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: {{ template "redpanda.name" . }}
+          image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+          env:
+            - name: REDPANDA_BROKERS
+              value: "{{ include "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.listeners.kafka.port }}"
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+          command:
+          - /bin/bash
+          - -c
+          - >
+            rpk topic create produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }} || exit 1 &&
+            echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }} || exit 1 &&
+            rpk topic consume produce.consume.test.$POD_NAME -n 1 {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
+          volumeMounts:
+            - name: config
+              mountPath: /etc/redpanda
 {{- if (include "tls-enabled" . | fromJson).bool -}}
   {{- range $name, $cert := .Values.tls.certs }}
-        - name: redpanda-{{ $name }}-cert
-          mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+            - name: redpanda-{{ $name }}-cert
+              mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
-      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
-  volumes:
-    - name: {{ template "redpanda.fullname" . }}
-      configMap:
-        name: {{ template "redpanda.fullname" . }}
-    - name: config
-      emptyDir: {}
+          resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
+      volumes:
+        - name: {{ template "redpanda.fullname" . }}
+          configMap:
+            name: {{ template "redpanda.fullname" . }}
+        - name: config
+          emptyDir: {}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
-    - name: redpanda-{{ $name }}-cert
-      secret:
-        defaultMode: 420
-        items:
-        - key: tls.key
-          path: tls.key
-        - key: tls.crt
-          path: tls.crt
-    {{- if $cert.caEnabled }}
-        - key: ca.crt
-          path: ca.crt
-    {{- end }}
-        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+        - name: redpanda-{{ $name }}-cert
+          secret:
+            defaultMode: 420
+            items:
+            - key: tls.key
+              path: tls.key
+            - key: tls.crt
+              path: tls.crt
+        {{- if $cert.caEnabled }}
+            - key: ca.crt
+              path: ca.crt
+        {{- end }}
+            secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
The error in the produce consume test was shwallowed by rpk.
```
unable to create topics [produce.consume.test]: unable to dial: dial tcp 127.0.0.1:9092: connect: connection refused
/bin/bash: line 1: exit: too many arguments
```

`REDPANDA_BROKERS` was added to the pod template spec as rpk in tls test need to have fully qualified name as it is defined in self signed certificate.

As the definition of the produce consume test changed from pod to job the topic needs to be uqnique per job run, that is why pod name is used to randomise the topic name.

Produce and consume test can now failed up to 2 times, before it is considered as failed.