### PR TITLE
chore: bump testing versions to align with current local testing

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
-          version: v3.10.2
+          version: v3.11.1
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.3.1
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.3.0
+        uses: helm/kind-action@v1.4.0
         with:
           config: .github/kind.yaml
         if: steps.list-changed.outputs.changed == 'true'
@@ -78,7 +78,7 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: install cert-manager
-        run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.10.0/cert-manager.yaml
+        run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install and upgrade)


### PR DESCRIPTION
This bumps version of actions and cert-manager used during testing. 