### PR TITLE
redpanda: allow super small memory settings for development

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.3
+version: 2.6.4
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/NOTES.txt
+++ b/charts/redpanda/templates/NOTES.txt
@@ -16,8 +16,23 @@ limitations under the License.
 */}}
 
 {{/*
-Any rpk command that's given to the user in in this file must be defined in _example-commands.tpl and tested in a test.
+  Add warnings to the warnings template
 */}}
+{{ $warnings := (fromJson (include "warnings" .)).result }}
+{{- if $warnings }}
+---
+{{ range $warning := $warnings }}
+{{ $warning }}
+{{- end }}
+
+---
+{{- end }}
+
+{{-
+/*
+Any rpk command that's given to the user in in this file must be defined in _example-commands.tpl and tested in a test.
+*/
+-}}
 
 {{- $anySASL := (include "sasl-enabled" . | fromJson).bool }}
 {{- $rpk := deepCopy . }}


### PR DESCRIPTION
This allows you to set memory as small as 256Mb. If you do, however, it will display a warning in the NOTES.txt output.

I also added a framework for adding warnings to that output.

Fixes #229