### PR TITLE
Console: Set same key for login-oidc-client-secret in Secret and Deployment

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.3.2
+version: 0.3.3
 
 # The app version is the version of the Chart application
 appVersion: v2.0.2

--- a/charts/console/templates/secret.yaml
+++ b/charts/console/templates/secret.yaml
@@ -29,7 +29,7 @@ data:
   login-github-personal-access-token: {{ .Values.secret.login.github.personalAccessToken | default "" | b64enc | quote }}
   login-okta-client-secret: {{ .Values.secret.login.okta.clientSecret | default "" | b64enc | quote }}
   login-okta-directory-api-token: {{ .Values.secret.login.okta.directoryApiToken | default "" | b64enc | quote }}
-  login-generic-oidc-client-secret: {{ .Values.secret.login.oidc.clientSecret | default "" | b64enc | quote }}
+  login-oidc-client-secret: {{ .Values.secret.login.oidc.clientSecret | default "" | b64enc | quote }}
 
   # Enterprise
   enterprise-license: {{ .Values.secret.enterprise.license | default "" | b64enc | quote }}


### PR DESCRIPTION
Currently, in the Helm chart the name for the login-oidc-client-secret key in the Secret does not match the key reference in the Deployment. In the Deployment the key login-oidc-client-secret is referenced, but in the Secret it is named login-generic-oidc-client-secret. I would drop the "generic-" part in the Secret, because in the values file it is configured under secret.login.oidc.clientSecret, also without "generic".

Key in the Deployment: https://github.com/redpanda-data/helm-charts/blob/main/charts/console/templates/deployment.yaml#L207