### PR TITLE
Allow full control of advertised listeners

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.5.1
+version: 2.5.2
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -221,6 +221,19 @@ Generate configuration needed for rpk
   {{- $result -}}
 {{- end -}}
 
+{{- define "external-nodeport-enabled" -}}
+{{- $values := .Values -}}
+{{- $enabled := and .Values.external.enabled (eq .Values.external.type "NodePort") -}}
+{{- range $listener := .Values.listeners -}}
+  {{- range $external := $listener.external -}}
+    {{- if and (dig "enabled" false $external) (eq (dig "type" $values.external.type $external) "NodePort") -}}
+      {{- $enabled = true -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- toJson (dict "bool" $enabled) -}}
+{{- end -}}
+
 {{- define "redpanda-reserve-memory" -}}
   {{/*
   Determines the value of --reserve-memory flag (in mebibytes with M suffix, per Seastar).

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -79,65 +79,11 @@ Use AppVersion if image.tag is not set
 Generate configuration needed for rpk
 */}}
 
-{{- define "listen.address" -}}
-{{- "$(POD_IP)" -}}
-{{- end -}}
-
-{{- define "nodeport.listen.address" -}}
-{{- "$(HOST_IP)" -}}
-{{- end -}}
-
 {{- define "redpanda.internal.domain" -}}
 {{- $service := include "redpanda.fullname" . -}}
 {{- $ns := .Release.Namespace -}}
 {{- $domain := .Values.clusterDomain | trimSuffix "." -}}
 {{- printf "%s.%s.svc.%s." $service $ns $domain -}}
-{{- end -}}
-
-{{- define "redpanda.kafka.internal.advertise.address" -}}
-{{- $host := "$(SERVICE_NAME)" -}}
-{{- $domain := include "redpanda.internal.domain" . -}}
-{{- printf "%s.%s" $host $domain -}}
-{{- end -}}
-
-{{/*
-The external advertised address can change depending on the externalisation method.
-If the method is to expose via load balancer this must be provided through the values
-load balancers configuration for parent zone. If the load balancer is not enabled
-then then services are externalised using NodePorts, in which case the external node
-IP is required for the advertised address.
-*/}}
-
-{{- define "redpanda.kafka.external.domain-lb-bkp" -}}
-{{- .Values.loadBalancer.parentZone | trimSuffix "." -}}
-{{- end -}}
-
-{{- define "redpanda.kafka.external.domain" -}}
-{{- .Values.external.domain | trimSuffix "." | default "$(HOST_IP)" -}}
-{{- end -}}
-
-{{- define "redpanda.kafka.external.advertise.address" -}}
-{{- $host := "$(SERVICE_NAME)" -}}
-{{- $domain := include "redpanda.kafka.external.domain" . -}}
-{{- printf "%s.%s" $host $domain -}}
-{{- end -}}
-
-{{- define "redpanda.rpc.advertise.address" -}}
-{{- $host := "$(SERVICE_NAME)" -}}
-{{- $domain := include "redpanda.internal.domain" . -}}
-{{- printf "%s.%s" $host $domain -}}
-{{- end -}}
-
-{{- define "redpanda.pandaproxy.internal.advertise.address" -}}
-{{- $host := "$(SERVICE_NAME)" -}}
-{{- $domain := include "redpanda.internal.domain" . -}}
-{{- printf "%s.%s" $host $domain -}}
-{{- end -}}
-
-{{- define "redpanda.pandaproxy.external.advertise.address" -}}
-{{- $host := "$(SERVICE_NAME)" -}}
-{{- $domain := include "redpanda.kafka.external.domain" . -}}
-{{- printf "%s.%s" $host $domain -}}
 {{- end -}}
 
 {{/* ConfigMap variables */}}
@@ -219,19 +165,6 @@ IP is required for the advertised address.
 
 {{- define "sasl-enabled" -}}
 {{- toJson (dict "bool" (dig "enabled" false .Values.auth.sasl)) -}}
-{{- end -}}
-
-{{- define "external-nodeport-enabled" -}}
-{{- $values := .Values -}}
-{{- $enabled := and .Values.external.enabled (eq .Values.external.type "NodePort") -}}
-{{- range $listener := .Values.listeners -}}
-  {{- range $external := $listener.external -}}
-    {{- if and (dig "enabled" false $external) (eq (dig "type" $values.external.type $external) "NodePort") -}}
-      {{- $enabled = true -}}
-    {{- end -}}
-  {{- end -}}
-{{- end -}}
-{{- toJson (dict "bool" $enabled) -}}
 {{- end -}}
 
 {{- define "SI-to-bytes" -}}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -148,7 +148,7 @@ data:
 {{- end }}
 {{- if .Values.listeners.schemaRegistry.enabled }}
     schema_registry:
