### PR TITLE
Auto external access via NodePort

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.11
+version: 2.3.12
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.3
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/templates/NOTES.txt
+++ b/charts/redpanda/templates/NOTES.txt
@@ -27,6 +27,22 @@ The pods will rollout in a few seconds. To check the status:
 
   kubectl -n {{ .Release.Namespace }} rollout status statefulset {{ template "redpanda.fullname" . }} --watch
 
+{{- if (default .Values.external true) }}
+Get your node's external IP addresses with the following command:
+  kubectl get nodes -o wide
+
+Then set the REDPANDA_BROKERS environment variable using the external IPs:
+  export REDPANDA_BROKERS=<external IP>:31092,<external IP>:31092,<external IP>:31092
+
+Add IP addresses for each of the {{ .Values.statefulset.replicas }} nodes in your cluster (the above example lists three).
+
+Now rpk can be used like this when using sub-commands that access the Kafka API port:
+  rpk cluster info
+
+For rpk sub-commands that use the admin API port, run rpk with the following flag:
+  rpk cluster health --api-urls <external IP>:31644,<external IP>:31644,<external IP>:31644
+{{- end }}
+
 Try some sample commands:
 
 {{- if and $anySASL }}

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -79,4 +79,27 @@ spec:
   selector:
     app.kubernetes.io/name: {{ template "redpanda.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: k8s-api-cr
+rules:
+- apiGroups: [""]
+  resources: ["pods", "nodes", "nodes/status"]
+  verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: k8s-api-crb
+  namespace: {{ .Release.Namespace | quote }}
+subjects:
+- kind: ServiceAccount
+  name: default
+  namespace: {{ .Release.Namespace | quote }}
+roleRef:
+  kind: ClusterRole
+  name: k8s-api-cr
+  apiGroup: rbac.authorization.k8s.io
 {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -74,19 +74,48 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
+            - name: EXTERNAL_ADDRESSES
+              value: {{ .Values.external.addresses }}
           args:
             - >
               CONFIG=/etc/redpanda/redpanda.yaml;
               cp /tmp/base-config/redpanda.yaml "$CONFIG";
+              NODE_ID=${SERVICE_NAME##*-};
               {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
               cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml;
               {{- end }}
               {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
-              NODE_ID=${SERVICE_NAME##*-};
               rpk --config "$CONFIG" redpanda config set redpanda.node_id $NODE_ID;
               if [ "$NODE_ID" = "0" ]; then
                 rpk --config "$CONFIG" redpanda config set redpanda.seed_servers '[]' --format yaml;
               fi;
+              {{- end }}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].name internal ;
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].address {{ $advertiseAddress }} ;
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].port {{ .Values.listeners.kafka.port }} ;
+              {{- $listenerIndex := 1 -}}
+              {{- range $name, $listener := .Values.listeners.kafka.external -}}
+                {{- $enabled := dig "enabled" $values.external.enabled $listener -}}
+                {{- $listenerNodePortEnabled := and $enabled (eq (dig "type" $values.external.type $listener) "NodePort") -}}
+                {{- $advertiseKafkaHost := $advertiseAddress -}}
+                {{- $advertiseKafkaPort := $listener.nodePort -}}
+                {{- if $listenerNodePortEnabled -}}
+                  {{- if $values.external.addresses -}}
+              NODE_INDEX=`expr $NODE_ID + 1`;
+              NODE_ADDRESS=`echo $EXTERNAL_ADDRESSES | cut -d ' ' -f $NODE_INDEX`;
+                    {{- if eq $values.external.addressType "ip" -}}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS;
+                    {{- else -}}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS.{{ $values.external.domain }};
+                    {{- end -}}
+                  {{- else -}}
+                    {{- $advertiseKafkaHost = printf "$(SERVICE_NAME).%s" $values.external.domain -}}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address {{ $advertiseKafkaHost }} ;
+                  {{- end -}}
+                {{- end -}}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].name {{ $name }} ;
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].port {{ $advertiseKafkaPort }} ;
+                {{- $listenerIndex = add $listenerIndex 1 -}}
               {{- end }}
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
@@ -200,17 +229,6 @@ spec:
             - --memory={{ template "redpanda-memory" . }}M
             - --reserve-memory={{ template "redpanda-reserve-memory" . }}
             - --default-log-level={{ .Values.logging.logLevel }}
-            - --advertise-kafka-addr=internal://{{ $advertiseAddress }}:{{ .Values.listeners.kafka.port }},
-{{- range $name, $listener := .Values.listeners.kafka.external -}}
-  {{- $enabled := dig "enabled" $values.external.enabled $listener -}}
-  {{- $listenerNodePortEnabled := and $enabled (eq (dig "type" $values.external.type $listener) "NodePort") -}}
-  {{- $advertiseKafkaHost := $advertiseAddress -}}
-  {{- $advertiseKafkaPort := $listener.nodePort -}}
-  {{- if $listenerNodePortEnabled -}}
-    {{- $advertiseKafkaHost = printf "$(SERVICE_NAME).%s" $values.external.domain -}}
-  {{- end -}}
-                {{ $name }}://{{ $advertiseKafkaHost }}:{{ $advertiseKafkaPort }},
-{{- end }}
             - --advertise-rpc-addr={{ $advertiseAddress }}:{{ .Values.listeners.rpc.port }}
             - --advertise-pandaproxy-addr=internal://{{ $advertiseAddress }}:{{ .Values.listeners.http.port }},
 {{- range $name, $listener := .Values.listeners.http.external -}}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -75,7 +75,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: EXTERNAL_ADDRESSES
-              value: {{ .Values.external.addresses }}
+              value: "{{ .Values.external.addresses }}"
           args:
             - >
               CONFIG=/etc/redpanda/redpanda.yaml;
@@ -90,31 +90,48 @@ spec:
                 rpk --config "$CONFIG" redpanda config set redpanda.seed_servers '[]' --format yaml;
               fi;
               {{- end }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].name internal ;
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].address {{ $advertiseAddress }} ;
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].port {{ .Values.listeners.kafka.port }} ;
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].name internal;
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].address {{ $advertiseAddress }};
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].port {{ .Values.listeners.kafka.port }};
               {{- $listenerIndex := 1 -}}
               {{- range $name, $listener := .Values.listeners.kafka.external -}}
                 {{- $enabled := dig "enabled" $values.external.enabled $listener -}}
                 {{- $listenerNodePortEnabled := and $enabled (eq (dig "type" $values.external.type $listener) "NodePort") -}}
