### PR TITLE
[experimental] autotune changes to run on postStart

### DIFF
--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -47,6 +47,7 @@ stringData:
     # path below should match the path defined on the statefulset
     source /var/lifecycle/common.sh
 
+    # Clearing out of maintenance mode
 {{- if gt ( .Values.statefulset.replicas | int64 ) 2 }}
     set -ex
 
@@ -63,13 +64,23 @@ stringData:
     done
 {{- end }}
 
+    # Setup and export SASL bootstrap-user
 {{- if and .Values.auth.sasl.enabled (not (empty .Values.auth.sasl.secretRef )) }}
     set +x
-    
-    # Setup and export SASL bootstrap-user
     IFS=":" read -r USER_NAME PASSWORD MECHANISM < $(find /etc/secrets/users/* -print)
     MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
     rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} || true
+{{- end }}
+
+    # Tuning process
+    # The redpanda container may not run all the processes attempted here.
+    # Some may require additional init containers or daemonsets, tbd
+{{- if .Values.tuning.enabled }}
+    set -xe
+    rpk redpanda mode {{ .Values.tuning.mode }}
+  {{- range .Values.tuning.tuners }}
+    rpk redpanda tune {{ . }} || true
+  {{- end }}
 {{- end }}
 
   preStop.sh: |-
@@ -82,6 +93,7 @@ stringData:
 
     set -ex
 
+    # Clearing out of maintenance mode before stopping
 {{- if gt ( .Values.statefulset.replicas | int64 ) 2 }}
     until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
         sleep 0.5

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -66,7 +66,7 @@ spec:
               rpk redpanda tune all
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add: ["CAP_SYS_RESOURCE"]
             privileged: true
             runAsUser: 0
             runAsGroup: 0

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -61,10 +61,12 @@ spec:
             - -c
           args:
             - |
+              set -xe
+              rpk redpanda mode production
               rpk redpanda tune all
           securityContext:
             capabilities:
-              add: ["CAP_SYS_RESOURCE"]
+              add: ["SYS_RESOURCE"]
             privileged: true
             runAsUser: 0
             runAsGroup: 0

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -711,6 +711,19 @@
     "tuning": {
       "type": "object",
       "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "mode": {
+          "type": "string",
+          "pattern": "^(dev|production)$"
+        },
+        "tuners": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "tune_aio_events": {
           "type": "boolean"
         },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -558,6 +558,20 @@ rbac:
   annotations: {}
 
 tuning:
+  # enabled will attempt to run autotune by first running
+  # `rpk redpanda mode production` and then running the set of enabled
+  # tuners via `rpk repdanda tune <enabled-tunner>`
+  # these will silently fail and
+  enabled: true
+  # What mode to enable, this sets default configurations for rpk
+  # default tuners not in this mode will be ignored
+  mode: production # acceptable values are dev,production
+
+  tuners:
+    - aio_events
+    - ballast_file
+    - cpu
+
   # This section contains Redpanda tuning parameters.
   # Each parameter below is set to their default values.
   # Remove the curly brackets above if you uncomment any parameters below.
@@ -568,7 +582,7 @@ tuning:
   #
   # Enabling this option will create a privileged container. If your security profile does not allow this,
   # see https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-tune-workers/ for tuning requirements.
-  tune_aio_events: true
+  tune_aio_events: false
   #
   # Syncs NTP
   # tune_clocksource: false


### PR DESCRIPTION
This is just a test PR to share a possible way we could run tunning. 

This can eliminate the priv initContainer and run several tunners on the pod that runs redpanda. 

We avoid having to exit with non-zero postStart process for now by silently failing, we also allow to setup the mode in the values file to get a list of possible tuners. 

Note that we are able to create the ballast file here and the tunners were found to run as intended. Not all tuners make sense to run and there is questions about how to handle tune_disk_irq at the moment. 

There may be some specific container settings (which maybe we can change in our image creation tools) like swappiness that expects to be able to write on a file that it does not have permissions to write.