### PR TITLE
Allow adding `extraEnv` and `extraEnvFrom` to post upgrade job

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.4.1
+version: 2.4.2
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.9

--- a/charts/redpanda/templates/_tplvalues.tpl
+++ b/charts/redpanda/templates/_tplvalues.tpl
@@ -1,0 +1,12 @@
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "common.tplvalues.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "common.tplvalues.render" -}}
+    {{- if typeIs "string" .value }}
+        {{- tpl .value .context }}
+    {{- else }}
+        {{- tpl (.value | toYaml) .context }}
+    {{- end }}
+{{- end -}}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -58,6 +58,14 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
         securityContext: {{ include "container-security-context" . | nindent 10 }}
+        {{- if .Values.post_upgrade_job.extraEnv }}
+        env:
+          {{- include "common.tplvalues.render" (dict "value" .Values.post_upgrade_job.extraEnv "context" $) | nindent 10 }}
+        {{- end }}
+        {{- if .Values.post_upgrade_job.extraEnvFrom }}
+        envFrom:
+          {{- include "common.tplvalues.render" (dict "value" .Values.post_upgrade_job.extraEnvFrom "context" $) | nindent 10 }}
+        {{- end }}
         volumeMounts:
           - name: {{ template "redpanda.fullname" . }}
             mountPath: /tmp/base-config

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -389,6 +389,12 @@
               }
             }
           }
+        },
+        "extraEnv": {
+          "type": ["array", "string"]
+        },
+        "extraEnvFrom": {
+          "type": ["array", "string"]
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -266,7 +266,7 @@ post_install_job:
   # labels: {}
   # annotations: {}
 
-post_upgrade_job: 
+post_upgrade_job:
   enabled: true
   # Resource requests and limits for the post-upgrade batch job
   # resources:
@@ -278,6 +278,17 @@ post_upgrade_job:
   #     memory: 1024Mi
   # labels: {}
   # annotations: {}
+  # Additional environment variables for the Post Upgrade Job
+  # extraEnv:
+  #   - name: AWS_SECRET_ACCESS_KEY
+  #     valueFrom:
+  #       secretKeyRef:
+  #         name: my-secret
+  #         key: redpanda-aws-secret-access-key
+  # Additional environment variables for the Post Upgrade Job mapped from Secret or ConfigMap
+  # extraEnvFrom:
+  #   - secretRef:
+  #       name: redpanda-aws-secrets
 
 statefulset:
   # Number of Redpanda brokers (recommend setting this to the number of nodes in the cluster)


### PR DESCRIPTION
With these changes `values.yaml` can look like below:

```yaml
config:
  cluster:
    cloud_storage_secret_key: $(AWS_SECRET_ACCESS_KEY)
post_upgrade_job:
  extraEnv:
    - name: AWS_SECRET_ACCESS_KEY
      valueFrom:
        secretKeyRef:
          name: my-secret
          key: redpanda-aws-secret-access-key
```

and `post-upgrade.yaml` renders:

```yaml
...
      containers:
      - name: redpanda-post-upgrade
        image: vectorized/redpanda:v22.3.9
        command: ["/bin/sh", "-c"]
        args:
          - |
            rpk cluster config import -f /tmp/base-config/bootstrap.yaml --brokers redpanda-0.redpanda.default.svc.cluster.local.:9092,<insert N brokers> --api-urls redpanda-0.redpanda.default.svc.cluster.local.:9644
            rpk cluster config set cloud_storage_secret_key $(AWS_SECRET_ACCESS_KEY) --brokers redpanda-0.redpanda.default.svc.cluster.local.:9092,<insert N brokers> --api-urls redpanda-0.redpanda.default.svc.cluster.local.:9644
...
        env:
          - name: AWS_SECRET_ACCESS_KEY
            valueFrom:
              secretKeyRef:
                name: my-secret
                key: redpanda-aws-secret-access-key
```

The reason for `extraEnv` and `extraEnvFrom` to be strings can be found here: https://github.com/redpanda-data/console/pull/507#issuecomment-1295474314