### PR TITLE
fix: allow jobs and sts to have the same tolerations and nodeselectors

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.5
+version: 2.6.6
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/_statefulset-helpers.tpl
+++ b/charts/redpanda/templates/_statefulset-helpers.tpl
@@ -1,0 +1,38 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Set tolerations for statefulset, defaults to global tolerations if not defined in statefulset
+*/}}
+{{- define "statefulset-tolerations" -}}
+{{- $tolerations := .Values.tolerations -}}
+{{- if not ( empty .Values.statefulset.tolerations ) -}}
+{{- $tolerations = .Values.statefulset.tolerations -}}
+{{- end -}}
+{{- toYaml $tolerations -}}
+{{- end -}}
+
+{{/*
+Set nodeSelector for statefulset, defaults to global nodeSelector if not defined in statefulset
+*/}}
+{{- define "statefulset-nodeSelectors" -}}
+{{- $nodeSelectors := .Values.nodeSelector -}}
+{{- if not ( empty .Values.statefulset.nodeSelector ) -}}
+{{- $nodeSelectors = .Values.statefulset.nodeSelector -}}
+{{- end -}}
+{{- toYaml $nodeSelectors -}}
+{{- end -}}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -54,6 +54,12 @@ spec:
   {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+    {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
       containers:

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -38,6 +38,12 @@ spec:
   {{- toYaml . | nindent 8 }}
 {{- end }}
     spec:
+    {{- with .Values.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+    {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
       containers:

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -1,3 +1,19 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
 {{- if gt ( .Values.statefulset.replicas | int64 ) 2 }}
 ---
 apiVersion: v1

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -409,14 +409,14 @@ spec:
         whenUnsatisfiable: {{ .whenUnsatisfiable }}
   {{- end }}
 {{- end }}
-{{- with .Values.statefulset.nodeSelector }}
-      nodeSelector: {{- toYaml . | nindent 8 }}
+{{- with ( include "statefulset-nodeSelectors" . ) }}
+      nodeSelector: {{- . | nindent 8 }}
 {{- end }}
 {{- if .Values.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.statefulset.priorityClassName }}
 {{- end }}
-{{- with .Values.statefulset.tolerations }}
-      tolerations: {{- toYaml . | nindent 8 }}
+{{- with ( include "statefulset-tolerations" . ) }}
+      tolerations: {{- . | nindent 8 }}
 {{- end }}
 {{- if or .Values.storage.persistentVolume.enabled (and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled .Values.storage.tieredStoragePersistentVolume.enabled) }}
   volumeClaimTemplates:

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -5,6 +5,24 @@
     "image"
   ],
   "properties": {
+    "nameOverride": {
+      "type": "string"
+    },
+    "fullnameOverride": {
+      "type": "string"
+    },
+    "clusterDomain": {
+      "type": "string"
+    },
+    "commonLabels": {
+      "type": "object"
+    },
+    "nodeSelector": {
+      "type": "object"
+    },
+    "tolerations": {
+      "type": "array"
+    },
     "image": {
       "description": "Values used to define the container image to be used for Redpanda",
       "type": "object",

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -33,6 +33,13 @@ clusterDomain: cluster.local
 # Additional labels added to all Kubernetes objects
 commonLabels: {}
 
+# Global node selection constraints for scheduling Pods, can override this for statefulsets.
+# https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
+nodeSelector: {}
+# Global taints to be tolerated by Pods, can override this for statefulsets.
+# https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
+
 # Redpanda parameters
 #
 image:
@@ -484,12 +491,14 @@ statefulset:
     # Does not apply for other anti-affinity types.
     weight: 100
   # Node selection constraints for scheduling Pods of this StatefulSet.
+  # these override the global nodeSelector value
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
   nodeSelector: {}
   # PriorityClassName given to Pods of this StatefulSet
   # https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass
   priorityClassName: ""
   # Taints to be tolerated by Pods of this StatefulSet.
+  # these override the global tolerations value
   # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
   tolerations: []
   # https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -33,10 +33,10 @@ clusterDomain: cluster.local
 # Additional labels added to all Kubernetes objects
 commonLabels: {}
 
-# Global node selection constraints for scheduling Pods, can override this for statefulsets.
+# Node selection constraints for scheduling Pods, can override this for statefulsets.
 # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector
 nodeSelector: {}
-# Global taints to be tolerated by Pods, can override this for statefulsets.
+# Taints to be tolerated by Pods, can override this for statefulsets.
 # https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 tolerations: []
 


### PR DESCRIPTION
Tested this locally:

- Creates tolerations and node-selectors for all pods/jobs from a global tolerations and nodeSelectors field.
- Allow for sts to override these values if so needed

Fixes #305 