### PR TITLE
feat: change podAntiAffinity to allow for customer anti-affinity rules

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.12.0
+version: 2.12.1
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/ci/07-multiple-listeners-values.yaml
+++ b/charts/redpanda/ci/07-multiple-listeners-values.yaml
@@ -1,3 +1,18 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
 tls:
   certs:
     cert2:

--- a/charts/redpanda/ci/08-custom-podantiaffinity-values.yaml
+++ b/charts/redpanda/ci/08-custom-podantiaffinity-values.yaml
@@ -14,12 +14,13 @@
 # limitations under the License.
 ---
 statefulset:
-  replicas: 1
-tls:
-  enabled: true
-auth:
-  sasl:
-    enabled: false
-storage:
-  persistentVolume:
-    size: 3Gi
+  replicas: 3
+  podAntiAffinity:
+    type: custom
+    custom:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - topologyKey: kubernetes.io/hostname
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: redpanda
+            app.kubernetes.io/instance: "redpanda"

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -403,7 +403,6 @@ spec:
   {{- end }}
   {{- if .Values.statefulset.podAntiAffinity }}
         podAntiAffinity:
-    {{- if .Values.statefulset.podAntiAffinity.type }}
       {{- if eq .Values.statefulset.podAntiAffinity.type "hard" }}
           requiredDuringSchedulingIgnoredDuringExecution:
             - topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
@@ -416,10 +415,9 @@ spec:
                 topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
                 labelSelector:
                   matchLabels: {{ include "statefulset-pod-labels" . | nindent 20 }}
+      {{- else if eq .Values.statefulset.podAntiAffinity.type "custom" }}
+          {{- toYaml .Values.statefulset.podAntiAffinity.custom | nindent 10 }}
       {{- end }}
-    {{- else }}
-      {{- toYaml .Values.statefulset.podAntiAffinity | nindent 10 }}
-    {{- end }}
   {{- end }}
 {{- end }}
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -612,10 +612,13 @@
             },
             "type": {
               "type": "string",
-              "pattern": "^(hard|soft)$"
+              "pattern": "^(hard|soft|custom)$"
             },
             "weight": {
               "type": "integer"
+            },
+            "custom": {
+              "type": "object"
             }
           }
         },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -505,11 +505,16 @@ statefulset:
     # The topologyKey to be used.
     # Can be used to spread across different nodes, AZs, regions etc.
     topologyKey: kubernetes.io/hostname
-    # Type of anti-affinity rules: either `soft` or `hard`.
+    # The two type of anti-affinity rules are either `soft` or `hard`
+    # Here we define default values for either case. However, you can select
+    # `custom` if you wish to supply your own rules
+    # If you do not wish to use either of these configurations and sup
     type: hard
     # Weight for `soft` anti-affinity rules.
     # Does not apply for other anti-affinity types.
     weight: 100
+    # change type to custom and supply here to supply your own podAntiAffinity rules
+    custom: {}
   # Node selection constraints for scheduling Pods of this StatefulSet.
   # these override the global nodeSelector value
   # https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector


### PR DESCRIPTION
Allow for custom podAntiAffinity rules. Currently the logic in place makes little sense. Nor is it clear where and how  your own rules can be placed. Here we allow for a mechanism that allows for removal of the rules complete, allows for the two defaults, and allows for a custom options. 

Fixes #294 