### PR TITLE
redpanda: add retries to all the tests

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.10.9
+version: 2.10.10
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -61,7 +61,7 @@ spec:
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
       containers:
       - name: {{ template "redpanda.name" . }}-post-install
-        image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+        image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
         {{- if not (empty .Values.license_secret_ref) }}
         env:
           - name: REDPANDA_LICENSE

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -58,7 +58,7 @@ spec:
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
       containers:
       - name: {{ template "redpanda.name" . }}-post-upgrade
-        image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+        image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
         command: ["/bin/sh", "-c"]
         args:
           - |

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -55,7 +55,7 @@ spec:
       initContainers:
 {{- if and (hasKey $values.tuning "tune_aio_events") $values.tuning.tune_aio_events }}
         - name: tuning
-          image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+          image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
           command:
             - bash
             - -c
@@ -89,7 +89,7 @@ spec:
   {{- end }}
 {{- end }}
         - name: {{ (include "redpanda.name" .) | trunc 51 }}-configurator
-          image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+          image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
           command: ["/bin/bash", "-c"]
           env:
             - name: SERVICE_NAME

--- a/charts/redpanda/templates/tests/test-api-status.yaml
+++ b/charts/redpanda/templates/tests/test-api-status.yaml
@@ -21,12 +21,12 @@ metadata:
   name: "{{ include "redpanda.fullname" . }}-test-api-status"
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -34,13 +34,17 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
-      - /bin/bash
+      - /usr/bin/timeout
+      - "120"
+      - bash
       - -c
-      - >
-        rpk cluster info
-        --brokers {{ include "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.kafka.port }}
+      - |
+        until rpk cluster info \
+          --brokers {{ include "redpanda.fullname" . }}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.kafka.port }}
+          do sleep 2
+        done
       volumeMounts:
         - name: {{ template "redpanda.fullname" . }}
           mountPath: /tmp/base-config