-                {{- $advertiseKafkaHost := $advertiseAddress -}}
                 {{- $advertiseKafkaPort := $listener.nodePort -}}
-                {{- if $listenerNodePortEnabled -}}
-                  {{- if $values.external.addresses -}}
-              NODE_INDEX=`expr $NODE_ID + 1`;
-              NODE_ADDRESS=`echo $EXTERNAL_ADDRESSES | cut -d ' ' -f $NODE_INDEX`;
-                    {{- if eq $values.external.addressType "ip" -}}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS;
-                    {{- else -}}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS.{{ $values.external.domain }};
-                    {{- end -}}
+                {{- if $values.external.addressType -}}
+                  {{- if and (eq $values.external.addressType "ip") (not $values.external.addresses) -}}
+                    {{ fail "external.addressType of ip must have external.addresses set"}}
+                  {{- else if and (eq $values.external.addressType "subdomain") (or (not $values.external.domain) (not $values.external.addresses)) -}}
+                    {{ fail "external.addressType of subdomain must have external.domain and external.addresses set"}}
                   {{- else -}}
-                    {{- $advertiseKafkaHost = printf "$(SERVICE_NAME).%s" $values.external.domain -}}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address {{ $advertiseKafkaHost }} ;
+              NODE_INDEX=`expr $NODE_ID + 1`;
+              EXTERNAL_ADDRESS=`echo $EXTERNAL_ADDRESSES | cut -d ' ' -f $NODE_INDEX`;
+                    {{- if eq $values.external.addressType "ip" -}}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $EXTERNAL_ADDRESS;
+                    {{- end -}}
+                    {{- if eq $values.external.addressType "subdomain" -}}
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $EXTERNAL_ADDRESS.{{ $values.external.domain }};
+                    {{- end -}}
                   {{- end -}}
