### PR TITLE
redpanda: allow the ability to skip the chown initContainer

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.10.1
+version: 2.10.2
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.12

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -53,19 +53,21 @@ spec:
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
       serviceAccountName: {{ include "redpanda.serviceAccountName" . }}
       initContainers:
+{{- if not .Values.statefulset.skipChown }}
         - name: set-datadir-ownership
           image: {{ .Values.statefulset.initContainerImage.repository }}:{{ .Values.statefulset.initContainerImage.tag }}
           command: ["/bin/sh", "-c", "chown {{ $uid }}:{{ $gid }} -R /var/lib/redpanda/data"]
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/redpanda/data
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
+  {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
         - name: set-tiered-storage-cache-dir-ownership
           image: {{ .Values.statefulset.initContainerImage.repository }}:{{ .Values.statefulset.initContainerImage.tag }}
           command: ["/bin/sh", "-c", 'chown {{ $uid }}:{{ $gid }} -R {{ template "tieredStorage.cacheDirectory" . }}']
           volumeMounts:
             - name: tiered-storage-dir
               mountPath: {{ template "tieredStorage.cacheDirectory" . }}
+  {{- end }}
 {{- end }}
         - name: {{ (include "redpanda.name" .) | trunc 51 }}-configurator
           image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -662,6 +662,9 @@
         },
         "initContainer": {
           "type": "string"
+        },
+        "skipChown": {
+          "type": "boolean"
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -530,6 +530,9 @@ statefulset:
   initContainerImage:
     repository: busybox
     tag: latest
+  # in environments where root is not allowed, you cannot change the ownership of files and directories
+  # set this to skip this step
+  skipChown: false
 
 # Service account management
 serviceAccount:


### PR DESCRIPTION
When a user is in an environment that restricts root containers, allow them to skip the chown initContainer as it won't work without being run as root.