### PR TITLE
redpanda: fix lifecycle hooks

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.2
+version: 2.6.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -407,9 +407,9 @@ runAsUser: {{ dig "podSecurityContext" "runAsUser" .Values.statefulset.securityC
 runAsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
 {{- end -}}
 
-{{- define "tls-curl-flags" -}}
+{{- define "admin-tls-curl-flags" -}}
   {{- $result := "" -}}
-  {{- if (include "tls-enabled" . | fromJson).bool -}}
+  {{- if (include "admin-internal-tls-enabled" . | fromJson).bool -}}
     {{- $path := (printf "/etc/tls/certs/%s" .Values.listeners.admin.tls.cert) -}}
     {{- $result = (printf "--cacert %s/tls.crt" $path) -}}
     {{- if .Values.listeners.admin.tls.requireClientAuth -}}
@@ -419,9 +419,9 @@ runAsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityCo
   {{- $result -}}
 {{- end -}}
 
-{{- define "http-protocol" -}}
+{{- define "admin-http-protocol" -}}
   {{- $result := "http" -}}
-  {{- if (include "tls-enabled" . | fromJson).bool -}}
+  {{- if (include "admin-internal-tls-enabled" . | fromJson).bool -}}
     {{- $result = "https" -}}
   {{- end -}}
   {{- $result -}}

--- a/charts/redpanda/templates/secret.yaml
+++ b/charts/redpanda/templates/secret.yaml
@@ -16,14 +16,14 @@ stringData:
     #!/usr/bin/env bash
 
     # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
-    CURL_URL="{{ (include "http-protocol" . ) }}://${SERVICE_NAME}.{{ template "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.listeners.admin.port }}"
+    CURL_URL="{{ include "admin-http-protocol" . }}://${SERVICE_NAME}.{{ template "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.listeners.admin.port }}"
 
     # commands used throughout
-    CURL_NODE_ID_CMD="curl --silent --fail {{ (include "tls-curl-flags" . ) }} ${CURL_URL}/v1/node_config"
+    CURL_NODE_ID_CMD="curl --silent --fail {{ include "admin-tls-curl-flags" . }} ${CURL_URL}/v1/node_config"
 
-    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'  
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
     CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
-    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent {{ (include "tls-curl-flags" . ) }} ${CURL_URL}/v1/maintenance"    
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent {{ include "admin-tls-curl-flags" . }} ${CURL_URL}/v1/maintenance"
 
   postStart.sh: |-
     #!/usr/bin/env bash
@@ -33,14 +33,14 @@ stringData:
     # path below should match the path defined on the statefulset
     source /var/lifecycle/common.sh
 
-    set -e
-    
+    set -ex
+
     until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
         sleep 0.5
     done
-    
+
     echo "Clearing maintenance mode on node ${NODE_ID}"
-    CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} {{ (include "tls-curl-flags" . ) }} ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+    CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} {{ include "admin-tls-curl-flags" . }} ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
     # a 400 here would mean not in maintenance mode
     until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
         status=$(${CURL_MAINTENANCE_DELETE_CMD})
@@ -51,23 +51,23 @@ stringData:
     #!/usr/bin/env bash
     # This code should be similar if not exactly the same as that found in the panda-operator, see
     # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
-    
+
     # path below should match the path defined on the statefulset
     source /var/lifecycle/common.sh
 
-    set -e
+    set -ex
 
     until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
         sleep 0.5
     done
-    
-    echo "Setting maintenance mode on node ${NODE_ID}"    
-    CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} {{ (include "tls-curl-flags" . ) }} ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+
+    echo "Setting maintenance mode on node ${NODE_ID}"
+    CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} {{ include "admin-tls-curl-flags" . }} ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
     until [ "${status:-}" = '"200"' ]; do
         status=$(${CURL_MAINTENANCE_PUT_CMD})
         sleep 0.5
     done
-    
+
     until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
         res=$(${CURL_MAINTENANCE_GET_CMD})
         finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')


### PR DESCRIPTION
only use tls if the admin internal port uses it