### PR TITLE
fix: revert to using service.targetPort with fallbacks

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.5.3
+version: 0.5.4
 
 # The app version is the version of the Chart application
 appVersion: v2.2.0

--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -73,17 +73,17 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Server Listen Port for Console's HTTP server.
-The port can be overriden in the provided config, but
-it defaults to 8080.
+Console's HTTP server Port.
+The port is defined from the service targetPort bu can be overridden
+in the provided config and if that is missing defaults to 8080.
 */}}
-{{- define "console.server.listenPort" -}}
+{{- define "console.containerPort" -}}
+{{- $listenPort := 8080 -}}
 {{- if .Values.console.config.server -}}
-{{- .Values.console.config.server.listenPort | default 8080 }}
-{{- else -}}
-8080
-{{- end }}
-{{- end }}
+{{- $listenPort = .Values.console.config.server.listenPort -}}
+{{- end -}}
+{{- .Values.service.targetPort | default $listenPort -}}
+{{- end -}}
 
 {{/*
 Some umbrella charts may use a global registry variable.

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ include "console.server.listenPort" . }}
+              containerPort: {{ include "console.containerPort" . }}
               protocol: TCP
           volumeMounts:
             - name: configs

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -1,19 +1,17 @@
+---
 apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "console.fullname" . }}
-  labels:
-    {{- include "console.labels" . | nindent 4 }}
+  labels: {{- include "console.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
+  annotations: {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ include "console.server.listenPort" . }}
+      targetPort: {{ include "console.containerPort" . }}
       protocol: TCP
       name: http
-  selector:
-    {{- include "console.selectorLabels" . | nindent 4 }}
+  selector: {{- include "console.selectorLabels" . | nindent 4 }}

--- a/charts/console/values.schema.json
+++ b/charts/console/values.schema.json
@@ -258,6 +258,16 @@
                 "port": {
                     "type": "integer"
                 },
+                "targetPort": {
+                    "anyOf": [
+                        {
+                            "type": "integer"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ]
+                },
                 "type": {
                     "type": "string"
                 }

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -44,7 +44,8 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
-  targetPort: # this will override using console.config.server.listenPort if defined
+  # this will override the value in console.config.server.listenPort if not nil
+  targetPort:
   annotations: {}
 
 ingress:

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -44,6 +44,7 @@ securityContext:
 service:
   type: ClusterIP
   port: 8080
+  targetPort: # this will override using console.config.server.listenPort if defined
   annotations: {}
 
 ingress:


### PR DESCRIPTION
Fixes #358 

The logic here is to bring back a null-able service.targetPort that is an override (if not nil) to the listenPort defined in console.config.server.listenPort which will default to 8080 if not in turn is not found.