### PR TITLE
Fix postStart.sh hook with custom Service domain (kubeadm's network.dnsDomain)

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.8.0
+version: 2.8.1
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.10

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -33,7 +33,7 @@ stringData:
     #!/usr/bin/env bash
 
     # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
-    CURL_URL="{{ include "admin-http-protocol" . }}://${SERVICE_NAME}.{{ template "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.listeners.admin.port }}"
+    CURL_URL="{{ include "admin-http-protocol" . }}://${SERVICE_NAME}.{{ template "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | trimSuffix "." }}:{{ .Values.listeners.admin.port }}"
 
     # commands used throughout
     CURL_NODE_ID_CMD="curl --silent --fail {{ include "admin-tls-curl-flags" . }} ${CURL_URL}/v1/node_config"

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -48,7 +48,7 @@ spec:
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
           env:
             - name: REDPANDA_BROKERS
-              value: "{{ include "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.listeners.kafka.port }}"
+              value: "{{ include "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | trimSuffix "." }}:{{ .Values.listeners.kafka.port }}"
             - name: POD_NAME
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
This PR fixes the postStart.sh script when using a custom Kubernetes cluster domain. Specifically, when using Cloud DNS in GKE with VPC scoped domain names as described in issue #313. 