### PR TITLE
Rename post install/upgrade job

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.10.4
+version: 2.10.5
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -21,7 +21,7 @@ limitations under the License.
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "redpanda.fullname" . }}-post-install
+  name: {{ template "redpanda.fullname" . }}-configuration
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{- with include "full.labels" . }}


### PR DESCRIPTION
The post-install suffix is misleading for end user. The job runs not only after install, but after upgrade too. That job can still error out before Admin API is able to serve any request.