-      schema_registry:
+      schema_registry_api:
         - name: internal
           address: 0.0.0.0
           port: {{ .Values.listeners.schemaRegistry.port }}

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- $values := .Values }}
-{{- if (include "external-nodeport-enabled" . | fromJson).bool }}
+{{- if (and .Values.external.enabled (eq .Values.external.type "NodePort")) }}
 ---
 apiVersion: v1
 kind: Service
@@ -38,42 +38,38 @@ spec:
   ports:
 {{- range $name, $listener := $values.listeners.admin.external }}
   {{- $enabled := dig "enabled" $values.external.enabled $listener }}
-  {{- $type := dig "type" $values.external.type $listener }}
-  {{- if and $enabled (eq $type "NodePort") }}
+  {{- if $enabled }}
     - name: admin-{{ $name }}
       protocol: TCP
       port: {{ $values.listeners.admin.port }}
-      nodePort: {{ $listener.nodePort }}
+      nodePort: {{ index $listener.advertisedPorts 0 }}
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $values.listeners.kafka.external }}
   {{- $enabled := dig "enabled" $values.external.enabled $listener }}
-  {{- $type := dig "type" $values.external.type $listener }}
-  {{- if and $enabled (eq $type "NodePort") }}
+  {{- if $enabled }}
     - name: kafka-{{ $name }}
       protocol: TCP
       port: {{ $listener.port }}
-      nodePort: {{ $listener.nodePort }}
+      nodePort: {{ index $listener.advertisedPorts 0 }}
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $values.listeners.http.external }}
   {{- $enabled := dig "enabled" $values.external.enabled $listener }}
-  {{- $type := dig "type" $values.external.type $listener }}
-  {{- if and $enabled (eq $type "NodePort") }}
+  {{- if $enabled }}
     - name: http-{{ $name }}
       protocol: TCP
       port: {{ $listener.port }}
-      nodePort: {{ $listener.nodePort }}
+      nodePort: {{ index $listener.advertisedPorts 0 }}
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $values.listeners.schemaRegistry.external }}
   {{- $enabled := dig "enabled" $values.external.enabled $listener }}
-  {{- $type := dig "type" $values.external.type $listener }}
-  {{- if and $enabled (eq $type "NodePort") }}
+  {{- if $enabled }}
     - name: schema-{{ $name }}
       protocol: TCP
-      port: {{ $listener.port }}
-      nodePort: {{ $listener.nodePort }}
+      port: {{ $values.listeners.schemaRegistry.port }}
+      nodePort: {{ index $listener.advertisedPorts 0 }}
   {{- end }}
 {{- end }}
   selector:

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- $values := .Values }}
-{{- if (and .Values.external.enabled (eq .Values.external.type "NodePort")) }}
+{{- if (include "external-nodeport-enabled" . | fromJson).bool }}
 ---
 apiVersion: v1
 kind: Service
@@ -42,7 +42,7 @@ spec:
     - name: admin-{{ $name }}
       protocol: TCP
       port: {{ $values.listeners.admin.port }}
-      nodePort: {{ index $listener.advertisedPorts 0 }}
+      nodePort: {{ dig "nodePort" (first (dig "advertisedPorts" (list $values.listeners.admin.port) $listener)) $listener }}
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $values.listeners.kafka.external }}
@@ -51,7 +51,7 @@ spec:
     - name: kafka-{{ $name }}
       protocol: TCP
       port: {{ $listener.port }}
-      nodePort: {{ index $listener.advertisedPorts 0 }}
+      nodePort: {{ dig "nodePort" (first (dig "advertisedPorts" (list $values.listeners.kafka.port) $listener)) $listener }}
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $values.listeners.http.external }}
@@ -60,7 +60,7 @@ spec:
     - name: http-{{ $name }}
       protocol: TCP
       port: {{ $listener.port }}
-      nodePort: {{ index $listener.advertisedPorts 0 }}
+      nodePort: {{ dig "nodePort" (first (dig "advertisedPorts" (list $values.listeners.http.port) $listener)) $listener }}
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $values.listeners.schemaRegistry.external }}
@@ -69,7 +69,7 @@ spec:
     - name: schema-{{ $name }}
       protocol: TCP
       port: {{ $values.listeners.schemaRegistry.port }}
