### PR TITLE
feat: allow cpu cores to be fractional whole cores and millicores

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.9.1
+version: 2.10.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.12

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -322,18 +322,19 @@ Returns the value of "resources.cpu.cores" in millicores.
 {{- end -}}
 
 {{/*
-Returns the SMP CPU count in whole cores, and sets "overprovisioned: true" when
-the "resources.cpu.cores" is less than 1 core.
+Returns the SMP CPU count in whole cores, with minimum of 1, and sets
+"resources.cpu.overprovisioned: true" when the "resources.cpu.cores" is less
+than 1 core.
 */}}
 {{- define "redpanda-smp" -}}
   {{- $coresInMillies := include "redpanda-cores-in-millis" . | int -}}
-  {{- if lt $coresInMillies 1000 -}}
-    {{- $_ := set $.Values.resources.cpu "overprovisioned" true -}}
-  {{- end -}}
   {{- if $coresInMillies -}}
-    {{- floor (divf $coresInMillies 1000) | int -}}
-  {{- else -}}
+    {{- if lt $coresInMillies 1000 -}}
+      {{- $_ := set $.Values.resources.cpu "overprovisioned" true -}}
+    {{- end -}}
     {{- int "1" -}}
+  {{- else -}}
+    {{- floor (divf $coresInMillies 1000) | int -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -312,12 +312,12 @@ Returns the value of "resources.cpu.cores" in millicores.
   {{- $cores := .Values.resources.cpu.cores -}}
   {{- if $cores -}}
     {{- if (hasSuffix "m" (toString $cores)) -}}
-      {{- trimSuffix "m" .Values.resources.cpu.cores | int -}}
+      {{- trimSuffix "m" .Values.resources.cpu.cores -}}
     {{- else -}}
-      {{- mulf 1000.0 ($cores | float64) | int -}}
+      {{- mulf 1000.0 ($cores | float64) -}}
     {{- end -}}
   {{- else -}}
-    {{ int "0" }}
+    {{ "0" }}
   {{- end -}}
 {{- end -}}
 
@@ -332,9 +332,9 @@ than 1 core.
     {{- if lt $coresInMillies 1000 -}}
       {{- $_ := set $.Values.resources.cpu "overprovisioned" true -}}
     {{- end -}}
-    {{- int "1" -}}
+    {{- "1" -}}
   {{- else -}}
-    {{- floor (divf $coresInMillies 1000) | int -}}
+    {{- floor (divf $coresInMillies 1000) -}}
   {{- end -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -309,7 +309,7 @@ Generate configuration needed for rpk
 Returns the value of "resources.cpu.cores" in millicores.
 */}}
 {{- define "redpanda-cores-in-millis" -}}
-  {{- $cores := .Values.resources.cpu.cores }}
+  {{- $cores := .Values.resources.cpu.cores -}}
   {{- if $cores -}}
     {{- if (hasSuffix "m" (toString $cores)) -}}
       {{- trimSuffix "m" .Values.resources.cpu.cores | int -}}
@@ -327,7 +327,7 @@ the "resources.cpu.cores" is less than 1 core.
 */}}
 {{- define "redpanda-smp" -}}
   {{- $coresInMillies := include "redpanda-cores-in-millis" . | int -}}
-  {{- if lt $coresInMillies 1000 }}
+  {{- if lt $coresInMillies 1000 -}}
     {{- $_ := set $.Values.resources.cpu "overprovisioned" true -}}
   {{- end -}}
   {{- if $coresInMillies -}}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -268,7 +268,7 @@ spec:
             - rpk
             - redpanda
             - start
-            - --smp={{ .Values.resources.cpu.cores }}
+            - --smp={{ include "redpanda-smp" . }}
             - --memory={{ template "redpanda-memory" . }}M
             - --reserve-memory={{ template "redpanda-reserve-memory" . }}M
             - --default-log-level={{ .Values.logging.logLevel }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -229,7 +229,7 @@
           ],
           "properties": {
             "cores": {
-              "type": "integer"
+              "type": ["integer", "string"]
             },
             "overprovisioned": {
               "type": "boolean"

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -178,6 +178,9 @@ resources:
     # Overprovisioned means Redpanda won't assume it has all of the provisioned CPU.
     # This should be true unless the container has CPU affinity (eg. min and max above are equal).
     # Equivalent to: --idle-poll-time-us 0 --thread-affinity 0 --poll-aio 0
+    #
+    # If the value of full cores in resources.cpu.cores is less than 1, this
+    # will be automatically set to true
     # overprovisioned: false
   #
   memory:


### PR DESCRIPTION
The Redpanda Helm chart is great in doing validations and ensuring sane values are used. The validation of CPU and Memory requests and limits is a wonderful safety net to ensure best experience with Redpanda. However, users should be able to go outside of recommended values.

While there is a way to override the chart's memory minimums, it's not possible to set CPU value to anything below a full core, due to current values schema constraints, and the way cores are passed to the `--smp` CLI flag.

Let's allow advanced users to experiment with Redpanda in K8s as they are able to do when running Docker images on their local workstations.

* updating values schema to allow integers and strings for `resources.cpu.cores`
* adding `redpanda-cores-in-millis` named templates to convert the `resources.cpu.cores` to millicores
* adding `redpanda-smp` named template to calculate the value passed to `--smp` CLI argument, while defaulting to 1, and making sure to automatically set `resources.cpu.overprovisioned: true` when working with less than 1 full core, and round down to number of full cores when working with fractional cores over 1 full core
* adding `redpanda-cpu-warning` named template to warn on lower than recommended value of cores, and adding it to the list of warnings

Related to https://github.com/redpanda-data/redpanda/issues/350.

Perhaps, when working with less than 1 full core the `--smp` flag should not be passed altogether?
Let's me know and I can make that change.