### PR TITLE
ensure the uid:gid and the fsgroup always match

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.20
+version: 2.4.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.9

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -430,3 +430,15 @@ IP is required for the advertised address.
 {{- define "redpanda-atleast-22-3-0" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.3.0"))) -}}
 {{- end -}}
+
+# manage backward compatibility with renaming podSecurityContext to securityContext
+{{- define "pod-security-context" -}}
+fsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
+{{- end -}}
+
+# for backward compatibility, force a default on releases that didn't
+# set the podSecurityContext.runAsUser before
+{{- define "container-security-context" -}}
+runAsUser: {{ dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset }}
+runAsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
+{{- end -}}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -48,6 +48,7 @@ spec:
 {{- end }}
     spec:
       restartPolicy: Never
+      securityContext: {{ include "pod-security-context" . | nindent 8 }}
       containers:
       - name: {{ template "redpanda.name" . }}-post-install
         image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
@@ -71,7 +72,7 @@ spec:
             # To avoid `set -e` from exiting the command when a user exists; catch the stderr output and exit codes into `creation_result`
             # and `creation_result_exit_code` for use later
             creation_result=$(rpk acl user create {{ $user.name }} -p {{ $user.password | quote }} --mechanism {{ include "sasl-user-mechanism" (dict "user" $user "Values" $values) }} {{ template "rpk-common-flags" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?
-            
+
             # On a non-success exit code
             if [[ $creation_result_exit_code -ne 0 ]]; then
               # Check if the stderr contains "User already exists"
@@ -99,6 +100,7 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext: {{ include "container-security-context" . | nindent 10 }}
         volumeMounts:
           - name: {{ template "redpanda.fullname" . }}
             mountPath: /tmp/base-config

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -32,6 +32,7 @@ spec:
 {{- end }}
     spec:
       restartPolicy: Never
+      securityContext: {{ include "pod-security-context" . | nindent 8 }}
       containers:
       - name: {{ template "redpanda.name" . }}-post-upgrade
         image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
@@ -49,6 +50,7 @@ spec:
         resources:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+        securityContext: {{ include "container-security-context" . | nindent 10 }}
         volumeMounts:
           - name: {{ template "redpanda.fullname" . }}
             mountPath: /tmp/base-config

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -57,13 +57,14 @@ spec:
         {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        {{- toYaml .Values.statefulset.podSecurityContext | nindent 8 }}
+      securityContext: {{ include "pod-security-context" . | nindent 8 }}
       serviceAccountName: {{ include "redpanda.serviceAccountName" . }}
       initContainers:
         - name: set-datadir-ownership
           image: busybox:latest
-          command: ["/bin/sh", "-c", "chown 101:101 -R /var/lib/redpanda/data"]
+          {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset }}
+          {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
+          command: ["/bin/sh", "-c", "chown {{ $uid }}:{{ $gid }} -R /var/lib/redpanda/data"]
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/redpanda/data
@@ -140,13 +141,13 @@ spec:
                 rpk --config "$CONFIG" redpanda config set redpanda.rack "${RACK}"
                 {{- end }}
               {{- end }}
+          securityContext: {{ include "container-security-context" . | nindent 12 }}
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
               mountPath: /tmp/base-config
             - name: config
               mountPath: /etc/redpanda
-          resources:
-            {{- toYaml .Values.statefulset.resources | nindent 12 }}
+          resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
       containers:
         - name: {{ template "redpanda.name" . }}
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
@@ -268,6 +269,7 @@ spec:
     {{- end }}
   {{- end }}
 {{- end }}
+          securityContext: {{ include "container-security-context" . | nindent 12 }}
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/redpanda/data

--- a/charts/redpanda/templates/tests/test-api-status.yaml
+++ b/charts/redpanda/templates/tests/test-api-status.yaml
@@ -34,6 +34,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
@@ -34,6 +34,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -39,6 +39,9 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      securityContext:
+        runAsUser: 65535
+        runAsGroup: 65535
       containers:
         - name: {{ template "redpanda.name" . }}
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -38,6 +38,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -34,6 +34,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -34,6 +34,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -41,6 +41,9 @@ spec:
   template:
     spec:
       restartPolicy: Never
+      securityContext:
+        runAsUser: 65535
+        runAsGroup: 65535
       containers:
         - name: {{ template "redpanda.name" . }}
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -34,6 +34,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -36,6 +36,9 @@ metadata:
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -409,7 +409,7 @@
         "priorityClassName",
         "tolerations",
         "topologySpreadConstraints",
-        "podSecurityContext"
+        "securityContext"
       ],
       "properties": {
         "replicas": {
@@ -554,17 +554,15 @@
             }
           }
         },
-        "podSecurityContext": {
+        "securityContext": {
           "type": "object",
           "required": [
-            "fsGroup"
+            "fsGroup",
+            "runAsUser"
           ],
           "properties": {
             "fsGroup": {
               "type": "integer"
-            },
-            "runAsNonRoot": {
-              "type": "boolean"
             },
             "runAsUser": {
               "type": "integer"

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -338,12 +338,9 @@ statefulset:
     maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
-  # When using persistent storage the volume will be mounted as root. In order for redpanda to use the volume
-  # we must set the fsGroup to the uid of redpanda, which is 101
-  podSecurityContext:
+  securityContext:
     fsGroup: 101
-    # runAsNonRoot: true
-    # runAsUser: 1000
+    runAsUser: 101
 
 # Service account management
 serviceAccount:


### PR DESCRIPTION
If the redpanda container changes the uid:gid for the "redpanda" user, it will no longer match the fsGroup and the pod will no longer be able to access its data or configuration. This ensures the ids always match the file ownership.