### PR TITLE
redpanda: fix console bug where deployment and configmap are erroneously created

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.10.2
+version: 2.10.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.12

--- a/charts/redpanda/templates/certs.yaml
+++ b/charts/redpanda/templates/certs.yaml
@@ -1,3 +1,19 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- $root := deepCopy . }}
   {{- $service := include "redpanda.fullname" . -}}

--- a/charts/redpanda/templates/console/configmap.yaml
+++ b/charts/redpanda/templates/console/configmap.yaml
@@ -1,3 +1,19 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{ $values := .Values }}
 
 {{/* if the console chart has the creation of the configmap disabled, create it here instead */}}

--- a/charts/redpanda/templates/console/configmap.yaml
+++ b/charts/redpanda/templates/console/configmap.yaml
@@ -1,7 +1,7 @@
 {{ $values := .Values }}
 
 {{/* if the console chart has the creation of the configmap disabled, create it here instead */}}
-{{ if not .Values.console.configmap.create }}
+{{ if and .Values.console.enabled (not .Values.console.configmap.create) }}
 {{ $consoleConfigmap := dict "create" true }}
 
 {{/* kafka section */}}

--- a/charts/redpanda/templates/console/deployment.yaml
+++ b/charts/redpanda/templates/console/deployment.yaml
@@ -1,3 +1,19 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{ if and .Values.console.enabled (not .Values.console.deployment.create) }}
 
 {{ $extraVolumes := list }}

--- a/charts/redpanda/templates/console/deployment.yaml
+++ b/charts/redpanda/templates/console/deployment.yaml
@@ -1,4 +1,4 @@
-{{ if (not .Values.console.deployment.create) }}
+{{ if and .Values.console.enabled (not .Values.console.deployment.create) }}
 
 {{ $extraVolumes := list }}
 {{ $extraVolumeMounts := list }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -1,3 +1,19 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
 {{- if .Values.post_upgrade_job.enabled }}
 {{- if (include "redpanda-atleast-22-1-1" . | fromJson).bool }}
 {{- $rpkFlags := include "rpk-flags-no-sasl" . }}


### PR DESCRIPTION
When console.enabled is false, the console deployment and configmap would still be created.