-      nodePort: {{ index $listener.advertisedPorts 0 }}
+      nodePort: {{ dig "nodePort" (first (dig "advertisedPorts" (list $values.listeners.schemaRegistry.port) $listener)) $listener }}
   {{- end }}
 {{- end }}
   selector:

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -15,6 +15,41 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+
+{{- /*
+advertised-port returns either the only advertised port if only one is specified,
+or the port specified for this pod ordinal when there is a full list provided.
+
+This will return a string int or panic if there is more than one port provided,
+but not enough ports for the number of replicas requested.
+*/ -}}
+{{- define "advertised-port" -}}
+  {{- $port := dig "port" .listenerVals.port .externalVals -}}
+  {{- if .externalVals.advertisedPorts -}}
+    {{- if eq (len .externalVals.advertisedPorts) 1 -}}
+      {{- $port = mustFirst .externalVals.advertisedPorts -}}
+    {{- else -}}
+      {{- $port = index .externalVals.advertisedPorts .replicaIndex -}}
+    {{- end -}}
+  {{- end -}}
+  {{ $port }}
+{{- end -}}
+
+{{- /*
+advertised-host returns a json sring with the data neded for configuring the advertised listener
+*/ -}}
+{{- define "advertised-host" -}}
+  {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
+  {{- if .values.external.addresses -}}
+    {{- if .values.external.domain -}}
+      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) .values.external.domain) "port" .port -}}
+    {{- else -}}
+      {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}
+    {{- end -}}
+  {{- end -}}
+  {{- toJson $host -}}
+{{- end -}}
+
 {{- $values := .Values }}
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
 {{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}
@@ -79,34 +114,27 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-{{- range $listenerName, $listenerVals := $values.listeners }}
+{{- range $listenerName := (list "kafka" "http") }}
+{{- $listenerVals := get $values.listeners $listenerName }}
   {{- $ordList := list }}
+  {{- /* do this for each pod in the statefulset */}}
   {{- range $replicaIndex := until ($values.statefulset.replicas | int) }}
-    {{- $listenerList := list }}
-    {{- if and $listenerVals.external (or (eq $listenerName "kafka") (eq $listenerName "http")) }}
-      {{- $listenerList = append $listenerList (toJson (dict "name" "internal" "address" $internalAdvertiseAddress "port" $listenerVals.port)) }}
+    {{- /* build a list of listeners */}}
+    {{- $listenerList := list (toJson (dict "name" "internal" "address" $internalAdvertiseAddress "port" $listenerVals.port)) }}
+    {{- if $listenerVals.external }}
+        {{- /* add each external listener */}}
         {{- range $externalName, $externalVals := $listenerVals.external }}
-
-          {{- $port := dig "port" $listenerVals.port $externalVals }}
-          {{- if $externalVals.advertisedPorts }}
-            {{- if eq (len $externalVals.advertisedPorts) 1 }}
-              {{- $port = index $externalVals.advertisedPorts 0 }}
-            {{- else }}
-              {{- $port = index $externalVals.advertisedPorts $replicaIndex }}
-            {{- end }}
-          {{- end }}
-
-          {{- $host := dict "name" $externalName "address" $externalAdvertiseAddress "port" $port }}
-          {{- if $values.external.addresses }}
-            {{- if $values.external.domain }}
-              {{- $host = dict "name" $externalName "address" (printf "%s.%s" (index $values.external.addresses $replicaIndex) $values.external.domain) "port" $port }}
-            {{- else }}
-              {{- $host = dict "name" $externalName  "address" (index $values.external.addresses $replicaIndex) "port" $port }}
-            {{- end }}
-          {{- end }}
-          {{- $listenerList = mustAppend $listenerList (toJson $host) }}
+          {{- $tmplVals := dict "listenerVals" $listenerVals "externalVals" $externalVals "replicaIndex" $replicaIndex "externalName" $externalName "externalAdvertiseAddress" $externalAdvertiseAddress "values" $values }}
+          {{- $port := int (include "advertised-port" $tmplVals) }}
+          {{- $host := include "advertised-host" (mustMerge $tmplVals (dict "port" $port)) }}
+          {{- $listenerList = mustAppend $listenerList $host }}
         {{- end }}
     {{- end }}
+    {{- /*
+    This is making a semicolon list of listeners, one list for each pod.
+    We can safely remove all the spaces as there cannot be a space in a name, address, or port, and this fixes
+    a problem where a user can feed in a trailing space on a hostname.
+    */}}
     {{- $ordList = mustAppend $ordList (nospace (join ";" $listenerList)) }}
   {{- end }}
             - name: ADVERTISED_{{ upper $listenerName }}_ADDRESSES

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -15,41 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-
-{{- /*
-advertised-port returns either the only advertised port if only one is specified,
-or the port specified for this pod ordinal when there is a full list provided.
-
-This will return a string int or panic if there is more than one port provided,
-but not enough ports for the number of replicas requested.
-*/ -}}
-{{- define "advertised-port" -}}
-  {{- $port := dig "port" .listenerVals.port .externalVals -}}
-  {{- if .externalVals.advertisedPorts -}}
-    {{- if eq (len .externalVals.advertisedPorts) 1 -}}
-      {{- $port = mustFirst .externalVals.advertisedPorts -}}
-    {{- else -}}
-      {{- $port = index .externalVals.advertisedPorts .replicaIndex -}}
-    {{- end -}}
-  {{- end -}}
-  {{ $port }}
-{{- end -}}
-
-{{- /*
-advertised-host returns a json sring with the data neded for configuring the advertised listener
-*/ -}}
-{{- define "advertised-host" -}}
-  {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
-  {{- if .values.external.addresses -}}
-    {{- if .values.external.domain -}}
-      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) .values.external.domain) "port" .port -}}
-    {{- else -}}
-      {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}
-    {{- end -}}
-  {{- end -}}
-  {{- toJson $host -}}
-{{- end -}}
-
 {{- $values := .Values }}
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
 {{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -16,7 +16,11 @@ limitations under the License.
 */}}
 
 {{- $values := .Values }}
