### PR TITLE
fix: enable sasl users from secrets.

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.7.0
+version: 2.8.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.6
+version: 2.7.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
@@ -19,9 +19,8 @@ tls:
 auth:
   sasl:
     enabled: true
-    users:
-      - name: admin
-        password: hunter2
+    secretRef: "redpanda-users"
+
 storage:
   persistentVolume:
     size: 3Gi

--- a/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
@@ -20,6 +20,9 @@ auth:
   sasl:
     enabled: true
     secretRef: "redpanda-users"
+    users:
+      - name: admin
+        password: hunter2
 
 storage:
   persistentVolume:

--- a/charts/redpanda/ci/05-one-node-cluster-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/05-one-node-cluster-tls-sasl-values.yaml
@@ -19,9 +19,8 @@ tls:
 auth:
   sasl:
     enabled: true
-    users:
-      - name: admin
-        password: hunter2
+    secretRef: "redpanda-users"
+
 storage:
   persistentVolume:
     size: 3Gi

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,63 +23,63 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-flags-no-sasl" . }}
 {{- end -}}
 
 {{- define "rpk-acl-create" -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{- define "rpk-cluster-info" -}}
-{{ .rpk }} cluster info {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} cluster info {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{- define "rpk-topic-create" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic create test-topic {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} topic create test-topic {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{- define "rpk-topic-describe" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic describe test-topic {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} topic describe test-topic {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{- define "rpk-topic-delete" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic delete test-topic {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} topic delete test-topic {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create-no-dummy-sasl" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-flags-no-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-create-no-dummy-sasl" -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-common-flags-no-admin" . }}
+{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-flags-no-admin" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-cluster-info-no-dummy-sasl" -}}
-{{ .rpk }} cluster info {{ include "rpk-common-flags-no-admin" . }}
+{{ .rpk }} cluster info {{ include "rpk-flags-no-admin" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-create-no-dummy-sasl" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic create test-topic {{ include "rpk-common-flags-no-admin" . }}
+{{ .rpk }} topic create test-topic {{ include "rpk-flags-no-admin" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-describe-no-dummy-sasl" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic describe test-topic {{ include "rpk-common-flags-no-admin" . }}
+{{ .rpk }} topic describe test-topic {{ include "rpk-flags-no-admin" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-delete-no-dummy-sasl" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic delete test-topic {{ include "rpk-common-flags-no-admin" . }}
+{{ .rpk }} topic delete test-topic {{ include "rpk-flags-no-admin" . }}
 {{- end -}}
 

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,36 +23,33 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-create" -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-topic-flags" . }}
+{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-cluster-info" -}}
-{{ .rpk }} cluster info {{ include "rpk-topic-flags" . }}
+{{ .rpk }} cluster info {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-create" -}}
-{{- $sasl := mustDeepCopy . -}}
-{{- $_ := set $sasl "auth" (dict "username" "myuser" "password" "changeme") -}}
-{{ .rpk }} topic create test-topic {{ include "rpk-topic-flags" $sasl }}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic create test-topic {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-describe" -}}
-{{- $sasl := mustDeepCopy . -}}
-{{- $_ := set $sasl "auth" (dict "username" "myuser" "password" "changeme") -}}
-{{ .rpk }} topic describe test-topic {{ include "rpk-topic-flags" $sasl }}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic describe test-topic {{ include "rpk-common-flags-no-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-delete" -}}
-{{- $sasl := mustDeepCopy . -}}
-{{- $_ := set $sasl "auth" (dict "username" "myuser" "password" "changeme") -}}
-{{ .rpk }} topic delete test-topic {{ include "rpk-topic-flags" $sasl }}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic delete test-topic {{ include "rpk-common-flags-no-sasl" . }}
 {{- end -}}

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -26,30 +26,60 @@ and tested in a test.
 {{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
-{{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-create" -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
-{{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-cluster-info" -}}
-{{ .rpk }} cluster info {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} cluster info {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
-{{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-create" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic create test-topic {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} topic create test-topic {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- end -}}
 
-{{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-describe" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic describe test-topic {{ include "rpk-common-flags-no-sasl" . }}
+{{ .rpk }} topic describe test-topic {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{- end -}}
+
+{{- define "rpk-topic-delete" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic delete test-topic {{ include "rpk-common-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{- end -}}
+
+
+{{/* tested in tests/test-kafka-sasl-status.yaml */}}
+{{- define "rpk-acl-user-create-no-dummy-sasl" -}}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
-{{- define "rpk-topic-delete" -}}
-{{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ .rpk }} topic delete test-topic {{ include "rpk-common-flags-no-sasl" . }}
+{{- define "rpk-acl-create-no-dummy-sasl" -}}
+{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-common-flags-no-admin" . }}
 {{- end -}}
+
+{{/* tested in tests/test-kafka-sasl-status.yaml */}}
+{{- define "rpk-cluster-info-no-dummy-sasl" -}}
+{{ .rpk }} cluster info {{ include "rpk-common-flags-no-admin" . }}
+{{- end -}}
+
+{{/* tested in tests/test-kafka-sasl-status.yaml */}}
+{{- define "rpk-topic-create-no-dummy-sasl" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic create test-topic {{ include "rpk-common-flags-no-admin" . }}
+{{- end -}}
+
+{{/* tested in tests/test-kafka-sasl-status.yaml */}}
+{{- define "rpk-topic-describe-no-dummy-sasl" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic describe test-topic {{ include "rpk-common-flags-no-admin" . }}
+{{- end -}}
+
+{{/* tested in tests/test-kafka-sasl-status.yaml */}}
+{{- define "rpk-topic-delete-no-dummy-sasl" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ .rpk }} topic delete test-topic {{ include "rpk-common-flags-no-admin" . }}
+{{- end -}}
+

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,7 +23,7 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }}
 {{- end -}}
 
 {{- define "rpk-acl-create" -}}
@@ -52,7 +52,7 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create-no-dummy-sasl" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-common-flags-no-sasl" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -346,6 +346,16 @@ Generate configuration needed for rpk
 {{ join " " (list $flags.brokers $flags.admin $flags.sasl $flags.kafka)}}
 {{- end -}}
 
+{{- define "rpk-common-flags-no-admin" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ join " " (list $flags.brokers $flags.kafka $flags.sasl)}}
+{{- end -}}
+
+{{- define "rpk-common-flags-no-admin-no-sasl" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ join " " (list $flags.brokers $flags.kafka)}}
+{{- end -}}
+
 {{- define "rpk-common-flags-no-sasl" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
 {{ join " " (list $flags.brokers $flags.admin $flags.kafka)}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -346,17 +346,12 @@ Generate configuration needed for rpk
 {{ join " " (list $flags.brokers $flags.admin $flags.sasl $flags.kafka)}}
 {{- end -}}
 
-{{- define "rpk-common-flags-no-admin" -}}
+{{- define "rpk-flags-no-admin" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
 {{ join " " (list $flags.brokers $flags.kafka $flags.sasl)}}
 {{- end -}}
 
-{{- define "rpk-common-flags-no-admin-no-sasl" -}}
-{{- $flags := fromJson (include "rpk-flags" .) -}}
-{{ join " " (list $flags.brokers $flags.kafka)}}
-{{- end -}}
-
-{{- define "rpk-common-flags-no-sasl" -}}
+{{- define "rpk-flags-no-sasl" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
 {{ join " " (list $flags.brokers $flags.admin $flags.kafka)}}
 {{- end -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -356,6 +356,11 @@ Generate configuration needed for rpk
 {{ join " " (list $flags.brokers $flags.admin $flags.kafka)}}
 {{- end -}}
 
+{{- define "rpk-flags-no-admin-no-sasl" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ join " " (list $flags.brokers $flags.kafka)}}
+{{- end -}}
+
 {{- define "rpk-dummy-sasl" -}}
 {{- if (include "sasl-enabled" . | fromJson).bool -}}
 {{ "--user <admin-user-in-secret> --password <admin-password-in-secret> --sasl-mechanism <mechanism-in-secret>" -}}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -109,9 +109,9 @@ spec:
 
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
           {{- if not (empty .Values.license_secret_ref) }}
-            rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-common-flags" $ }}
+            rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-common-flags-no-sasl" $ }}
           {{- else if not (empty .Values.license_key) }}
-            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-common-flags" $ }}
+            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-common-flags-no-sasl" $ }}
           {{- end }}
         {{- end }}
         {{- with .Values.post_install_job.resources }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -89,7 +89,7 @@ spec:
               fi
               echo "Creating user ${USER_NAME}..."
               MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
-              creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-common-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+              creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
               if [[ $creation_result_exit_code -ne 0 ]]; then
               # Check if the stderr contains "User already exists"
                 if [[ $creation_result == *"User already exists"* ]]; then
@@ -109,9 +109,9 @@ spec:
 
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
           {{- if not (empty .Values.license_secret_ref) }}
-            rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-common-flags-no-sasl" $ }}
+            rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-flags-no-sasl" $ }}
           {{- else if not (empty .Values.license_key) }}
-            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-common-flags-no-sasl" $ }}
+            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-flags-no-sasl" $ }}
           {{- end }}
         {{- end }}
         {{- with .Values.post_install_job.resources }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -83,16 +83,21 @@ spec:
             USERS_FILE=$(find /etc/secrets/users/* -print)
             while read p; do
               IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+              # Do not process empty lines
+              if [ -z "$USER_NAME" ]; then
+                continue
+              fi
               echo "Creating user ${USER_NAME}..."
               MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
               creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-common-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
               if [[ $creation_result_exit_code -ne 0 ]]; then
               # Check if the stderr contains "User already exists"
                 if [[ $creation_result == *"User already exists"* ]]; then
+                  # TODO: change user password instead in the future when api enables this.
                   echo "the user ${USER_NAME} already exists, skipping creation."
                 else
                   # Another error occurred, so output the original message and exit code
-                  echo "error creating user ${USER_NAME}: ${creation_result}"  ${USER_NAME}
+                  echo "error creating user ${USER_NAME}: ${creation_result}"
                   exit $creation_result_exit_code
                 fi
               # On a success, the user was created so output that

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -79,7 +79,7 @@ spec:
         args:
           - |
             set -e
-        {{- if $sasl.enabled }}
+        {{- if and $sasl.enabled (not (empty $sasl.secretRef ))  }}
             USERS_FILE=$(find /etc/secrets/users/* -print)
             while read p; do
               IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
@@ -130,7 +130,7 @@ spec:
             mountPath: {{ printf "/etc/tls/certs/%s" $name }}
           {{- end }}
         {{- end }}
-          {{- if $sasl.enabled }}
+          {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
           - name: {{ $sasl.secretRef }}
             mountPath: "/etc/secrets/users"
             readOnly: true
@@ -158,7 +158,7 @@ spec:
             secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
         {{- end }}
       {{- end -}}
-      {{- if $sasl.enabled }}
+      {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
         - name: {{ $sasl.secretRef }}
           secret:
             secretName: {{ $sasl.secretRef }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.post_install_job.enabled }}
+{{- $values := .Values }}
+{{- $sasl := $values.auth.sasl }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -73,42 +75,40 @@ spec:
                 name: {{ .Values.license_secret_ref.secret_name }}
                 key: {{ .Values.license_secret_ref.secret_key }}
         {{- end }}
-        command:
-            - bash
-            - -c
+        command: ["bash","-c"]
         args:
           - |
             set -e
-{{- if .Values.auth.sasl.enabled }}
-  {{- $values := .Values }}
-  {{- range $user := .Values.auth.sasl.users }}
-            # To avoid `set -e` from exiting the command when a user exists; catch the stderr output and exit codes into `creation_result`
-            # and `creation_result_exit_code` for use later
-            creation_result=$(rpk acl user create {{ $user.name }} -p {{ $user.password | quote }} --mechanism {{ include "sasl-user-mechanism" (dict "user" $user "Values" $values) }} {{ template "rpk-common-flags" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?
-
-            # On a non-success exit code
-            if [[ $creation_result_exit_code -ne 0 ]]; then
+        {{- if $sasl.enabled }}
+            USERS_FILE=$(find /etc/secrets/users/* -print)
+            while read p; do
+              IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+              echo "Creating user ${USER_NAME}..."
+              MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
+              creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-common-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+              if [[ $creation_result_exit_code -ne 0 ]]; then
               # Check if the stderr contains "User already exists"
-              if [[ $creation_result == *"User already exists"* ]]; then
-                printf "The %s user already exists, skipping creation.\n" {{ $user.name }}
+                if [[ $creation_result == *"User already exists"* ]]; then
+                  echo "the user ${USER_NAME} already exists, skipping creation."
+                else
+                  # Another error occurred, so output the original message and exit code
+                  echo "error creating user ${USER_NAME}: ${creation_result}"  ${USER_NAME}
+                  exit $creation_result_exit_code
+                fi
+              # On a success, the user was created so output that
               else
-                # Another error occurred, so output the original message and exit code
-                echo "$creation_result"
-                exit $creation_result_exit_code
+                echo "Created user ${USER_NAME}."
               fi
-            # On a success, the user was created so output that
-            else
-              printf "Created user %s.\n" {{ $user.name }}
-            fi
-  {{- end }}
-{{- end }}
-{{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
-  {{- if not (empty .Values.license_secret_ref) }}
+            done < $USERS_FILE
+        {{- end }}
+
+        {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
+          {{- if not (empty .Values.license_secret_ref) }}
             rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-common-flags" $ }}
-  {{- else if not (empty .Values.license_key) }}
+          {{- else if not (empty .Values.license_key) }}
             rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-common-flags" $ }}
-  {{- end }}
-{{- end }}
+          {{- end }}
+        {{- end }}
         {{- with .Values.post_install_job.resources }}
         resources:
           {{- toYaml . | nindent 10 }}
@@ -119,20 +119,25 @@ spec:
             mountPath: /tmp/base-config
           - name: config
             mountPath: /etc/redpanda
-{{- if (include "tls-enabled" . | fromJson).bool }}
-  {{- range $name, $cert := .Values.tls.certs }}
+        {{- if (include "tls-enabled" . | fromJson).bool }}
+          {{- range $name, $cert := .Values.tls.certs }}
           - name: redpanda-{{ $name }}-cert
             mountPath: {{ printf "/etc/tls/certs/%s" $name }}
-  {{- end }}
-{{- end }}
+          {{- end }}
+        {{- end }}
+          {{- if $sasl.enabled }}
+          - name: {{ $sasl.secretRef }}
+            mountPath: "/etc/secrets/users"
+            readOnly: true
+          {{- end}}
       volumes:
         - name: {{ template "redpanda.fullname" . }}
           configMap:
             name: {{ template "redpanda.fullname" . }}
         - name: config
           emptyDir: {}
-{{- if (include "tls-enabled" . | fromJson).bool }}
-  {{- range $name, $cert := .Values.tls.certs }}
+      {{- if (include "tls-enabled" . | fromJson).bool }}
+        {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert
           secret:
             defaultMode: 420
@@ -141,11 +146,17 @@ spec:
               path: tls.key
             - key: tls.crt
               path: tls.crt
-    {{- if $cert.caEnabled }}
+          {{- if $cert.caEnabled }}
             - key: ca.crt
               path: ca.crt
-    {{- end }}
+          {{- end }}
             secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
-  {{- end }}
-{{- end -}}
+        {{- end }}
+      {{- end -}}
+      {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          secret:
+            secretName: {{ $sasl.secretRef }}
+            optional: false
+      {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.post_upgrade_job.enabled }}
 {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
-{{- $rpkFlags := include "rpk-common-flags" . }}
+{{- $rpkFlags := include "rpk-common-flags-no-sasl" . }}
 {{- $sasl := .Values.auth.sasl }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.post_upgrade_job.enabled }}
 {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
-{{- $rpkFlags := include "rpk-common-flags-no-sasl" . }}
+{{- $rpkFlags := include "rpk-flags-no-sasl" . }}
 {{- $sasl := .Values.auth.sasl }}
 apiVersion: batch/v1
 kind: Job

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.post_upgrade_job.enabled }}
 {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
 {{- $rpkFlags := include "rpk-common-flags" . }}
+{{- $sasl := .Values.auth.sasl }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -83,6 +84,11 @@ spec:
             mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
+          {{- if $sasl.enabled }}
+          - name: {{ $sasl.secretRef }}
+            mountPath: "/etc/secrets/users"
+            readOnly: true
+          {{- end}}
       volumes:
         - name: {{ template "redpanda.fullname" . }}
           configMap:
@@ -106,5 +112,11 @@ spec:
             secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
 {{- end -}}
+        {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          secret:
+            secretName: {{ $sasl.secretRef }}
+            optional: false
+        {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -84,7 +84,7 @@ spec:
             mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
-          {{- if $sasl.enabled }}
+          {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
           - name: {{ $sasl.secretRef }}
             mountPath: "/etc/secrets/users"
             readOnly: true
@@ -112,7 +112,7 @@ spec:
             secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
 {{- end -}}
-        {{- if $sasl.enabled }}
+        {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
         - name: {{ $sasl.secretRef }}
           secret:
             secretName: {{ $sasl.secretRef }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -102,7 +102,11 @@ type: Opaque
 stringData:
   users.txt: |-
   {{- range $user := .Values.auth.sasl.users }}
+    {{- if not (empty $user.mechanism) }}
     {{ printf "%s:%s:%s" $user.name $user.password $user.mechanism }}
+    {{- else }}
+    {{ printf "%s:%s" $user.name $user.password}}
+    {{- end }}
   {{- end }}
     # intentional empty line
 {{- end }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -92,7 +92,7 @@ stringData:
         sleep 0.5
     done
 {{- end }}
-{{- if and (not (empty .Values.auth.sasl.secretRef ) ) (and .Values.auth.sasl.enabled ( gt ( len .Values.auth.sasl.users ) 0 ) ) }}
+{{- if and (not (empty .Values.auth.sasl.secretRef)) (and .Values.auth.sasl.enabled .Values.auth.sasl.users) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -92,12 +92,19 @@ stringData:
         sleep 0.5
     done
 {{- end }}
-{{- if and .Values.auth.sasl.enabled ( gt ( len .Values.auth.sasl.users ) 0 ) }}
+{{- if and (not (empty .Values.auth.sasl.secretRef ) ) (and .Values.auth.sasl.enabled ( gt ( len .Values.auth.sasl.users ) 0 ) ) }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.auth.sasl.secretRef | quote }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    helm.sh/chart: {{ template "redpanda.chart" . }}
+    app.kubernetes.io/name: {{ template "redpanda.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/component: {{ template "redpanda.name" . }}
 type: Opaque
 stringData:
   users.txt: |-

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -20,6 +20,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "redpanda.fullname" . }}-sts-lifecycle
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     helm.sh/chart: {{ template "redpanda.chart" . }}
     app.kubernetes.io/name: {{ template "redpanda.name" . }}
@@ -90,4 +91,18 @@ stringData:
         draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
         sleep 0.5
     done
+{{- end }}
+{{- if and .Values.auth.sasl.enabled ( gt ( len .Values.auth.sasl.users ) 0 ) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.auth.sasl.secretRef | quote }}
+type: Opaque
+stringData:
+  users.txt: |-
+  {{- range $user := .Values.auth.sasl.users }}
+    {{ printf "%s:%s:%s" $user.name $user.password $user.mechanism }}
+  {{- end }}
+    # intentional empty line
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+{{- $sasl := .Values.auth.sasl }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -69,6 +70,11 @@ spec:
               mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
+            {{- if $sasl.enabled }}
+            - name: {{ $sasl.secretRef }}
+              mountPath: "/etc/secrets/users"
+              readOnly: true
+            {{- end}}
           resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
       volumes:
         - name: {{ template "redpanda.fullname" . }}
@@ -76,6 +82,12 @@ spec:
             name: {{ template "redpanda.fullname" . }}
         - name: config
           emptyDir: {}
+        {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          secret:
+            secretName: {{ $sasl.secretRef }}
+            optional: false
+        {{- end }}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -58,9 +58,11 @@ spec:
           - -c
           - |
             set -e
+          {{- if and (not $sasl.enabled) (and $sasl.enabled (not (empty $sasl.secretRef ))) }}
             rpk topic create produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
             echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
             rpk topic consume produce.consume.test.$POD_NAME -n 1 {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/redpanda
@@ -70,7 +72,7 @@ spec:
               mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
-            {{- if $sasl.enabled }}
+            {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
             - name: {{ $sasl.secretRef }}
               mountPath: "/etc/secrets/users"
               readOnly: true
@@ -82,7 +84,7 @@ spec:
             name: {{ template "redpanda.fullname" . }}
         - name: config
           emptyDir: {}
-        {{- if $sasl.enabled }}
+        {{- if and $sasl.enabled  (not (empty $sasl.secretRef )) }}
         - name: {{ $sasl.secretRef }}
           secret:
             secretName: {{ $sasl.secretRef }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -18,6 +18,7 @@ limitations under the License.
 {{- $testTopicFlags := mustRegexReplaceAll "--user \\S+ " (include "rpk-topic-flags" . ) "--user myuser" }}
 {{- $testTopicFlags := mustRegexReplaceAll "--password \\S+ " $testTopicFlags "--password changeme" }}
 {{- $rpk := deepCopy . }}
+{{- $sasl := .Values.auth.sasl }}
 {{- $_ := set $rpk "rpk" "rpk" }}
 apiVersion: v1
 kind: Pod
@@ -48,16 +49,17 @@ spec:
       - /bin/bash
       - -c
       - |
+        set -xe
         rpk acl user delete myuser {{ include "rpk-common-flags" . }}
         sleep 3
-        set -e
-        {{ include "rpk-cluster-info" $rpk }}
-        {{ include "rpk-acl-user-create" $rpk }}
-        {{ include "rpk-acl-create" $rpk }}
+
+        {{ include "rpk-cluster-info-no-dummy-sasl" $rpk }}
+        {{ include "rpk-acl-user-create-no-dummy-sasl" $rpk }}
+        {{ include "rpk-acl-create-no-dummy-sasl" $rpk }}
         sleep 3
-        {{ include "rpk-topic-create" $rpk }}
-        {{ include "rpk-topic-describe" $rpk }}
-        {{ include "rpk-topic-delete" $rpk }}
+        {{ include "rpk-topic-create-no-dummy-sasl" $rpk }}
+        {{ include "rpk-topic-describe-no-dummy-sasl" $rpk }}
+        {{ include "rpk-topic-delete-no-dummy-sasl" $rpk }}
         rpk acl user delete myuser {{ include "rpk-common-flags" . }}
       volumeMounts:
         - name: config
@@ -68,6 +70,11 @@ spec:
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
+        {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+        {{- end}}
       resources:
 {{- toYaml .Values.statefulset.resources | nindent 12 }}
   volumes:
@@ -76,6 +83,12 @@ spec:
         name: {{ template "redpanda.fullname" . }}
     - name: config
       emptyDir: {}
+    {{- if $sasl.enabled }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
+    {{- end }}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
     - name: redpanda-{{ $name }}-cert

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -50,6 +50,7 @@ spec:
       - -c
       - |
         set -xe
+      {{- if and (not $sasl.enabled) (and $sasl.enabled (not (empty $sasl.secretRef ))) }}
         rpk acl user delete myuser {{ include "rpk-common-flags" . }}
         sleep 3
 
@@ -61,6 +62,7 @@ spec:
         {{ include "rpk-topic-describe-no-dummy-sasl" $rpk }}
         {{ include "rpk-topic-delete-no-dummy-sasl" $rpk }}
         rpk acl user delete myuser {{ include "rpk-common-flags" . }}
+      {{- end }}
       volumeMounts:
         - name: config
           mountPath: /etc/redpanda
@@ -70,7 +72,7 @@ spec:
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
-        {{- if $sasl.enabled }}
+        {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
         - name: {{ $sasl.secretRef }}
           mountPath: "/etc/secrets/users"
           readOnly: true
@@ -83,7 +85,7 @@ spec:
         name: {{ template "redpanda.fullname" . }}
     - name: config
       emptyDir: {}
-    {{- if $sasl.enabled }}
+    {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
     - name: {{ $sasl.secretRef }}
       secret:
         secretName: {{ $sasl.secretRef }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -92,41 +92,32 @@
           "required": [
             "enabled"
           ],
-          "if": {
-            "properties": {
-              "enabled": {
-                "enum": [
-                  true
-                ]
-              }
-            }
-          },
-          "then": {
-            "required": [
-              "secretRef"
-            ],
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "mechanism": {
-                "type": "string"
-              },
-              "secretRef": {
-                "type": "string"
-              }
-            }
-          },
-          "else": {
-            "properties": {
-              "enabled": {
-                "type": "boolean"
-              },
-              "mechanism": {
-                "type": "string"
-              },
-              "secretRef": {
-                "type": "string"
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "mechanism": {
+              "type": "string"
+            },
+            "secretRef": {
+              "type": "string"
+            },
+            "users": {
+              "type": "array",
+              "minItems": 0,
+              "items": {
+                "properties": {
+                  "name": {
+                    "type": "string"
+                  },
+                  "password": {
+                    "type": "string"
+                  },
+                  "mechanism": {
+                    "type": "string",
+                    "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256)$"
+                  }
+                }
               }
             }
           }

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -90,8 +90,7 @@
         "sasl": {
           "type": "object",
           "required": [
-            "enabled",
-            "users"
+            "enabled"
           ],
           "if": {
             "properties": {
@@ -103,45 +102,18 @@
             }
           },
           "then": {
+            "required": [
+              "secretRef"
+            ],
             "properties": {
               "enabled": {
                 "type": "boolean"
               },
-              "users": {
-                "type": "array",
-                "minItems": 1,
-                "items": {
-                  "properties": {
-                    "name": {
-                      "type": "string"
-                    },
-                    "password": {
-                      "type": "string"
-                    },
-                    "mechanism": {
-                      "type": "string",
-                      "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256)$"
-                    }
-                  },
-                  "oneOf": [
-                    {
-                      "required": [
-                        "name",
-                        "password"
-                      ]
-                    },
-                    {
-                      "required": [
-                        "name",
-                        "secretName"
-                      ]
-                    }
-                  ]
-                }
-              },
               "mechanism": {
-                "type": "string",
-                "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256)$"
+                "type": "string"
+              },
+              "secretRef": {
+                "type": "string"
               }
             }
           },
@@ -149,6 +121,12 @@
             "properties": {
               "enabled": {
                 "type": "boolean"
+              },
+              "mechanism": {
+                "type": "string"
+              },
+              "secretRef": {
+                "type": "string"
               }
             }
           }

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -114,7 +114,7 @@ tls:
 external:
   # Default external access value for each service
   # Services can toggle external access per listener (ie. `listeners.<service name>.external.<listener name>.enabled`)
-  enabled: false
+  enabled: true
   # External access type. `NodePort` is the only acceptable value if defined.
   # If undefined, then advertised listeners will be configured in Redpanda, but the helm chart will not create a Service. You must create a Service manually.
   type: NodePort

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -73,14 +73,21 @@ auth:
     enabled: false
     # if unspecified, mechanism defaults to SCRAM-SHA-512
     mechanism: SCRAM-SHA-512
-    # A secret is expected to exist to contain several files that contain a user in the following format:
-    # <fileName>=<userName>:<password>:<mechanism>
+    # A secret is expected to exist to contain a file with users in the following format:
+    # <userName>:<password>:<mechanism>
     # You can create these users in the following way:
     # create a file with one entry per line in the following format:
     # <username>:<password>:<mechanism>
+    # Ensure there is an empty line at the end of the file.
     # kubectl -n redpanda create secret generic my-users --from-file=users.txt
-    # secret/my-users created
-    secretRef: ""
+    # Then secretRef is required, regardless if created a users list (below) or not
+    secretRef: "redpanda-users"
+    # optional list of users
+    # If not an empty list, these users will be created in a secret whose name is defined in "secretRef"
+    users:
+    - name: admin
+      password: change-me
+      mechanism: SCRAM-SHA-512
 
 # TLS configuration
 tls:

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -65,27 +65,23 @@ rackAwareness:
   # this if you have your own custom Node annotation to use instead.
   nodeAnnotation: topology.kubernetes.io/zone
 
-#
 # Authentication
 auth:
-  #
   # SASL configuration
   sasl:
+    # When enabling SASL, you are required to have a secret available and referenced in secretRef
     enabled: false
-    # user list
-    # TODO create user at startup
-    users:
-      - name: admin
-        # Password for the user. This will be used to generate a secret
-        # password: password
-        # If password isn't given, then the secretName must point to an already existing secret
-        # secretName: adminPassword
-        # if the mecanism is unspecified, it defaults to .Values.auth.sasl.mechanism
-        # mechanism: SCRAM-SHA-512
     # if unspecified, mechanism defaults to SCRAM-SHA-512
-    # mechanism: SCRAM-SHA-512
+    mechanism: SCRAM-SHA-512
+    # A secret is expected to exist to contain several files that contain a user in the following format:
+    # <fileName>=<userName>:<password>:<mechanism>
+    # You can create these users in the following way:
+    # create a file with one entry per line in the following format:
+    # <username>:<password>:<mechanism>
+    # kubectl -n redpanda create secret generic my-users --from-file=users.txt
+    # secret/my-users created
+    secretRef: ""
 
-#
 # TLS configuration
 tls:
   # Enable global TLS, which turns on TLS by default for all listeners
@@ -111,7 +107,7 @@ tls:
 external:
   # Default external access value for each service
   # Services can toggle external access per listener (ie. `listeners.<service name>.external.<listener name>.enabled`)
-  enabled: true
+  enabled: false
   # External access type. `NodePort` is the only acceptable value if defined.
   # If undefined, then advertised listeners will be configured in Redpanda, but the helm chart will not create a Service. You must create a Service manually.
   type: NodePort


### PR DESCRIPTION
Note: This is a breaking change.

Tested this with the following values file:


```
auth:
  sasl:
    enabled: true
    secretRef: "redpanda-users"
    users:
    - name: admin
       password: change-me
       mechanism: SCRAM-SHA-512
    - name: user1
       password: change-me-2
       mechanism: SCRAM-SHA-512
    - name: user2
       password: change-me-3
       mechanism: SCRAM-SHA-512
```

and created the appropriate secret. The users were created, you can and should probably use the wait flag:

```
helm install ... --wait
```
The flag waits for the brokers to be up and running, otherwise you will have post-install jobs running. The response 

```
Creating user "admin"...
Created user "admin".
Creating user "user1"...
Created user "user1".
Creating user "user2"...
Created user "user2".
```

and the pods volumes that were added:

```
    Type:        Secret (a volume populated by a Secret)
    SecretName:  panda-users
    Optional:    false
 ```

I also included some nits and a few improvements for ease of error solving.

Fixes: #227 

Part of #203 