+                {{- else -}}
+              APISERVER=https://kubernetes.default.svc;
+              SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount;
+              NAMESPACE=$(cat ${SERVICEACCOUNT}/namespace);
+              TOKEN=$(cat ${SERVICEACCOUNT}/token);
+              CACERT=${SERVICEACCOUNT}/ca.crt;
+              cd /etc/redpanda;
+              curl https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 -sLo jq;
+              chmod +x jq;
+              NODE_NAME=`curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/namespaces/redpanda/pods | ./jq -r --arg SERVICE_NAME $SERVICE_NAME '.items | map( select(.metadata.name == $SERVICE_NAME)) | .[] | .spec.nodeName'`;
+              EXTERNAL_IP=`curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/status | ./jq -r '.status.addresses | .[] | select(.type=="ExternalIP") | .address'`;
+              INTERNAL_IP=`curl -s --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/api/v1/nodes/${NODE_NAME}/status | ./jq -r '.status.addresses | .[] | select(.type=="InternalIP") | .address'`;
+              if [ -n $EXTERNAL_IP ];
+              then rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $EXTERNAL_IP;
+              else rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $INTERNAL_IP;
+              fi;
                 {{- end -}}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].name {{ $name }} ;
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].port {{ $advertiseKafkaPort }} ;
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].name {{ $name }};
+              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].port {{ $advertiseKafkaPort }};
                 {{- $listenerIndex = add $listenerIndex 1 -}}
               {{- end }}
           volumeMounts:

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -185,6 +185,13 @@
         "domain": {
           "type": "string",
           "format": "idn-hostname"
+        },
+        "addressType": {
+          "type": "string",
+          "pattern": "^(subdomain|ip)$"
+        },
+        "addresses": {
+          "type": "string"
         }
       }
     },

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -171,8 +171,7 @@
       "type": "object",
       "required": [
         "enabled",
-        "type",
-        "domain"
+        "type"
       ],
       "properties": {
         "enabled": {

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -96,9 +96,22 @@ external:
   # External config doesn't apply to RPC listeners as they are never externally accessible
   # These values can be overridden by each listener if needed
   enabled: true
-  # Default external access type (NodePort is the only option for now)
+  # Default external access type (only NodePort at the moment)
   type: NodePort
+  # Domain to be used for each node
   domain: local
+  #
+  # addressType can be set to the following: subdomain ip
+  # with subdomain, each node will advertise an address with <external.addresses[replica index]>.<domain>
+  # with ip, each node will advertise only <external.addresses[replica index]> (and domain will be ignored)
+  # addressType: subdomain
+  #
+  # The addresses list must have an entry for each statefulset replica
+  # By default, the statefulset is called redpanda and has 3 replicas
+  # If you want to access nodes by their IP: addresses: "18.224.215.250 18.118.163.26 3.142.153.29"
+  # Or if you want to access nodes via DNS: addresses: "apple bacon carrot"
+  # addresses: "redpanda-0 redpanda-1 redpanda-2"
+  #
   # annotations:
     # For example:
     # cloud.google.com/load-balancer-type: "Internal"

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -96,21 +96,23 @@ external:
   # External config doesn't apply to RPC listeners as they are never externally accessible
   # These values can be overridden by each listener if needed
   enabled: true
-  # Default external access type (only NodePort at the moment)
+  #
+  # Default external service type (only NodePort at the moment)
   type: NodePort
-  # Domain to be used for each node
-  domain: local
   #
-  # addressType can be set to the following: subdomain ip
-  # with subdomain, each node will advertise an address with <external.addresses[replica index]>.<domain>
-  # with ip, each node will advertise only <external.addresses[replica index]> (and domain will be ignored)
-  # addressType: subdomain
+  # addressType can be set to ip or subdomain
+  # with ip, each node will advertise <external.addresses[replica-index]>
+  # with subdomain, each node will advertise <external.addresses[replica-index]>.<external.domain>
+  # addressType: ip
   #
-  # The addresses list must have an entry for each statefulset replica
+  # The domain to be used for each node (only used if external.addressType: subdomain)
+  # domain: local
+  #
+  # Addresses must have an entry for each node (and node count must equal statefulset replica count)
   # By default, the statefulset is called redpanda and has 3 replicas
-  # If you want to access nodes by their IP: addresses: "18.224.215.250 18.118.163.26 3.142.153.29"
+  # If you want to access nodes by their IP: addresses: "203.0.113.3 203.0.113.5 203.0.113.7"
   # Or if you want to access nodes via DNS: addresses: "apple bacon carrot"
-  # addresses: "redpanda-0 redpanda-1 redpanda-2"
+  # addresses: "203.0.113.3 203.0.113.5 203.0.113.7"
   #
   # annotations:
     # For example:


### PR DESCRIPTION
This enables automatic external access for deployments where nodes have an associated external IP (most cloud providers). Users can switch between advertising ip and subdomain by properly setting external.addressType, external.addresses, and external.domain. More details on how this works in values.yaml.

This builds on #220 . I didn't want to include the changes here in that PR since this PR changes the default behavior, and will likely need a more thorough review and testing period.

Some changes I'd like to include:
- [ ] update NOTES.txt to include more details on how to use a locally-installed rpk for the various commands
- [ ] update NOTES.txt to include details on installing rpk locally
- [ ] print the `export REDPANDA_BROKERS=...` command populated with IP values of the Kubernetes nodes (this may be impossible since I only know how to do this from within a container)
- [ ] update other advertised listeners
- [ ] ensure Kubernetes API compatibility by requiring Kubernetes within a semver range
- [ ] remove `external.type` since we only allow `NodePort`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1204056567789500