### PR TITLE
Revert "#187 Check `Capabilities` to render `PodDisruptionBudget` manifest"

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.8
+version: 2.3.10
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.3
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,9 +23,13 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.9
+version: 2.3.8
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.3
+# kubeVersion must be suffixed with "-0" to be able to match cloud providers
+# kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
+# pre-release. Our "-0" allows pre-releases to be matched.
+kubeVersion: "^1.21.0-0"
 icon: https://images.ctfassets.net/paqvtpyf8rwu/3cYHw5UzhXCbKuR24GDFGO/73fb682e6157d11c10d5b2b5da1d5af0/skate-stand-panda.svg
 sources:
   - https://github.com/redpanda-data/helm-charts

--- a/charts/redpanda/templates/poddisruptionbudget.yaml
+++ b/charts/redpanda/templates/poddisruptionbudget.yaml
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{- if .Capabilities.APIVersions.Has "policy/v1/PodDisruptionBudget" }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -36,6 +35,3 @@ spec:
       app.kubernetes.io/name: {{ template "redpanda.name" . }}
       app.kubernetes.io/instance: {{ .Release.Name | quote }}
   maxUnavailable: {{ .Values.statefulset.budget.maxUnavailable | int64 }}
-{{- else if (not .Values.ephemeralUsage.enabled) }}
-{{- fail "You must use Kubernetes 1.21+ for a production cluster. If you're not using this in production and you know why doing this is a bad idea, you can set 'ephemeralUsage.enabled=false' to continue." }}
-{{- end }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -466,13 +466,6 @@ listeners:
         # This listener port will be used for the external port if this is not included
         nodePort: 30081
 
-### Non-production usage
-#
-# ephemeralUsage - Enabling this key relaxes some properties related to high availability, like the
-#   implementation of a PodDisruptionBudget (this enables deployment onto older K8s versions as well)
-ephemeralUsage:
-  enabled: false
-
 # Expert Config
 
 # This section contains various settings supported by Redpanda that may not work


### PR DESCRIPTION
Reverts redpanda-data/helm-charts#188

This breaks the ability to use "helm template"