### PR TITLE
redpanda: default to putting redpanda on separate nodes

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.0
+version: 2.6.1
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -479,7 +479,7 @@ statefulset:
     topologyKey: kubernetes.io/hostname
     # Type of anti-affinity rules: either `soft`, `hard` or empty value (which
     # disables anti-affinity rules).
-    type: soft
+    type: hard
     # Weight for `soft` anti-affinity rules.
     # Does not apply for other anti-affinity types.
     weight: 100


### PR DESCRIPTION
Set the default anti-affinity rule to prevent broker pods from being created on the same Node.