-{{- $advertiseAddress := include "redpanda.kafka.internal.advertise.address" . }}
+{{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
+{{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}
+{{- if $values.external.domain -}}
+  {{- $externalAdvertiseAddress = printf "$(SERVICE_NAME).%s" $values.external.domain -}}
+{{- end -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -69,14 +73,46 @@ spec:
               mountPath: /var/lib/redpanda/data
         - name: {{ template "redpanda.name" . }}-configurator
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
-          command: ["/bin/sh", "-c"]
+          command: ["/bin/bash", "-c"]
           env:
             - name: SERVICE_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-            - name: EXTERNAL_ADDRESSES
-              value: {{ .Values.external.addresses }}
+{{- range $listenerName, $listenerVals := $values.listeners }}
+  {{- if and $listenerVals.external (or (eq $listenerName "kafka") (eq $listenerName "http")) }}
+            - name: ADVERTISED_{{ upper $listenerName }}_ADDRESSES
+              value: "{{ range $replicaIndex := until ($values.statefulset.replicas | int) -}}
+{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ("internal" | squote) ("address" | squote) ($internalAdvertiseAddress | squote) ("port" | squote) ($listenerVals.port | squote) -}} };
+      {{- range $externalName, $externalVals := $listenerVals.external -}}
+        {{- $port := $listenerVals.port -}}
+        {{- if $externalVals.port -}}
+          {{- $port = $externalVals.port -}}
+        {{- end -}}
+        {{- if $externalVals.advertisedPorts -}}
+          {{- if lt (sub (len $externalVals.advertisedPorts) 1) $replicaIndex -}}
+            {{- $port = index $externalVals.advertisedPorts (sub (len $externalVals.advertisedPorts) 1) -}}
+          {{- else -}}
+            {{- $port = index $externalVals.advertisedPorts $replicaIndex -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if $values.external.addresses -}}
+          {{- if $values.external.domain -}}
+{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ($externalName | squote) ("address" | squote) ((printf "%s.%s" (index $values.external.addresses $replicaIndex) $values.external.domain) | squote) ("port" | squote) ($port | squote) -}} }
+          {{- else -}}
+{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ($externalName | squote) ("address" | squote) (index $values.external.addresses $replicaIndex | squote) ("port" | squote) ($port | squote) -}} }
+          {{- end -}}
+        {{- else -}}
+{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ($externalName | squote) ("address" | squote) ($externalAdvertiseAddress | squote) ("port" | squote) ($port | squote) -}} }
+        {{- end -}}
+;
+      {{- end }}
+      {{- if not (eq $replicaIndex (sub $values.statefulset.replicas 1)) -}}
+        {{- " " -}}
+      {{- end -}}
+    {{- end }}"
+  {{- end }}
+{{- end }}
             - name: KUBERNETES_NODE_NAME
               valueFrom:
                 fieldRef:
@@ -102,36 +138,23 @@ spec:
               fi
               {{- end }}
 
