### PR TITLE
Update README.md

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.17
+version: 2.3.18
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.5

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -2,19 +2,7 @@
 
 [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/redpanda-data)](https://artifacthub.io/packages/search?repo=redpanda-data)
 
-This Helm chart (`redpanda`) deploys a Redpanda cluster.
-Once deployed, you continue to use the Helm command and override values to change and/or upgrade your Redpanda deployment.
-The defaults are in [values.yaml][values].
-
-## Requirements
-
-- Helm v3.5.0 or newer
-- Kubernetes 1.21.0 or newer
-- Cert-manager 1.9.0 or newer (optional for TLS support)
-
-## Overview
-
-This is the Helm Chart for [Redpanda](https://redpanda.com). It provides the ability to set up a multi node redpanda cluster with the following optional features:
+The Redpanda Helm chart deploys a Redpanda cluster in Kubernetes, and provides the following features:
 
 - Schema registry (enabled by default)
 - REST (aka PandaProxy, enabled by default)
@@ -22,22 +10,37 @@ This is the Helm Chart for [Redpanda](https://redpanda.com). It provides the abi
 - SASL
 - External access
 
-See the [examples folder][examples] with more details on how to use this helm chart.
-Each example focuses on specific features like the ones listed above.
-We recommend completing the instructions in the [60-Second Guide for Kubernetes][kubernetes-qs-dev] before continuing steps in any of these examples.
+## Requirements
 
-The [values.yaml][values] file is documented throughout.
-Please see this file for more details.
+- Helm version 3.6.0 or later
+- Kubernetes version 1.21.0 or later
+- Cert-manager 1.9.0 or later (required for TLS support only)
 
 ## Installation
 
-See the [60-Second Guide for Kubernetes][kubernetes-qs-dev]
+To get started, see the [Redpanda documentation][kubernetes-qs-dev].
+
+For examples of using the Helm chart, see the [`examples/` directory][examples]. Each example focuses on a specific feature.
+
+## Configuration
+
+The Redpanda Helm chart is configured in the [`values.yaml`][values] file. To customize your deployment, you can override the default values in your own YAML file with the `--values` option or in the command line with the --set option. For example, you can do the following:
+
+- Specify which Kubernetes components to deploy.
+
+- Configure the deployed Kubernetes components.
+
+To learn how to override the default values in the `values.yaml` file, see the [Helm documentation](helm).
+
+All configuration options for the Redpanda Helm chart are documented in the [`values.yaml`][values] file.
 
 ## Contributing
 
 If you have improvements that can be made to this Helm chart, please consider becoming a contributor.
-See our [Contributing][contributing] document for more details.
+To contribute to the Helm chart, see our [contribution guidelines][contributing].
 
+[redpanda]: https://redpanda.com
+[helm]: https://helm.sh/docs/chart_template_guide/values_files/
 [values]: https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml
 [examples]: https://github.com/redpanda-data/helm-charts/blob/main/examples/README.md
 [contributing]: https://github.com/redpanda-data/helm-charts/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
- Fixes the broken link to `values.yaml`
- Updates the required Helm version to 3.6.0
- Provides guidance for configuring the Helm chart
- Removes the overview section and adds it to the start of the README as introductory content