### PR TITLE
Fix job security

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.12.1
+version: 2.12.2
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -159,4 +159,6 @@ spec:
             secretName: {{ $sasl.secretRef }}
             optional: false
       {{- end }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
+      serviceAccountName: {{ include "redpanda.serviceAccountName" . }}
 {{- end -}}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -56,6 +56,7 @@ spec:
     {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
+      serviceAccountName: {{ include "redpanda.serviceAccountName" . }}
       containers:
       - name: {{ template "redpanda.name" . }}-post-upgrade
         image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}


### PR DESCRIPTION
- add securityContext and serviceAccountName to post-install-upgrade job
- add serviceAccountName to post-upgrade job

These changes are needed for deploying to OpenShift (but also useful for any other deployment).