-              # Configure internal kafka listeners
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].name internal
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].address {{ $advertiseAddress }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[0].port {{ .Values.listeners.kafka.port }}
+              NODE_INDEX=`expr $POD_ORDINAL + 1`
 
-              # Configure external kafka listeners
-              {{- $listenerIndex := 1 }}
-              {{- range $name, $listener := .Values.listeners.kafka.external }}
-                {{- $enabled := dig "enabled" $values.external.enabled $listener }}
-                {{- $listenerNodePortEnabled := and $enabled (eq (dig "type" $values.external.type $listener) "NodePort") }}
-                {{- $advertiseKafkaHost := $advertiseAddress }}
-                {{- $advertiseKafkaPort := $listener.nodePort }}
-                {{- if $listenerNodePortEnabled }}
-                  {{- if $values.external.addresses }}
-              NODE_INDEX=`expr $NODE_ID + 1`
-              NODE_ADDRESS=`echo $EXTERNAL_ADDRESSES | cut -d ' ' -f $NODE_INDEX`
-                    {{- if eq $values.external.addressType "ip" }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS
-                    {{- else }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS.{{ $values.external.domain }}
-                    {{- end }}
-                  {{- else }}
-                    {{- $advertiseKafkaHost = printf "$(SERVICE_NAME).%s" $values.external.domain }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address {{ $advertiseKafkaHost }}
-                  {{- end }}
-                {{- end }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].name {{ $name }}
-              rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].port {{ $advertiseKafkaPort }}
-                {{- $listenerIndex = add $listenerIndex 1 }}
-              {{- end }}
+              LISTENER_INDEX=1
+              LISTENER=`echo $ADVERTISED_KAFKA_ADDRESSES | cut -d ' ' -f $NODE_INDEX | cut -d ';' -f $LISTENER_INDEX`
+              until [ "$LISTENER" == "" ]; do
+                rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[$(($LISTENER_INDEX-1))] "$LISTENER"
+                let "LISTENER_INDEX+=1"
+                LISTENER=`echo $ADVERTISED_KAFKA_ADDRESSES | cut -d ' ' -f $NODE_INDEX | cut -d ';' -f $LISTENER_INDEX`
+              done
+
+              LISTENER_INDEX=1
+              LISTENER=`echo $ADVERTISED_HTTP_ADDRESSES | cut -d ' ' -f $NODE_INDEX | cut -d ';' -f $LISTENER_INDEX`
+              until [ "$LISTENER" == "" ]; do
+                rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[$(($LISTENER_INDEX-1))] "$LISTENER"
+                let "LISTENER_INDEX+=1"
+                LISTENER=`echo $ADVERTISED_HTTP_ADDRESSES | cut -d ' ' -f $NODE_INDEX | cut -d ';' -f $LISTENER_INDEX`
+              done
 
               {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
                 {{- if .Values.rackAwareness.enabled }}
@@ -261,14 +284,10 @@ spec:
             - --memory={{ template "redpanda-memory" . }}M
             - --reserve-memory={{ template "redpanda-reserve-memory" . }}
             - --default-log-level={{ .Values.logging.logLevel }}
-            - --advertise-rpc-addr={{ $advertiseAddress }}:{{ .Values.listeners.rpc.port }}
-            - --advertise-pandaproxy-addr=internal://{{ $advertiseAddress }}:{{ .Values.listeners.http.port }},
-{{- range $name, $listener := .Values.listeners.http.external -}}
-                {{ $name }}://{{ $advertiseAddress }}:{{ $listener.nodePort }},
-{{- end }}
+            - --advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}
           ports:
 {{- range $name, $listener := .Values.listeners }}
-            - name: {{ lower $name }}
+            - name: {{ lower $name | trunc 6 }}-internal
               containerPort: {{ $listener.port }}
   {{- range $externalName, $external := $listener.external }}
     {{- if $external.port }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -80,38 +80,37 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
 {{- range $listenerName, $listenerVals := $values.listeners }}
-  {{- if and $listenerVals.external (or (eq $listenerName "kafka") (eq $listenerName "http")) }}
-            - name: ADVERTISED_{{ upper $listenerName }}_ADDRESSES
-              value: "{{ range $replicaIndex := until ($values.statefulset.replicas | int) -}}
-{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ("internal" | squote) ("address" | squote) ($internalAdvertiseAddress | squote) ("port" | squote) ($listenerVals.port | squote) -}} };
-      {{- range $externalName, $externalVals := $listenerVals.external -}}
-        {{- $port := $listenerVals.port -}}
-        {{- if $externalVals.port -}}
-          {{- $port = $externalVals.port -}}
-        {{- end -}}
-        {{- if $externalVals.advertisedPorts -}}
-          {{- if lt (sub (len $externalVals.advertisedPorts) 1) $replicaIndex -}}
-            {{- $port = index $externalVals.advertisedPorts (sub (len $externalVals.advertisedPorts) 1) -}}
-          {{- else -}}
-            {{- $port = index $externalVals.advertisedPorts $replicaIndex -}}
-          {{- end -}}
-        {{- end -}}
-        {{- if $values.external.addresses -}}
-          {{- if $values.external.domain -}}
-{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ($externalName | squote) ("address" | squote) ((printf "%s.%s" (index $values.external.addresses $replicaIndex) $values.external.domain) | squote) ("port" | squote) ($port | squote) -}} }
-          {{- else -}}
-{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ($externalName | squote) ("address" | squote) (index $values.external.addresses $replicaIndex | squote) ("port" | squote) ($port | squote) -}} }
-          {{- end -}}
-        {{- else -}}
-{ {{- printf "%s:%s,%s:%s,%s:%s" ("name" | squote) ($externalName | squote) ("address" | squote) ($externalAdvertiseAddress | squote) ("port" | squote) ($port | squote) -}} }
-        {{- end -}}
-;
-      {{- end }}
-      {{- if not (eq $replicaIndex (sub $values.statefulset.replicas 1)) -}}
-        {{- " " -}}
-      {{- end -}}
-    {{- end }}"
+  {{- $ordList := list }}
+  {{- range $replicaIndex := until ($values.statefulset.replicas | int) }}
+    {{- $listenerList := list }}
+    {{- if and $listenerVals.external (or (eq $listenerName "kafka") (eq $listenerName "http")) }}
+      {{- $listenerList = append $listenerList (toJson (dict "name" "internal" "address" $internalAdvertiseAddress "port" $listenerVals.port)) }}
+        {{- range $externalName, $externalVals := $listenerVals.external }}
+
+          {{- $port := dig "port" $listenerVals.port $externalVals }}
+          {{- if $externalVals.advertisedPorts }}
+            {{- if eq (len $externalVals.advertisedPorts) 1 }}
+              {{- $port = index $externalVals.advertisedPorts 0 }}
+            {{- else }}
+              {{- $port = index $externalVals.advertisedPorts $replicaIndex }}
+            {{- end }}
+          {{- end }}
+
+          {{- $host := dict "name" $externalName "address" $externalAdvertiseAddress "port" $port }}
+          {{- if $values.external.addresses }}
+            {{- if $values.external.domain }}
+              {{- $host = dict "name" $externalName "address" (printf "%s.%s" (index $values.external.addresses $replicaIndex) $values.external.domain) "port" $port }}
+            {{- else }}
+              {{- $host = dict "name" $externalName  "address" (index $values.external.addresses $replicaIndex) "port" $port }}
+            {{- end }}
+          {{- end }}
+          {{- $listenerList = mustAppend $listenerList (toJson $host) }}
+        {{- end }}
+    {{- end }}
+    {{- $ordList = mustAppend $ordList (nospace (join ";" $listenerList)) }}
   {{- end }}
