### PR TITLE
redpanda: fix license_key regex

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.10.6
+version: 2.10.7
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -52,7 +52,7 @@
     },
     "license_key": {
       "type": "string",
-      "pattern": "^(?:[A-Za-z0-9+/.])*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$",
+      "pattern": "^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?\\.(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$|^$",
       "deprecated": true
     },
     "license_secret_ref": {


### PR DESCRIPTION
The regex for the license_key should match `<base64>.<base64>`