### PR TITLE
console: set service targetPort to config listenPort

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.4.0
+version: 0.4.1
 
 # The app version is the version of the Chart application
 appVersion: v2.1.1

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -12,7 +12,6 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -12,6 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
   selector:

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
+      targetPort: {{ include "console.server.listenPort" . }}
       protocol: TCP
       name: http
   selector:


### PR DESCRIPTION
The service `targetPort` is currently set to `.Values.service.targetPort` which doesn't exist in the values file, so it ends up as `null` unless overwritten.

Not sure many people change the listenPort in the config file, but since that value is [already used](https://github.com/redpanda-data/helm-charts/blob/acec1790fec99f320e08a8385ece84817bc73c17/charts/console/templates/deployment.yaml#L60) as the `containerPort` in the deployment, it should also be used here.

