### PR TITLE
Relocate `if` statement so `schemaRegistry` is still defined if pandaproxy is not enabled

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.15
+version: 2.3.16
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.5
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -148,7 +148,6 @@ data:
             address: "{{ template "redpanda.fullname" $ }}-{{ . }}.{{ template "redpanda.internal.domain" $ }}"
             port: {{ $values.listeners.rpc.port }}
 {{- end }}
-{{- if .Values.listeners.http.enabled }}
 {{- if .Values.listeners.schemaRegistry.enabled }}
     schema_registry:
       schema_registry:
@@ -181,6 +180,7 @@ data:
     {{- end }}
   {{- end }}
 {{- end }}
+{{- if .Values.listeners.http.enabled }}
     pandaproxy:
       pandaproxy_api:
         - name: internal


### PR DESCRIPTION
This should hopefully close/fix https://github.com/redpanda-data/helm-charts/issues/237, assuming there is no dependency between schema registry and pandaproxy.

If there is, I guess close dismiss both the issue and this PR 😀