### PR TITLE
configure tls for multiple listeners

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.6
+version: 2.7.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/ci/07-multiple-listeners.yaml
+++ b/charts/redpanda/ci/07-multiple-listeners.yaml
@@ -1,0 +1,60 @@
+tls:
+  certs:
+    cert2:
+      caEnabled: false
+listeners:
+  kafka:
+    tls:
+      enabled: false
+    external:
+      ext2:
+        port: 19094
+        advertisedPorts:
+          - 31292
+        tls:
+          enabled: true
+      ext3:
+        port: 29094
+        advertisedPorts:
+          - 31392
+        tls:
+          enabled: true
+          cert: cert2
+          requireClientAuth: true
+  schemaRegistry:
+    tls:
+      enabled: false
+    external:
+      ext2:
+        port: 18081
+        advertisedPorts:
+          - 30181
+        tls:
+          enabled: true
+      ext3:
+        port: 28081
+        advertisedPorts:
+          - 30281
+        tls:
+          enabled: true
+          cert: cert2
+          requireClientAuth: true
+  http:
+    tls:
+      enabled: false
+    external:
+      ext2:
+        port: 18083
+        advertisedPorts:
+          - 30183
+        tls:
+          enabled: true
+      ext3:
+        port: 28083
+        advertisedPorts:
+          - 30283
+        tls:
+          enabled: true
+          cert: cert2
+          requireClientAuth: true
+

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -219,7 +219,14 @@ data:
   {{- range $name, $listener := $service.external }}
         - name: {{ $name }}
           address: 0.0.0.0
-          port: {{ $listener.port }}
+          {{- /*
+            when upgrading from an older version that had a missing port, fail if we cannot guess a default
+            this should work in all cases as the older versions would have failed with multiple listeners anyway
+          */}}
+          {{- if and (empty $listener.port) (ne (len $service.external) 1) }}
+            {{- fail "missing required port for schemaRegistry listener $listener.name" }}
+          {{- end }}
+          port: {{ $listener.port | default 8084 }}
   {{- end }}
       schema_registry_api_tls:
   {{- if (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool }}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{/*
+{{- /*
 Licensed to the Apache Software Foundation (ASF) under one or more
 contributor license agreements.  See the NOTICE file distributed with
 this work for additional information regarding copyright ownership.
@@ -95,59 +95,105 @@ data:
       {{- with dig "node" dict .Values.config }}
       {{- . | toYaml | nindent 6 }}
       {{- end }}
+{{- /* LISTENERS */}}
+{{- /* Admin API */}}
+{{- $service := .Values.listeners.admin }}
       admin:
         name: admin
         address: 0.0.0.0
-        port: {{ .Values.listeners.admin.port }}
+        port: {{ $service.port }}
 {{- if (include "admin-internal-tls-enabled" . | fromJson).bool }}
       admin_api_tls:
-        - name: admin
-          enabled: true
-          cert_file: /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/tls.crt
-          key_file: /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/tls.key
-          truststore_file: /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt
-          require_client_auth: {{ .Values.listeners.admin.tls.requireClientAuth }}
+        name: admin
+        enabled: true
+        cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
+        key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
+        require_client_auth: {{ $service.tls.requireClientAuth }}
+  {{- $cert := get .Values.tls.certs $service.tls.cert }}
+  {{- if empty $cert }}
+    {{- fail (printf "Certificate, '%s', used but not defined")}}
+  {{- end }}
+  {{- if $cert.caEnabled }}
+        truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+  {{- else }}
+        {{- /* This is a required field so we use the default in the redpanda debian container */}}
+        truststore_file: /etc/ssl/certs/ca-certificates.crt
+  {{- end }}
 {{- end }}
+{{- /* Kafka API */}}
+{{- $service = .Values.listeners.kafka }}
       kafka_api:
         - name: internal
           address: 0.0.0.0
-          port: {{ .Values.listeners.kafka.port }}
+          port: {{ $service.port }}
 {{- range $name, $listener := .Values.listeners.kafka.external }}
         - name: {{ $name }}
           address: 0.0.0.0
           port: {{ $listener.port }}
 {{- end }}
       kafka_api_tls:
-{{- $service := .Values.listeners.kafka }}
 {{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
         - name: internal
           enabled: true
           cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
           key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
-          truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
           require_client_auth: {{ $service.tls.requireClientAuth }}
+  {{- $cert := get .Values.tls.certs $service.tls.cert }}
+  {{- if empty $cert }}
+    {{- fail (printf "Certificate, '%s', used but not defined")}}
+  {{- end }}
+  {{- if $cert.caEnabled }}
+          truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+  {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+  {{- end }}
 {{- end }}
 {{- range $name, $listener := $service.external }}
   {{- $k := dict "Values" $values "listener" $listener }}
   {{- if (include "kafka-external-tls-enabled" $k | fromJson).bool }}
+    {{- $mtls := dig "tls" "requireClientAuth" false $listener }}
+    {{- $mtls = dig "tls" "requireClientAuth" $mtls $k }}
+    {{- $certName := include "kafka-external-tls-cert" $k }}
+    {{- $certPath := printf "/etc/tls/certs/%s" $certName }}
+    {{- $cert := get $values.tls.certs $certName }}
+    {{- if empty $cert }}
+      {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- end }}
         - name: {{ $name }}
           enabled: true
-          cert_file: /etc/tls/certs/{{ template "kafka-external-tls-cert" $k}}/tls.crt
-          key_file: /etc/tls/certs/{{ template "kafka-external-tls-cert" $k}}/tls.key
-          truststore_file: /etc/tls/certs/{{ template "kafka-external-tls-cert" $k}}/ca.crt
-          require_client_auth: {{ dig "tls" "requireClientAuth" false $listener }}
+          cert_file: {{ $certPath }}/tls.crt
+          key_file: {{ $certPath }}/tls.key
+          require_client_auth: {{ $mtls }}
+    {{- if $cert.caEnabled }}
+          truststore_file: {{ $certPath }}/ca.crt
+    {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+    {{- end }}
   {{- end }}
 {{- end }}
+{{- /* RPC Server */}}
+{{- $service = .Values.listeners.rpc }}
       rpc_server:
         address: 0.0.0.0
-        port: {{ .Values.listeners.rpc.port }}
+        port: {{ $service.port }}
 {{- if (include "rpc-tls-enabled" . | fromJson).bool }}
       rpc_server_tls:
         enabled: true
-        require_client_auth: {{ .Values.listeners.rpc.tls.requireClientAuth }}
-        cert_file: /etc/tls/certs/{{ .Values.listeners.rpc.tls.cert }}/tls.crt
-        key_file: /etc/tls/certs/{{ .Values.listeners.rpc.tls.cert }}/tls.key
-        truststore_file: /etc/tls/certs/{{ .Values.listeners.rpc.tls.cert }}/ca.crt
+        cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
+        key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
+        require_client_auth: {{ $service.tls.requireClientAuth }}
+  {{- $cert := get .Values.tls.certs $service.tls.cert }}
+  {{- if empty $cert }}
+    {{- fail (printf "Certificate, '%s', used but not defined")}}
+  {{- end }}
+  {{- if $cert.caEnabled }}
+        truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+  {{- else }}
+        {{- /* This is a required field so we use the default in the redpanda debian container */}}
+        truststore_file: /etc/ssl/certs/ca-certificates.crt
+  {{- end }}
 {{- end }}
       seed_servers:
 {{- range untilStep 0 (.Values.statefulset.replicas|int) 1 }}
@@ -162,70 +208,120 @@ data:
     {{- unset .Values.storage.tieredConfig "cloud_storage_credentials_source" | toYaml | nindent 6 }}
   {{- end }}
 {{- end }}
+{{- /* Schema Registry API */}}
 {{- if .Values.listeners.schemaRegistry.enabled }}
+  {{- $service = .Values.listeners.schemaRegistry }}
     schema_registry:
       schema_registry_api:
         - name: internal
           address: 0.0.0.0
-          port: {{ .Values.listeners.schemaRegistry.port }}
-{{- range $name, $listener := .Values.listeners.schemaRegistry.external }}
+          port: {{ $service.port }}
+  {{- range $name, $listener := $service.external }}
         - name: {{ $name }}
           address: 0.0.0.0
           port: {{ $listener.port }}
-{{- end }}
+  {{- end }}
       schema_registry_api_tls:
   {{- if (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool }}
         - name: internal
           enabled: true
-          cert_file: /etc/tls/certs/{{ .Values.listeners.schemaRegistry.tls.cert }}/tls.crt
-          key_file: /etc/tls/certs/{{ .Values.listeners.schemaRegistry.tls.cert }}/tls.key
-          truststore_file: /etc/tls/certs/{{ .Values.listeners.schemaRegistry.tls.cert }}/ca.crt
-          require_client_auth: {{ .Values.listeners.schemaRegistry.tls.requireClientAuth }}
+          cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
+          key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
+          require_client_auth: {{ $service.tls.requireClientAuth }}
+    {{- $cert := get .Values.tls.certs $service.tls.cert }}
+    {{- if empty $cert }}
+      {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- end }}
+    {{- if $cert.caEnabled }}
+          truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+    {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+    {{- end }}
   {{- end }}
-  {{- range $i, $listener := .Values.listeners.schemaRegistry.external }}
+  {{- range $name, $listener := $service.external }}
     {{- $k := dict "Values" $values "listener" $listener }}
     {{- if (include "schemaRegistry-external-tls-enabled" $k | fromJson).bool }}
-        - name: {{ $listener.name }}
+      {{- $mtls := dig "tls" "requireClientAuth" false $listener }}
+      {{- $mtls = dig "tls" "requireClientAuth" $mtls $k }}
+      {{- $certName := include "schemaRegistry-external-tls-cert" $k }}
+      {{- $certPath := printf "/etc/tls/certs/%s" $certName }}
+      {{- $cert := get $values.tls.certs $certName }}
+      {{- if empty $cert }}
+        {{- fail (printf "Certificate, '%s', used but not defined")}}
+      {{- end }}
+        - name: {{ $name }}
           enabled: true
-          cert_file: /etc/tls/certs/{{ template "schemaRegistry-external-tls-cert" $k }}/tls.crt
-          key_file: /etc/tls/certs/{{ template "schemaRegistry-external-tls-cert" $k }}/tls.key
-          truststore_file: /etc/tls/certs/{{ template "schemaRegistry-external-tls-cert" $k }}/ca.crt
-          require_client_auth: {{ dig "tls" "requireClientAuth" false $listener}}
+          cert_file: {{ $certPath }}/tls.crt
+          key_file: {{ $certPath }}/tls.key
+          require_client_auth: {{ $mtls }}
+      {{- if $cert.caEnabled }}
+          truststore_file: {{ $certPath }}/ca.crt
+      {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
+{{- /* HTTP Proxy */}}
 {{- if .Values.listeners.http.enabled }}
+  {{- $service = .Values.listeners.http }}
     pandaproxy:
       pandaproxy_api:
         - name: internal
           address: 0.0.0.0
-          port: {{ .Values.listeners.http.port }}
-  {{- range $name, $listener := .Values.listeners.http.external }}
+          port: {{ $service.port }}
+  {{- range $name, $listener := $service.external }}
         - name: {{ $name }}
           address: 0.0.0.0
           port: {{ $listener.port }}
   {{- end }}
       pandaproxy_api_tls:
   {{- if (include "http-internal-tls-enabled" . | fromJson).bool }}
-          - name: internal
-            enabled: true
-            cert_file: /etc/tls/certs/{{ .Values.listeners.http.tls.cert }}/tls.crt
-            key_file: /etc/tls/certs/{{ .Values.listeners.http.tls.cert }}/tls.key
-            truststore_file: /etc/tls/certs/{{ .Values.listeners.http.tls.cert }}/ca.crt
-            require_client_auth: {{ .Values.listeners.http.tls.requireClientAuth }}
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
+          key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
+          require_client_auth: {{ $service.tls.requireClientAuth }}
+    {{- $cert := get .Values.tls.certs $service.tls.cert }}
+    {{- if empty $cert }}
+      {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- end }}
+    {{- if $cert.caEnabled }}
+          truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+    {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+    {{- end }}
   {{- end }}
-  {{- range $name, $listener := .Values.listeners.http.external }}
+  {{- range $name, $listener := $service.external }}
     {{- $k := dict "Values" $values "listener" $listener }}
     {{- if (include "http-external-tls-enabled" $k | fromJson).bool }}
-          - name: {{ $name }}
-            enabled: true
-            cert_file: /etc/tls/certs/{{ template "kafka-external-tls-cert" $k }}/tls.crt
-            key_file: /etc/tls/certs/{{ template "kafka-external-tls-cert" $k }}/tls.key
-            truststore_file: /etc/tls/certs/{{ template "kafka-external-tls-cert" $k}}/ca.crt
-            require_client_auth: {{ dig "tls" "requireClientAuth" false $listener }}
+      {{- $mtls := dig "tls" "requireClientAuth" false $listener }}
+      {{- $mtls = dig "tls" "requireClientAuth" $mtls $k }}
+      {{- $certName := include "http-external-tls-cert" $k }}
+      {{- $certPath := printf "/etc/tls/certs/%s" $certName }}
+      {{- $cert := get $values.tls.certs $certName }}
+      {{- if empty $cert }}
+        {{- fail (printf "Certificate, '%s', used but not defined")}}
+      {{- end }}
+        - name: {{ $name }}
+          enabled: true
+          cert_file: {{ $certPath }}/tls.crt
+          key_file: {{ $certPath }}/tls.key
+          require_client_auth: {{ $mtls }}
+      {{- if $cert.caEnabled }}
+          truststore_file: {{ $certPath }}/ca.crt
+      {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
+{{- /* END LISTENERS */}}
+
     rpk:
       enable_usage_stats: {{ .Values.logging.usageStats.enabled }}
       overprovisioned: {{ dig "cpu" "overprovisioned" false .Values.resources }}

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -68,7 +68,7 @@ spec:
   {{- if $enabled }}
     - name: schema-{{ $name }}
       protocol: TCP
-      port: {{ $values.listeners.schemaRegistry.port }}
+      port: {{ dig "port" $values.listeners.schemaRegistry.port $listener }}
       nodePort: {{ dig "nodePort" (first (dig "advertisedPorts" (list $values.listeners.schemaRegistry.port) $listener)) $listener }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
+{{- if and (include "kafka-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -44,18 +44,32 @@ spec:
       - /bin/bash
       - -c
       - >
+  {{- $service := .Values.listeners.kafka -}}
+  {{- $cert := get .Values.tls.certs $service.tls.cert }}
+  {{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
         rpk cluster info
         --brokers {{ include "redpanda.fullname" .}}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.kafka.port }}
-        --tls-enabled --tls-truststore /etc/tls/certs/{{ .Values.listeners.kafka.tls.cert }}/ca.crt
+        --tls-enabled
+    {{- if $cert.caEnabled }}
+        --tls-truststore /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+    {{- else }}
+        {{- /* This is a required field so we use the default in the redpanda debian container */}}
+        --tls-truststore /etc/ssl/certs/ca-certificates.crt
+    {{- end }}
+  {{- end }}
+      resources:
+{{- toYaml .Values.statefulset.resources | nindent 12 }}
       volumeMounts:
+        - name: {{ template "redpanda.fullname" . }}
+          mountPath: /tmp/base-config
         - name: config
           mountPath: /etc/redpanda
+{{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
-      resources:
-{{- toYaml .Values.statefulset.resources | nindent 12 }}
+{{- end }}
   volumes:
     - name: {{ template "redpanda.fullname" . }}
       configMap:

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -14,7 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
+{{- if and (include "http-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
+{{- $service := .Values.listeners.http -}}
+{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -44,8 +46,10 @@ spec:
         - curl
         - -svm3
         - --ssl-reqd
+  {{- if $cert.caEnabled }}
         - --cacert
-        - /etc/tls/certs/{{ .Values.listeners.admin.tls.cert }}/ca.crt
+        - /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+  {{- end }}
         - https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.http.port }}/brokers
       volumeMounts:
         - name: config

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -14,7 +14,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "tls-enabled" . | fromJson).bool (not (include "sasl-enabled" .|fromJson).bool) }}
+{{- if and (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" .|fromJson).bool) }}
+{{- $service := .Values.listeners.schemaRegistry -}}
+{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -44,8 +46,10 @@ spec:
         - curl
         - -svm3
         - --ssl-reqd
+  {{- if $cert.caEnabled }}
         - --cacert
-        - /etc/tls/certs/{{ .Values.listeners.schemaRegistry.tls.cert }}/ca.crt
+        - /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+  {{- end }}
         - https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
       volumeMounts:
         - name: config

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -645,6 +645,7 @@ listeners:
     external:
       default:
         # enabled: true
+        port: 8084
         advertisedPorts:
         - 30081
 


### PR DESCRIPTION
This allows separate tls config for external listeners. This also fixes the ability for the ca file to be disabled, as would be appropriate for not-self-signed certificates.

These values:
```
tls:
  certs:
    cert2:
      caEnabled: false
listeners:
  kafka:
    tls:
      enabled: false
    external:
      ext2:
        port: 19094
        advertisedPorts:
          - 31292
        tls:
          enabled: true
      ext3:
        port: 29094
        advertisedPorts:
          - 31392
        tls:
          enabled: true
          cert: cert2
          requireClientAuth: true
```
will produce this in the redpanda.yaml ConfigMap:
```
      kafka_api:
        - name: internal
          address: 0.0.0.0
          port: 9093
        - name: default
          address: 0.0.0.0
          port: 9094
        - name: ext2
          address: 0.0.0.0
          port: 19094
        - name: ext3
          address: 0.0.0.0
          port: 29094
      kafka_api_tls:
        - name: ext2
          enabled: true
          cert_file: /etc/tls/certs/default/tls.crt
          key_file: /etc/tls/certs/default}}/tls.key
          require_client_auth: false
          truststore_file: /etc/tls/certs/default}}/ca.crt
        - name: ext3
          enabled: true
          cert_file: /etc/tls/certs/cert2/tls.crt
          key_file: /etc/tls/certs/cert2}}/tls.key
          require_client_auth: true
```

Fixes #276 