### PR TITLE
chore: allow resource configuration of initContainers

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.12.2
+version: 2.13.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/ci/09-initcontainers-resources-values.yaml
+++ b/charts/redpanda/ci/09-initcontainers-resources-values.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+statefulset:
+  initContainers:
+    configurator:
+      resources:
+        requests:
+          memory: "20Mi"
+          cpu: "100m"
+        limits:
+          memory: "60Mi"
+          cpu: "200m"

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -83,7 +83,7 @@ spec:
             - name: datadir
               mountPath: /var/lib/redpanda/data
         {{- if .Values.statefulset.initContainers.set-datadir-ownership.resources }}
-          resources: {{- toYaml .Values.statefulset.initContainers.set-datadir-ownership.resources | nindent 12 }}
+          resources: {{- toYaml .Values.statefulset.initContainers.setDatadirOwnership.resources | nindent 12 }}
         {{- end }}
 {{- end }}
 {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
@@ -93,8 +93,8 @@ spec:
           volumeMounts:
             - name: tiered-storage-dir
               mountPath: {{ template "tieredStorage.cacheDirectory" . }}
-        {{- if .Values.statefulset.initContainers.set-tiered-storage-cache-dir-ownership.resources }}
-          resources: {{- toYaml .Values.statefulset.initContainers.set-tiered-storage-cache-dir-ownership.resources | nindent 12 }}
+        {{- if .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership.resources }}
+          resources: {{- toYaml .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership.resources | nindent 12 }}
         {{- end }}
 {{- end }}
         - name: {{ (include "redpanda.name" .) | trunc 51 }}-configurator

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -82,7 +82,7 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/redpanda/data
-        {{- if .Values.statefulset.initContainers.set-datadir-ownership.resources }}
+        {{- if .Values.statefulset.initContainers.setDatadirOwnership.resources }}
           resources: {{- toYaml .Values.statefulset.initContainers.setDatadirOwnership.resources | nindent 12 }}
         {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -71,6 +71,9 @@ spec:
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
               mountPath: /etc/redpanda
+        {{- if .Values.statefulset.initContainers.tuning.resources }}
+          resources: {{- toYaml .Values.statefulset.initContainers.tuning.resources | nindent 12 }}
+        {{- end }}
 {{- end }}
 {{- if not .Values.statefulset.skipChown }}
         - name: set-datadir-ownership
@@ -79,14 +82,20 @@ spec:
           volumeMounts:
             - name: datadir
               mountPath: /var/lib/redpanda/data
-  {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
+        {{- if .Values.statefulset.initContainers.set-datadir-ownership.resources }}
+          resources: {{- toYaml .Values.statefulset.initContainers.set-datadir-ownership.resources | nindent 12 }}
+        {{- end }}
+{{- end }}
+{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
         - name: set-tiered-storage-cache-dir-ownership
           image: {{ .Values.statefulset.initContainerImage.repository }}:{{ .Values.statefulset.initContainerImage.tag }}
           command: ["/bin/sh", "-c", 'chown {{ $uid }}:{{ $gid }} -R {{ template "tieredStorage.cacheDirectory" . }}']
           volumeMounts:
             - name: tiered-storage-dir
               mountPath: {{ template "tieredStorage.cacheDirectory" . }}
-  {{- end }}
+        {{- if .Values.statefulset.initContainers.set-tiered-storage-cache-dir-ownership.resources }}
+          resources: {{- toYaml .Values.statefulset.initContainers.set-tiered-storage-cache-dir-ownership.resources | nindent 12 }}
+        {{- end }}
 {{- end }}
         - name: {{ (include "redpanda.name" .) | trunc 51 }}-configurator
           image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
@@ -178,7 +187,9 @@ spec:
               mountPath: /tmp/base-config
             - name: config
               mountPath: /etc/redpanda
-          resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
+        {{- if .Values.statefulset.initContainers.configurator.resources }}
+          resources: {{- toYaml .Values.statefulset.initContainers.configurator.resources | nindent 12 }}
+        {{- end }}
       containers:
         - name: {{ template "redpanda.name" . }}
           image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -666,9 +666,44 @@
             }
           }
         },
-        "initContainer": {
-          "type": "string"
+        "initContainers": {
+          "type": "object",
+          "properties": {
+            "tuning": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                }
+              }
+            },
+            "set-datadir-ownership": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                }
+              }
+            },
+            "set-tiered-storage-cache-dir-ownership": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                }
+              }
+            },
+            "configurator": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                }
+              }
+            }
+          }
         },
+
         "skipChown": {
           "type": "boolean"
         }

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -677,7 +677,7 @@
                 }
               }
             },
-            "set-datadir-ownership": {
+            "setDatadirOwnership": {
               "type": "object",
               "properties": {
                 "resources": {
@@ -685,7 +685,7 @@
                 }
               }
             },
-            "set-tiered-storage-cache-dir-ownership": {
+            "setTieredStorageCacheDirOwnership": {
               "type": "object",
               "properties": {
                 "resources": {

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -460,7 +460,6 @@ post_upgrade_job:
   # extraEnvFrom:
   #   - secretRef:
   #       name: redpanda-aws-secrets
-
 statefulset:
   # Number of Redpanda brokers (recommend setting this to the number of nodes in the cluster)
   replicas: 3
@@ -534,6 +533,15 @@ statefulset:
   securityContext:
     fsGroup: 101
     runAsUser: 101
+  initContainers:
+    tuning:
+      resources: {}
+    set-datadir-ownership:
+      resources: {}
+    set-tiered-storage-cache-dir-ownership:
+      resources: {}
+    configurator:
+      resources: {}
   initContainerImage:
     repository: busybox
     tag: latest

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -536,9 +536,9 @@ statefulset:
   initContainers:
     tuning:
       resources: {}
-    set-datadir-ownership:
+    setDatadirOwnership:
       resources: {}
-    set-tiered-storage-cache-dir-ownership:
+    setTieredStorageCacheDirOwnership:
       resources: {}
     configurator:
       resources: {}


### PR DESCRIPTION
Fixes #367 

This adds the resource fields to the initContainers that were missing and the associated values file entries. This was a regression as customers were able to set these in the past. The defaults are set to empty as they are generally not needed, but some customers are already relying on these. At the very least it remove the wrong references that were left in a refactor for the redpanda container resource settings. 