### PR TITLE
Update link

### DIFF
--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -89,7 +89,7 @@ affinity: {}
 
 console:
   # Config.yaml is required for Console
-  # See reference config: https://github.com/redpanda-data/console/blob/master/docs/config/console.yaml)
+  # See reference config: https://docs.redpanda.com/docs/reference/console/config/)
   config: {}
   # roles:
   # roleBindings:


### PR DESCRIPTION
The previous link goes to a YAML file that is no longer kept up to date. We should link to the public docs page for reference.