### PR TITLE
use pod labels that don't interfere with each other

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.6.4
+version: 2.6.5
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -472,9 +472,9 @@ advertised-host returns a json sring with the data neded for configuring the adv
   {{- $result := list -}}
   {{- $warnings := list "redpanda-memory-warning" -}}
   {{- range $t := $warnings -}}
-    {{- $warning := printf "**Warning**: %s" (include $t $) -}}
+    {{- $warning := include $t $ -}}
       {{- if $warning -}}
-        {{- $result = append $result $warning -}}
+        {{- $result = append $result (printf "**Warning**: %s" $warning) -}}
       {{- end -}}
   {{- end -}}
   {{/* fromJson cannot decode list */}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -466,17 +466,6 @@ advertised-host returns a json sring with the data neded for configuring the adv
 {{- end -}}
 
 {{/*
-Set default path for tiered storage cache or use one provided
-*/}}
-{{- define "tieredStorage.cacheDirectory" -}}
-{{- if empty .Values.storage.tieredConfig.cloud_storage_cache_directory }}
-  {{- printf "/var/lib/redpanda/data/cloud_storage_cache" }}
-{{- else }}
-  {{- .Values.storage.tieredConfig.cloud_storage_cache_directory }}
-{{- end }}
-{{- end }}
-
-{{/*
 "warnings" is an aggregate that returns a list of warnings to be shown in NOTES.txt
 */}}
 {{- define "warnings" -}}

--- a/charts/redpanda/templates/_statefulset.tpl
+++ b/charts/redpanda/templates/_statefulset.tpl
@@ -1,0 +1,36 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "statefulset-pod-labels" -}}
+app.kubernetes.io/name: {{ template "redpanda.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/component: {{ (include "redpanda.name" .) | trunc 51 }}-statefulset
+{{- with .Values.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Set default path for tiered storage cache or use one provided
+*/}}
+{{- define "tieredStorage.cacheDirectory" -}}
+{{- if empty .Values.storage.tieredConfig.cloud_storage_cache_directory -}}
+  {{- printf "/var/lib/redpanda/data/cloud_storage_cache" -}}
+{{- else -}}
+  {{- .Values.storage.tieredConfig.cloud_storage_cache_directory -}}
+{{- end -}}
+{{- end -}}

--- a/charts/redpanda/templates/poddisruptionbudget.yaml
+++ b/charts/redpanda/templates/poddisruptionbudget.yaml
@@ -30,8 +30,13 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "redpanda.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name | quote }}
   maxUnavailable: {{ .Values.statefulset.budget.maxUnavailable | int64 }}
+  selector:
+    matchLabels: {{ (include "statefulset-pod-labels" .) | nindent 6 }}
+{{- $budget := .Values.statefulset.budget.maxUnavailable }}
+{{- /* to maintain quorum, raft cannot lose more than half its members */}}
+{{- $minReplicas := divf .Values.statefulset.replicas 2 | floor }}
+{{- /* the lowest we can go is 1 so allow that always */}}
+{{- if and (gt $budget (float64 1)) (gt $budget $minReplicas) }}
+  {{- fail "statefulset.budget.maxUnavailable is set too high to maintain quorum: $budget > $minReplicas" }}
+{{- end }}

--- a/charts/redpanda/templates/poddisruptionbudget.yaml
+++ b/charts/redpanda/templates/poddisruptionbudget.yaml
@@ -14,29 +14,30 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+{{- $budget := .Values.statefulset.budget.maxUnavailable -}}
+{{- /* to maintain quorum, raft cannot lose more than half its members */ -}}
+{{- $minReplicas := divf .Values.statefulset.replicas 2 | floor -}}
+{{- /* the lowest we can go is 1 so allow that always */ -}}
+{{- if and (gt $budget (float64 1)) (gt $budget $minReplicas) -}}
+  {{ fail "statefulset.budget.maxUnavailable is set too high to maintain quorum: $budget > $minReplicas" }}
+{{- end -}}
 
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "redpanda.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     helm.sh/chart: {{ template "redpanda.chart" . }}
     app.kubernetes.io/name: {{ template "redpanda.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app.kubernetes.io/component: {{ template "redpanda.name" . }}
   {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  maxUnavailable: {{ .Values.statefulset.budget.maxUnavailable | int64 }}
+  maxUnavailable: {{ $budget | int64 }}
   selector:
     matchLabels: {{ (include "statefulset-pod-labels" .) | nindent 6 }}
-{{- $budget := .Values.statefulset.budget.maxUnavailable }}
-{{- /* to maintain quorum, raft cannot lose more than half its members */}}
-{{- $minReplicas := divf .Values.statefulset.replicas 2 | floor }}
-{{- /* the lowest we can go is 1 so allow that always */}}
-{{- if and (gt $budget (float64 1)) (gt $budget $minReplicas) }}
-  {{- fail "statefulset.budget.maxUnavailable is set too high to maintain quorum: $budget > $minReplicas" }}
-{{- end }}
+      redpanda.com/poddisruptionbudget: {{ template "redpanda.name" . }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -49,7 +49,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "redpanda.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        app.kubernetes.io/component: {{ template "redpanda.name" . }}
+        app.kubernetes.io/component: {{ (include "redpanda.name" .) | trunc 50  }}-post-install
 {{- with .Values.commonLabels }}
   {{- toYaml . | nindent 8 }}
 {{- end }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -33,7 +33,7 @@ spec:
       labels:
         app.kubernetes.io/name: {{ template "redpanda.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        app.kubernetes.io/component: {{ template "redpanda.name" . }}
+        app.kubernetes.io/component: {{ (include "redpanda.name" .) | trunc 50  }}-post-upgrade
 {{- with .Values.commonLabels }}
   {{- toYaml . | nindent 8 }}
 {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -322,7 +322,7 @@ spec:
 {{- if gt ( .Values.statefulset.replicas | int64 ) 2 }}
         - name: lifecycle-scripts
           secret:
-            secretName: {{ trunc 50 (include "redpanda.fullname" .) }}-sts-lifecycle
+            secretName: {{ (include "redpanda.fullname" . | trunc 50 ) }}-sts-lifecycle
             defaultMode: 0774
 {{- end }}
         - name: datadir

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -21,6 +21,8 @@ limitations under the License.
 {{- if $values.external.domain -}}
   {{- $externalAdvertiseAddress = printf "$(SERVICE_NAME).%s" $values.external.domain -}}
 {{- end -}}
+{{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset -}}
+{{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -37,9 +39,7 @@ metadata:
 {{- end }}
 spec:
   selector:
-    matchLabels:
-      app.kubernetes.io/name: {{ template "redpanda.name" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
+    matchLabels: {{ (include "statefulset-pod-labels" .) | nindent 6 }}
   serviceName: {{ template "redpanda.fullname" . }}
   replicas: {{ .Values.statefulset.replicas | int64 }}
   updateStrategy:
@@ -47,13 +47,7 @@ spec:
   podManagementPolicy: {{ .Values.statefulset.podManagementPolicy }}
   template:
     metadata:
-      labels:
-        app.kubernetes.io/name: {{ template "redpanda.name" . }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        app.kubernetes.io/component: {{ template "redpanda.name" . }}
-{{- with .Values.commonLabels }}
-        {{- toYaml . | nindent 8 }}
-{{- end }}
+      labels: {{ (include "statefulset-pod-labels" .) | nindent 8 }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- with $.Values.statefulset.annotations }}
@@ -65,8 +59,6 @@ spec:
       initContainers:
         - name: set-datadir-ownership
           image: busybox:latest
-          {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset }}
-          {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
           command: ["/bin/sh", "-c", "chown {{ $uid }}:{{ $gid }} -R /var/lib/redpanda/data"]
           volumeMounts:
             - name: datadir
@@ -74,14 +66,12 @@ spec:
 {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
-          {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset }}
-          {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
           command: ["/bin/sh", "-c", 'chown {{ $uid }}:{{ $gid }} -R {{ template "tieredStorage.cacheDirectory" . }}']
           volumeMounts:
             - name: tiered-storage-dir
               mountPath: {{ template "tieredStorage.cacheDirectory" . }}
 {{- end }}
-        - name: {{ template "redpanda.name" . }}-configurator
+        - name: {{ (include "redpanda.name" .) | trunc 51 }}-configurator
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
           command: ["/bin/bash", "-c"]
           env:
@@ -331,7 +321,7 @@ spec:
 {{- if gt ( .Values.statefulset.replicas | int64 ) 2 }}
         - name: lifecycle-scripts
           secret:
-            secretName: {{ template "redpanda.fullname" . }}-sts-lifecycle
+            secretName: {{ trunc 50 (include "redpanda.fullname" .) }}-sts-lifecycle
             defaultMode: 0774
 {{- end }}
         - name: datadir
@@ -394,18 +384,14 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
               labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: {{ template "redpanda.name" . }}
-                  app.kubernetes.io/instance: {{ .Release.Name | quote }}
+                matchLabels: {{ include "statefulset-pod-labels" . | nindent 18 }}
       {{- else if eq .Values.statefulset.podAntiAffinity.type "soft" }}
           preferredDuringSchedulingIgnoredDuringExecution:
             - weight: {{ .Values.statefulset.podAntiAffinity.weight | int64 }}
               podAffinityTerm:
                 topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
                 labelSelector:
-                  matchLabels:
-                    app.kubernetes.io/name: {{ template "redpanda.name" . }}
-                    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+                  matchLabels: {{ include "statefulset-pod-labels" . | nindent 20 }}
       {{- end }}
     {{- else }}
       {{- toYaml .Values.statefulset.podAntiAffinity | nindent 10 }}
@@ -415,9 +401,7 @@ spec:
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
       topologySpreadConstraints:
       - labelSelector:
-          matchLabels:
-            app.kubernetes.io/name: {{ template "redpanda.name" . }}
-            app.kubernetes.io/instance: {{ .Release.Name | quote }}
+          matchLabels: {{ include "statefulset-pod-labels" . | nindent 12 }}
   {{- with .Values.statefulset.topologySpreadConstraints }}
         maxSkew: {{ .maxSkew }}
         topologyKey: {{ .topologyKey }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -48,6 +48,7 @@ spec:
   template:
     metadata:
       labels: {{ (include "statefulset-pod-labels" .) | nindent 8 }}
+        redpanda.com/poddisruptionbudget: {{ template "redpanda.name" . }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
 {{- with $.Values.statefulset.annotations }}


### PR DESCRIPTION
The same labels were being used for the statefulset pods and the job pods. This was causing them to interfere with the pod anti-affinity and the podDisruptionBudget. This changes the labels so they can be correctly matched.