### PR TITLE
fix: use pod ordinal for the node-index to select correct address

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.4.2
+version: 2.4.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.9

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -117,8 +117,8 @@ spec:
                 {{- $advertiseKafkaPort := $listener.nodePort }}
                 {{- if $listenerNodePortEnabled }}
                   {{- if $values.external.addresses }}
-              NODE_INDEX=`expr $NODE_ID + 1`
-              NODE_ADDRESS=`echo $EXTERNAL_ADDRESSES | cut -d ' ' -f $NODE_INDEX`
+              NODE_INDEX=`expr ${POD_ORDINAL} + 1`
+              NODE_ADDRESS=`echo $EXTERNAL_ADDRESSES | cut -d ' ' -f ${NODE_INDEX}`
                     {{- if eq $values.external.addressType "ip" }}
               rpk redpanda --config "$CONFIG" config set redpanda.advertised_kafka_api[{{ $listenerIndex }}].address $NODE_ADDRESS
                     {{- else }}


### PR DESCRIPTION
Attempting to fix #258 

I verified that the pods are using the correct entry on the address string after making this change.  