### PR TITLE
Update Redpanda chart version from v22.3.5 to v22.3.9

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.3.19
+version: 2.3.20
 
 # The app version is the default version of Redpanda to install.
-appVersion: v22.3.5
+appVersion: v22.3.9
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
 # pre-release. Our "-0" allows pre-releases to be matched.
@@ -43,6 +43,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: vectorized/redpanda:v22.3.5
+      image: vectorized/redpanda:v22.3.9
     - name: busybox
       image: busybox:latest


### PR DESCRIPTION
Bump Redpanda version to the latest released.

REF
https://github.com/redpanda-data/redpanda/releases/tag/v22.3.9

Mirror of https://github.com/redpanda-data/helm-charts/pull/231