### PR TITLE
Handle case when user already exists to avoid job failing

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.14
+version: 2.3.15
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.5
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -68,7 +68,24 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
   {{- $values := .Values }}
   {{- range $user := .Values.auth.sasl.users }}
-            rpk acl user create {{ $user.name }} -p {{ $user.password | quote }} --mechanism {{ include "sasl-user-mechanism" (dict "user" $user "Values" $values) }} {{ template "rpk-common-flags" $ }}
+            # To avoid `set -e` from exiting the command when a user exists; catch the stderr output and exit codes into `creation_result`
+            # and `creation_result_exit_code` for use later
+            creation_result=$(rpk acl user create {{ $user.name }} -p {{ $user.password | quote }} --mechanism {{ include "sasl-user-mechanism" (dict "user" $user "Values" $values) }} {{ template "rpk-common-flags" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?
+            
+            # On a non-success exit code
+            if [[ $creation_result_exit_code -ne 0 ]]; then
+              # Check if the stderr contains "User already exists"
+              if [[ $creation_result == *"User already exists"* ]]; then
+                printf "The %s user already exists, skipping creation.\n" {{ $user.name }}
+              else
+                # Another error occurred, so output the original message and exit code
+                echo "$creation_result"
+                exit $creation_result_exit_code
+              fi
+            # On a success, the user was created so output that
+            else
+              printf "Created user %s.\n" {{ $user.name }}
+            fi
   {{- end }}
 {{- end }}
 {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}


### PR DESCRIPTION
Should close/resolve issue https://github.com/redpanda-data/helm-charts/issues/230. Basically I just caught the output, so it can be checked against in the case of the user existing. If it isn't the string we expect, then echo out/exit with the original code. Bit of a bash noob, so maybe there is a more concise way of doing this 😁

I've tried this with creation of two users, and re-running after those two users are created.

First couple job runs when cluster not ready:
```text
Retrying POST for error: Post "https://kafka-0.afka.default.svc.cluster.local.:9644/v1/security/users": dial tcp: lookup kafka-0.kafka.default.svc.cluster.local. on 10.0.0.10:53: no such host
Retrying POST for error: Post "https://kafka-0.kafka.default.svc.cluster.local.:9644/v1/security/users": dial tcp: lookup kafka-0.kafka.default.svc.cluster.local. on 10.0.0.10:53: no such host
unable to create user "admin": Post "https://kafka-0.kafka.default.svc.cluster.local.:9644/v1/security/users": dial tcp: lookup kafka-0.kafka.default.svc.cluster.local. on 10.0.0.10:53: no such host
```

When cluster is ready:
```text
Created user admin.
Created user console.
```

When upgrading the chart:
```text
The admin user already exists, skipping creation.
The console user already exists, skipping creation.
```