### PR TITLE
Add production tunable configuration

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.4.4
+version: 2.4.5
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -419,6 +419,24 @@ IP is required for the advertised address.
 {{- end -}}
 {{- end -}}
 
+{{- define "tunable" -}}
+{{- $tunable := dig "tunable" dict .Values.config }}
+{{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
+{{- toYaml $tunable | nindent 4 }}
+{{- else if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
+{{- $tunable = unset $tunable "log_segment_size_min" }}
+{{- $tunable = unset $tunable "log_segment_size_max" }}
+{{- $tunable = unset $tunable "kafka_batch_max_bytes" }}
+{{- toYaml $tunable | nindent 4 }}
+{{- else if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
+{{- $tunable = unset $tunable "log_segment_size_min" }}
+{{- $tunable = unset $tunable "log_segment_size_max" }}
+{{- $tunable = unset $tunable "kafka_batch_max_bytes" }}
+{{- $tunable = unset $tunable "topic_partitions_per_shard" }}
+{{- toYaml $tunable | nindent 4 }}
+{{- end }}
+{{- end }}
+
 {{- define "redpanda-atleast-22-1-1" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.1.1"))) -}}
 {{- end -}}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -46,9 +46,7 @@ data:
   {{- with (dig "cluster" dict .Values.config) }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- with (dig "tunable" dict .Values.config) }}
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "tunable" . }}
   {{- if and (not (hasKey .Values.config.cluster "storage_min_free_bytes")) ((include "redpanda-atleast-22-2-0" . | fromJson).bool) }}
     storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
   {{- end }}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -79,7 +79,7 @@ data:
   {{- with (dig "tunable" dict .Values.config) }}
       {{- toYaml . | nindent 6 }}
   {{- end }}
-  {{- if not (hasKey "storage_min_free_bytes" .Values.config.cluster) }}
+  {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
       storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -550,7 +550,19 @@ config:
     # tm_sync_timeout_ms: 2000ms                                   # Time to wait state catch up before rejecting a request
     # tm_violation_recovery_policy: crash                          # Describes how to recover from an invariant violation happened on the transaction coordinator level
     # transactional_id_expiration_ms: 10080min                     # Producer ids are expired once this time has elapsed after the last write with the given producer ID
-  tunable: {}
+  tunable:
+    log_segment_size: 134217728                                    # 128 mb
+    log_segment_size_min: 16777216                                 # 16 mb
+    log_segment_size_max: 268435456                                # 256 mb
+    kafka_batch_max_bytes: 1048576                                 # 1 mb
+    topic_partitions_per_shard: 1000
+    compacted_log_segment_size: 67108864                           # 64 mb
+    max_compacted_log_segment_size: 536870912                      # 512 mb
+    kafka_connection_rate_limit: 1000
+    group_topic_partitions: 16
+    # cloud_storage_enable_remote_read: true                       # cluster wide configuration for read from remote cloud storage
+    # cloud_storage_enable_remote_write: true                      # cluster wide configuration for writing to remote cloud storage
+
     # alter_topic_cfg_timeout_ms: 5s                               # Time to wait for entries replication in controller log when executing alter configuration request
     # compacted_log_segment_size: 256MiB                           # How large in bytes should each compacted log segment be (default 256MiB)
     # controller_backend_housekeeping_interval_ms: 1s              # Interval between iterations of controller backend housekeeping loop


### PR DESCRIPTION
Redpanda configuration that is cluster wide and could be changed on runtime.

|                                | default | this PR | available from   | source code link                                                                                                                       |
|--------------------------------|---------|---------|------------------|----------------------------------------------------------------------------------------------------------------------------------------|
| log_segment_size               | 1 GiB   | 128 Mb  | at least 21.11.x | [line 37](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L37)   |
| log_segment_size_min           | 1 MiB   | 16 Mb   | 22.3.x           | [line 47](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L47)   |
| log_segment_size_max           | null    | 256 Mb  | 22.3.x           | [line 56](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L56)   |
| kafka_batch_max_bytes          | 1 MiB   | 1 Mb    | 22.3.x           | [line 867](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L867) |
| topic_partitions_per_shard     | 7000    | 1000    | 22.2.x           | [line 161](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L161) |
| compacted_log_segment_size     | 256 MiB | 64 Mb   | at least 21.11.x | [line 74](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L74)   |
| max_compacted_log_segment_size | 5 GiB   | 512 Mb  | at least 21.11.x | [line 803](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L803) |
| kafka_connection_rate_limit    | null    | 1000    | 22.1.x           | [line 438](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L438) |
| group_topic_partitions         | 16      | 16      | at least 21.11.x | [line 507](https://github.com/redpanda-data/redpanda/blob/bd322f74606f52ef7cee8dde1f64b32068105ce4/src/v/config/configuration.cc#L507) |

REF:
https://github.com/redpanda-data/helm-charts/issues/203