--- a/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
@@ -14,6 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+{{- $service := .Values.listeners.kafka -}}
+{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 {{- if and (include "kafka-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
 apiVersion: v1
 kind: Pod
@@ -21,12 +23,12 @@ metadata:
   name: {{ include "redpanda.fullname" . }}-test-kafka-internal-tls-status
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -34,58 +36,44 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
-      - /bin/bash
+      - /usr/bin/timeout
+      - "120"
+      - bash
       - -c
-      - >
-  {{- $service := .Values.listeners.kafka -}}
-  {{- $cert := get .Values.tls.certs $service.tls.cert }}
-  {{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
-        rpk cluster info
-        --brokers {{ include "redpanda.fullname" .}}-0.{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.kafka.port }}
-        --tls-enabled
-    {{- if $cert.caEnabled }}
-        --tls-truststore /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
-    {{- else }}
+      - |
+        until rpk cluster info \
+          --brokers {{ include "redpanda.fullname" .}}-0.{{ include "redpanda.internal.domain" . }}:{{ $service.port }} \
+          --tls-enabled \
+  {{- if $cert.caEnabled }}
+          --tls-truststore /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+  {{- else }}
         {{- /* This is a required field so we use the default in the redpanda debian container */}}
-        --tls-truststore /etc/ssl/certs/ca-certificates.crt
-    {{- end }}
+          --tls-truststore /etc/ssl/certs/ca-certificates.crt
   {{- end }}
-      resources:
-{{- toYaml .Values.statefulset.resources | nindent 12 }}
+        do sleep 2
+        done
+      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
       volumeMounts:
         - name: {{ template "redpanda.fullname" . }}
           mountPath: /tmp/base-config
         - name: config
           mountPath: /etc/redpanda
-{{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
-{{- end }}
   volumes:
     - name: {{ template "redpanda.fullname" . }}
       configMap:
         name: {{ template "redpanda.fullname" . }}
     - name: config
       emptyDir: {}
-{{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
     - name: redpanda-{{ $name }}-cert
       secret:
-        defaultMode: 420
-        items:
-        - key: tls.key
-          path: tls.key
-        - key: tls.crt
-          path: tls.crt
-    {{- if $cert.caEnabled }}
-        - key: ca.crt
-          path: ca.crt
-    {{- end }}
+        defaultMode: 0644
         secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
-{{- end -}}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -16,8 +16,8 @@ limitations under the License.
 */}}
 {{- $sasl := .Values.auth.sasl }}
 {{- $useSaslSecret := and $sasl.enabled (not (empty $sasl.secretRef )) }}
-apiVersion: batch/v1
-kind: Job
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ include "redpanda.fullname" . }}-test-kafka-produce-consume
   namespace: {{ .Release.Namespace | quote }}
@@ -27,79 +27,69 @@ metadata:
 {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  backoffLimit: 2
-  completions: 1
-  parallelism: 1
-  ttlSecondsAfterFinished: 120
-  template:
-    spec:
-      restartPolicy: Never
-      securityContext:
-        runAsUser: 65535
-        runAsGroup: 65535
-      containers:
-        - name: {{ template "redpanda.name" . }}
-          image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
-          env:
-            - name: REDPANDA_BROKERS
-              value: "{{ include "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | trimSuffix "." }}:{{ .Values.listeners.kafka.port }}"
-            - name: POD_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: metadata.name
-          command:
-          - /bin/bash
-          - -c
-          - |
-            set -e
-          {{- if or (not $sasl.enabled) $useSaslSecret }}
-            rpk topic create produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
-            echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
-            rpk topic consume produce.consume.test.$POD_NAME -n 1 {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
-          {{- end }}
-          volumeMounts:
-            - name: config
-              mountPath: /etc/redpanda
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
+  containers:
+    - name: {{ template "redpanda.name" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
+      env:
+        - name: REDPANDA_BROKERS
+          value: "{{ include "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | trimSuffix "." }}:{{ .Values.listeners.kafka.port }}"
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+      command:
+        - /usr/bin/timeout
+        - "120"
+        - bash
+        - -c
+        - |
+          set -e
+{{- if or (not $sasl.enabled) $useSaslSecret }}
+          until rpk topic create produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
+            do sleep 2
+          done
+          echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
+          rpk topic consume produce.consume.test.$POD_NAME -n 1 {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
+          rpk topic delete produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
+{{- end }}
+      volumeMounts:
+        - name: config
+          mountPath: /etc/redpanda
 {{- if (include "tls-enabled" . | fromJson).bool -}}
   {{- range $name, $cert := .Values.tls.certs }}
-            - name: redpanda-{{ $name }}-cert
-              mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+        - name: redpanda-{{ $name }}-cert
+          mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
-            {{- if $useSaslSecret }}
-            - name: {{ $sasl.secretRef }}
-              mountPath: "/etc/secrets/users"
-              readOnly: true
-            {{- end}}
-          resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
-      volumes:
-        - name: {{ template "redpanda.fullname" . }}
-          configMap:
-            name: {{ template "redpanda.fullname" . }}
-        - name: config
-          emptyDir: {}
-        {{- if $useSaslSecret }}
+{{- if $useSaslSecret }}
         - name: {{ $sasl.secretRef }}
-          secret:
-            secretName: {{ $sasl.secretRef }}
-            optional: false
-        {{- end }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+{{- end}}
+      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
+  volumes:
+    - name: {{ template "redpanda.fullname" . }}
+      configMap:
+        name: {{ template "redpanda.fullname" . }}
+    - name: config
+      emptyDir: {}
+{{- if $useSaslSecret }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
+{{- end }}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
-        - name: redpanda-{{ $name }}-cert
-          secret:
-            defaultMode: 420
-            items:
-            - key: tls.key
-              path: tls.key
-            - key: tls.crt
-              path: tls.crt
-        {{- if $cert.caEnabled }}
-            - key: ca.crt
-              path: ca.crt
-        {{- end }}
-            secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+    - name: redpanda-{{ $name }}-cert
+      secret:
+        defaultMode: 0644
+        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -32,7 +32,7 @@ metadata:
 {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -40,23 +40,27 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
-      - /bin/bash
-      - -c
-      - |
-        set -xe
-        rpk acl user delete myuser {{ include "rpk-common-flags" . }}
-        sleep 3
+        - /usr/bin/timeout
+        - "120"
+        - bash
+        - -c
+        - |
+          set -xe
+          until rpk acl user delete myuser {{ include "rpk-common-flags" . }}
+            do sleep 2
+          done
+          sleep 3
 
-        {{ include "rpk-cluster-info" $rpk }}
-        {{ include "rpk-acl-user-create" $rpk }}
-        {{ include "rpk-acl-create" $rpk }}
-        sleep 3
-        {{ include "rpk-topic-create" $rpk }}
-        {{ include "rpk-topic-describe" $rpk }}
-        {{ include "rpk-topic-delete" $rpk }}
-        rpk acl user delete myuser {{ include "rpk-common-flags" . }}
+          {{ include "rpk-cluster-info" $rpk }}
+          {{ include "rpk-acl-user-create" $rpk }}
+          {{ include "rpk-acl-create" $rpk }}
+          sleep 3
+          {{ include "rpk-topic-create" $rpk }}
+          {{ include "rpk-topic-describe" $rpk }}
+          {{ include "rpk-topic-delete" $rpk }}
+          rpk acl user delete myuser {{ include "rpk-common-flags" . }}
       volumeMounts:
         - name: config
           mountPath: /etc/redpanda
@@ -89,16 +93,7 @@ spec:
   {{- range $name, $cert := .Values.tls.certs }}
     - name: redpanda-{{ $name }}-cert
       secret:
-        defaultMode: 420
-        items:
-        - key: tls.key
-          path: tls.key
-        - key: tls.crt
-          path: tls.crt
-    {{- if $cert.caEnabled }}
-        - key: ca.crt
-          path: ca.crt
-    {{- end }}
+        defaultMode: 0644
         secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -14,21 +14,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "http-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
 {{- $service := .Values.listeners.http -}}
 {{- $cert := get .Values.tls.certs $service.tls.cert -}}
+{{- if and (include "http-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
 apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "redpanda.fullname" . }}-test-pandaproxy-internal-tls-status
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -36,10 +36,16 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
         - curl
         - -svm3
+        - --fail
+        - --retry
+        - "120"
+        - --retry-max-time
+        - "120"
+        - --retry-all-errors
         - --ssl-reqd
   {{- if $cert.caEnabled }}
         - --cacert
@@ -53,29 +59,19 @@ spec:
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
-      resources:
-{{- toYaml .Values.statefulset.resources | nindent 12 }}
+      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
   volumes:
     - name: {{ template "redpanda.fullname" . }}
       configMap:
         name: {{ template "redpanda.fullname" . }}
     - name: config
       emptyDir: {}
-{{- if (include "tls-enabled" . | fromJson).bool }}
-  {{- range $name, $cert := .Values.tls.certs }}
+  {{- if (include "tls-enabled" . | fromJson).bool }}
+    {{- range $name, $cert := .Values.tls.certs }}
     - name: redpanda-{{ $name }}-cert
       secret:
-        defaultMode: 420
-        items:
-        - key: tls.key
-          path: tls.key
-        - key: tls.crt
-          path: tls.crt
-    {{- if $cert.caEnabled }}
-        - key: ca.crt
-          path: ca.crt
-    {{- end }}
+        defaultMode: 0644
         secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+    {{- end }}
   {{- end }}
 {{- end -}}
-{{- end }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -21,12 +21,12 @@ metadata:
   name: "{{ include "redpanda.fullname" . }}-test-pandaproxy-status"
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -34,9 +34,15 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
         - curl
         - -svm3
+        - --fail
+        - --retry
+        - "120"
+        - --retry-max-time
+        - "120"
+        - --retry-all-errors
         - http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.http.port }}/brokers
 {{- end }}

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -15,39 +15,33 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.rackAwareness.enabled -}}
-{{- if not (or (include "tls-enabled" . | fromJson).bool (include "sasl-enabled" .)) -}}
-apiVersion: batch/v1
-kind: Job
+  {{- if not (or (include "tls-enabled" . | fromJson).bool (include "sasl-enabled" .)) -}}
+apiVersion: v1
+kind: Pod
 metadata:
   name: {{ include "redpanda.fullname" . }}-test-rack-awareness
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+    {{- with include "full.labels" . }}
+        {{- . | nindent 4 }}
+    {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  backoffLimit: 2
-  completions: 1
-  parallelism: 1
-  ttlSecondsAfterFinished: 120
-  template:
-    spec:
-      restartPolicy: Never
-      securityContext:
-        runAsUser: 65535
-        runAsGroup: 65535
-      containers:
-        - name: {{ template "redpanda.name" . }}
-          image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
-          command:
-          - /bin/bash
-          - -c
-          - |
-            set -e
-            curl --silent --fail http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
-            rpk redpanda admin config print --host {{ include "redpanda.fullname" . }}:{{ .Values.listeners.admin.port }} | grep '"enable_rack_awareness": true'
-{{- end -}}
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
+  containers:
+    - name: {{ template "redpanda.name" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
+      command:
+      - /bin/bash
+      - -c
+      - |
+        set -e
+        curl --silent --fail --retry 120 --retry-max-time 120 --retry-all-errors http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
+        rpk redpanda admin config print --host {{ include "redpanda.fullname" . }}:{{ .Values.listeners.admin.port }} | grep '"enable_rack_awareness": true'
+  {{- end -}}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -14,21 +14,21 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" .|fromJson).bool) }}
 {{- $service := .Values.listeners.schemaRegistry -}}
 {{- $cert := get .Values.tls.certs $service.tls.cert -}}
+{{- if and (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" .|fromJson).bool) -}}
 apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "redpanda.fullname" . }}-test-schemaregistry-internal-tls-status
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -36,10 +36,16 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
         - curl
         - -svm3
+        - --fail
+        - --retry
+        - "120"
+        - --retry-max-time
+        - "120"
+        - --retry-all-errors
         - --ssl-reqd
   {{- if $cert.caEnabled }}
         - --cacert
@@ -53,8 +59,7 @@ spec:
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
-      resources:
-{{- toYaml .Values.statefulset.resources | nindent 12 }}
+      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
   volumes:
     - name: {{ template "redpanda.fullname" . }}
       configMap:
@@ -64,16 +69,7 @@ spec:
   {{- range $name, $cert := .Values.tls.certs }}
     - name: redpanda-{{ $name }}-cert
       secret:
-        defaultMode: 420
-        items:
-        - key: tls.key
-          path: tls.key
-        - key: tls.crt
-          path: tls.crt
-    {{- if $cert.caEnabled }}
-        - key: ca.crt
-          path: ca.crt
-    {{- end }}
+        defaultMode: 0644
         secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
-{{- end }}
+{{- end -}}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -14,8 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- /* TODO test fails if SASL is enabled */}}
-{{- /* TODO test expects the first listener to have TLS enabled */}}
 {{- if not (or (include "tls-enabled" . | fromJson).bool (include "sasl-enabled" . | fromJson).bool) }}
 apiVersion: v1
 kind: Pod
@@ -23,12 +21,12 @@ metadata:
   name: "{{ include "redpanda.fullname" . }}-test-schemaregistry-status"
   namespace: {{ .Release.Namespace | quote }}
   labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext:
@@ -36,13 +34,15 @@ spec:
     runAsGroup: 65535
   containers:
     - name: {{ template "redpanda.name" . }}
-      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
       command:
         - curl
         - -svm3
+        - --fail
         - --retry
-        - "300"
+        - "120"
         - --retry-max-time
         - "120"
+        - --retry-all-errors
         - http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 {{- end }}


### PR DESCRIPTION
Convert the Job tests back to pods so we can get the logs. Add retries and timeouts for every test so they can succeed without Jobs.