### PR TITLE
Allow PLAIN authentication for sasl

### DIFF
--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -102,7 +102,7 @@
                     },
                     "mechanism": {
                       "type": "string",
-                      "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256)$"
+                      "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256|PLAIN)$"
                     }
                   },
                   "oneOf": [
@@ -123,7 +123,7 @@
               },
               "mechanism": {
                 "type": "string",
-                "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256)$"
+                "pattern": "^(SCRAM-SHA-512|SCRAM-SHA-256|PLAIN)$"
               }
             }
           },


### PR DESCRIPTION
Currently, SASL PLAIN authentication isn't allowed through the redpanda `values.schema.json` file. This change makes that functionality possible.