### PR TITLE
rp: add required resources to clusterrole for rpk debug bundle

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.1
+version: 2.6.2
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/rbac.yaml
+++ b/charts/redpanda/templates/rbac.yaml
@@ -43,6 +43,42 @@ rules:
       - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redpanda.fullname" . }}-rpk-bundle
+  labels:
+    helm.sh/chart: {{ template "redpanda.chart" . }}
+    app.kubernetes.io/name: {{ template "redpanda.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "redpanda.name" . }}
+  {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - persistentvolumeclaims
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "redpanda.fullname" . }}
@@ -63,6 +99,32 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "redpanda.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "redpanda.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redpanda.fullname" . }}-rpk-bundle
+  labels:
+    helm.sh/chart: {{ template "redpanda.chart" . }}
+    app.kubernetes.io/name: {{ template "redpanda.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "redpanda.name" . }}
+  {{- with .Values.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redpanda.fullname" . }}-rpk-bundle
 subjects:
   - kind: ServiceAccount
     name: {{ include "redpanda.serviceAccountName" . }}


### PR DESCRIPTION
We are introducing rpk debug bundle for k8s environments in 23.1, this functionality depends on the k8s API and it needs to be able to 'get' the listed resources of this commit.

Here is where we use them: https://github.com/redpanda-data/redpanda/blob/dev/src/go/rpk/pkg/cli/cmd/debug/bundle/bundle_k8s_linux.go#L265-L274

That means that rpk debug bundle will only work if you have `Values.rbac.enabled=true`