+            - name: ADVERTISED_{{ upper $listenerName }}_ADDRESSES
+              value: {{ squote (join " " $ordList) }}
 {{- end }}
             - name: KUBERNETES_NODE_NAME
               valueFrom:

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -314,7 +314,7 @@ spec:
             - --advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}
           ports:
 {{- range $name, $listener := .Values.listeners }}
-            - name: {{ lower $name | trunc 6 }}-internal
+            - name: {{ lower $name }}
               containerPort: {{ $listener.port }}
   {{- range $externalName, $external := $listener.external }}
     {{- if $external.port }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -49,5 +49,5 @@ spec:
         - "300"
         - --retry-max-time
         - "120"
-        - http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+        - http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 {{- end }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -185,9 +185,7 @@
     "external": {
       "type": "object",
       "required": [
-        "enabled",
-        "type",
-        "domain"
+        "enabled"
       ],
       "properties": {
         "enabled": {
@@ -201,12 +199,8 @@
           "type": "string",
           "format": "idn-hostname"
         },
-        "addressType": {
-          "type": "string",
-          "pattern": "^(subdomain|ip)$"
-        },
         "addresses": {
-          "type": "string"
+          "type": "array"
         }
       }
     },
@@ -657,23 +651,19 @@
             },
             "external": {
               "type": "object",
-              "minProperties": 1,
               "patternProperties": {
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
-                  "required": [
-                    "nodePort"
-                  ],
                   "properties": {
                     "enabled": {
                       "type": "boolean"
                     },
-                    "type": {
-                      "type": "string",
-                      "pattern": "^NodePort$"
-                    },
-                    "nodePort": {
-                      "type": "integer"
+                    "advertisedPorts": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "integer"
+                      }
                     }
                   }
                 }
@@ -703,7 +693,6 @@
           "type": "object",
           "required": [
             "port",
-            "external",
             "tls"
           ],
           "properties": {
@@ -717,8 +706,7 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
                   "required": [
-                    "port",
-                    "nodePort"
+                    "port"
                   ],
                   "properties": {
                     "enabled": {
@@ -727,12 +715,12 @@
                     "port": {
                       "type": "integer"
                     },
-                    "type": {
-                      "type": "string",
-                      "pattern": "^NodePort$"
-                    },
-                    "nodePort": {
-                      "type": "integer"
+                    "advertisedPorts": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "integer"
+                      }
                     }
                   }
                 }
@@ -785,8 +773,7 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
                   "required": [
-                    "port",
-                    "nodePort"
+                    "port"
                   ],
                   "properties": {
                     "enabled": {
@@ -795,12 +782,12 @@
                     "port": {
                       "type": "integer"
                     },
-                    "type": {
-                      "type": "string",
-                      "pattern": "^NodePort$"
-                    },
-                    "nodePort": {
-                      "type": "integer"
+                    "advertisedPorts": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "integer"
+                      }
                     }
                   }
                 }
