### PR TITLE
Fix release redpanda chart version

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.10.5
+version: 2.10.6
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13


### PR DESCRIPTION
By merging 2 PRs quickly CI can not release second change as the Chart version is the same.

REF:
https://github.com/redpanda-data/helm-charts/pull/345
https://github.com/redpanda-data/helm-charts/pull/272