### PR TITLE
fix: error: invalid command 'bdist_wheel'

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -21,7 +21,7 @@ on:
       - "**"
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -39,7 +39,7 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR is meant to reduce the number of "Error:" messages we get in the logs. This usually leads to confusion and searching in the wrong places when diagnosing issues. 