@@ -882,10 +869,6 @@
               "patternProperties": {
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
-                  "required": [
-                    "port",
-                    "nodePort"
-                  ],
                   "properties": {
                     "enabled": {
                       "type": "boolean"
@@ -893,12 +876,12 @@
                     "port": {
                       "type": "integer"
                     },
-                    "type": {
-                      "type": "string",
-                      "pattern": "^NodePort$"
-                    },
-                    "nodePort": {
-                      "type": "integer"
+                    "advertisedPorts": {
+                      "type": "array",
+                      "minItems": 1,
+                      "items": {
+                        "type": "integer"
+                      }
                     }
                   }
                 }

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -651,6 +651,7 @@
             },
             "external": {
               "type": "object",
+              "minProperties": 1,
               "patternProperties": {
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
@@ -693,6 +694,7 @@
           "type": "object",
           "required": [
             "port",
+            "external",
             "tls"
           ],
           "properties": {

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -102,8 +102,8 @@ tls:
 #
 # External access configuration
 external:
-  # Default external access value
-  # This be overridden by each listener if needed
+  # Default external access value for each service
+  # Services can toggle external access per listener (ie. `listeners.<service name>.external.<listener name>.enabled`)
   enabled: true
   # External access type. `NodePort` is the only acceptable value if defined.
   # If undefined, then advertised listeners will be configured in Redpanda, but the helm chart will not create a Service. You must create a Service manually.

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -28,7 +28,7 @@
 nameOverride: ""
 # Override redpanda.fullname template
 fullnameOverride: ""
-# Default kuberentes cluster domain
+# Default kubernetes cluster domain
 clusterDomain: cluster.local
 # Additional labels added to all Kubernetes objects
 commonLabels: {}
@@ -102,25 +102,21 @@ tls:
 #
 # External access configuration
 external:
-  # Default external access value for all listeners except RPC
-  # External config doesn't apply to RPC listeners as they are never externally accessible
-  # These values can be overridden by each listener if needed
+  # Default external access value
+  # This be overridden by each listener if needed
   enabled: true
-  # Default external access type (only NodePort at the moment)
+  # External access type. `NodePort` is the only acceptable value if defined.
+  # If undefined, then advertised listeners will be configured and a service must be created manually
   type: NodePort
-  # Domain to be used for each node
-  domain: local
-  #
-  # addressType can be set to the following: subdomain ip
-  # with subdomain, each node will advertise an address with <external.addresses[replica index]>.<domain>
-  # with ip, each node will advertise only <external.addresses[replica index]> (and domain will be ignored)
-  # addressType: subdomain
-  #
-  # The addresses list must have an entry for each statefulset replica
-  # By default, the statefulset is called redpanda and has 3 replicas
-  # If you want to access nodes by their IP: addresses: "18.224.215.250 18.118.163.26 3.142.153.29"
-  # Or if you want to access nodes via DNS: addresses: "apple bacon carrot"
-  # addresses: "redpanda-0 redpanda-1 redpanda-2"
+  # Optional domain advertised to external clients
+  # If specified, then it will be appended to the `external.addresses` values as each broker's advertised address
+  # domain: local
+  # An optional addresses list with an entry for each broker / statefulset replica combo (default count of 3)
+  # The values can be IP addresses or DNS names. Keep in mind that `external.domain`, if exists, will be appended to this value
+  # addresses:
+  # - redpanda-0
+  # - redpanda-1
+  # - redpanda-2
   #
   # annotations:
     # For example:
@@ -420,21 +416,22 @@ tuning: {}
 # listeners.
 #
 listeners:
-  # Admin API listener
-  # The kafka listener group cannot be disabled
+  # Admin API listener (only one)
   admin:
-    # The port for the admin server
+    # The port for both internal and external connections to the admin API
     port: 9644
     # Optional external section
     external:
+      # Name of the external listener
       default:
-        # `enabled`` is used to override the setting of the `external` top-level key
-        # for this external listener. The default is `true`.
+        # This overrides `external.enabled` for only this listener
         # enabled: true
-
-        # External port
-        # `nodePort` defines the TCP port to listen on for NodePort types.
-        nodePort: 31644
+        # The port advertised to this listener's external clients
+        # List one port if you want to use the same port for each broker (would be the case when using NodePort service)
+        # Otherwise list the port you want to use for each broker in order by statefulset replica
+        # If undefined, `listeners.admin.port` is used
+        advertisedPorts:
+        - 31644
     # Optional TLS section (required if global TLS is enabled)
     tls:
       # Optional flag to override the global TLS enabled flag
@@ -444,47 +441,39 @@ listeners:
       # If true, the truststore file for this listener will be included in the ConfigMap
       requireClientAuth: false
   # Kafka API listeners
-  # The kafka listener group cannot be disabled
   kafka:
-    port: 9093
-    # Listeners internal to kubernetes service network
+    # The port for internal client connections (10092 is default to avoid conflicts with the external default port 9092)
+    port: 10092
     tls:
       # enabled: true
       cert: default
       requireClientAuth: false
-    # External listeners
     external:
-    # to disable external kafka listeners when the global `external` is enabled,
-    # replace this with an empty list, ie: `external: []`
       default:
-        port: 9094
-        # If unset, it will default to the type in the `external` section.
-        type: NodePort
-        # External port
-        # This listener port will be used on each kubernetes node
-        nodePort: 31092
+        # enabled: true
+        # The port used for external client connections
+        port: 9092
+        # If undefined, `listeners.kafka.external.port` is used
+        advertisedPorts:
+        - 31092
   # HTTP API listeners (aka PandaProxy)
-  # PandaProxy is a kafka client that connects to an endpoint from listeners.kafka.endpoints
   http:
     enabled: true
-    port: 8082
+    port: 9082
+    # TODO is this for internal and external clients? why can't internal connect to kafka internal, and each external connect to matchin kafka external? then this can be removed
+    # determines which kafka listener the internal kafka client backing this API will connect to
     kafkaEndpoint: default
     tls:
       # enabled: true
       cert: default
       requireClientAuth: false
-    # External listeners
     external:
       default:
-        # Ports must be unique per listener
-        port: 8083
-        # If unset, it will default to the type in the `external` section.
-        type: NodePort
-        # External port
-        # This listener port will be used for the external port if NodePort is selected
-        nodePort: 30082
-  # RPC listener
-  # The RPC listener cannot be disabled
+        # enabled: true
+        port: 8082
+        advertisedPorts:
+        - 30082
+  # RPC listener (this is never externally accessible)
   rpc:
     port: 33145
     tls:
@@ -495,7 +484,6 @@ listeners:
   schemaRegistry:
     enabled: true
     port: 8081
-    # Schema Registry is a kafka client that connects to an endpoint from listeners.kafka.endpoints
     kafkaEndpoint: default
     tls:
       # enabled: true
@@ -503,15 +491,9 @@ listeners:
       requireClientAuth: false
     external:
       default:
-        # Ports must be unique per listener
-        port: 8080
-        # Optional external section
         # enabled: true
-        # If unset, it will default to the type in the `external` section.
-        # type: NodePort
-        # External port
-        # This listener port will be used for the external port if this is not included
-        nodePort: 30081
+        advertisedPorts:
+        - 31081
 
 # Expert Config
 

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -106,7 +106,7 @@ external:
   # This be overridden by each listener if needed
   enabled: true
   # External access type. `NodePort` is the only acceptable value if defined.
-  # If undefined, then advertised listeners will be configured and a service must be created manually
+  # If undefined, then advertised listeners will be configured in Redpanda, but the helm chart will not create a Service. You must create a Service manually.
   type: NodePort
   # Optional domain advertised to external clients
   # If specified, then it will be appended to the `external.addresses` values as each broker's advertised address
@@ -443,7 +443,7 @@ listeners:
   # Kafka API listeners
   kafka:
     # The port for internal client connections (10092 is default to avoid conflicts with the external default port 9092)
-    port: 10092
+    port: 9093
     tls:
       # enabled: true
       cert: default
@@ -452,16 +452,14 @@ listeners:
       default:
         # enabled: true
         # The port used for external client connections
-        port: 9092
+        port: 9094
         # If undefined, `listeners.kafka.external.port` is used
         advertisedPorts:
         - 31092
   # HTTP API listeners (aka PandaProxy)
   http:
     enabled: true
-    port: 9082
-    # TODO is this for internal and external clients? why can't internal connect to kafka internal, and each external connect to matchin kafka external? then this can be removed
-    # determines which kafka listener the internal kafka client backing this API will connect to
+    port: 8082
     kafkaEndpoint: default
     tls:
       # enabled: true
@@ -470,7 +468,7 @@ listeners:
     external:
       default:
         # enabled: true
-        port: 8082
+        port: 8083
         advertisedPorts:
         - 30082
   # RPC listener (this is never externally accessible)
@@ -493,7 +491,7 @@ listeners:
       default:
         # enabled: true
         advertisedPorts:
-        - 31081
+        - 30081
 
 # Expert Config
 


### PR DESCRIPTION
This PR enables configuring advertised listeners without creating a service for external access. This makes it possible for helm chart deployments to work with a variety of external access methods, such as LoadBalancer service.

Fixes #258, fixes #256 

### Changes
1. made `external.type` optional. If undefined, then advertised listeners will be configured without creating a service
3. removed `$externalListener.nodePorts`, added `$externalListener.advertisedPorts`:
  a. when `external.type` is `NodePort`, the first element of the array is the port opened on each node
  b. when `external.type` is undefined, each element of the array is the port to be opened externally for accessing the pod where array index == statefulset replica index
  c. when advertisedPorts is undefined, `listeners.*.external.*.port` then `listeners.*.port` is used
4. removed container start command listener flags, add listeners other than RPC to statefulset initContainer
5. removed unused templates
6. switched `external.addresses` from string to array
7. removed `listeners.*.external.type` and assume `external.type` is used across all externally enabled listeners
8. fix `schema_registry_api` in configmap.yaml (was `schema_registry`)
9. update test-schema-registry-status to use same short hostname URL as other tests (rather than FQDN)
10. fixed issue after `NODE_ID` was renamed to `POD_ORDINAL`