### PR TITLE
Update appVersion from v22.3.13 to v23.1.1

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -82,7 +82,9 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: install cert-manager
-        run: kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.0/cert-manager.yaml
+        run: |
+          helm repo add jetstack https://charts.jetstack.io &&
+          helm install cert-manager --namespace cert-manager --create-namespace --version v1.11.0 jetstack/cert-manager --set installCRDs=true --wait --wait-for-jobs
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install and upgrade)

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -68,7 +68,7 @@ jobs:
           fi
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.4.0
+        uses: helm/kind-action@v1.5.0
         with:
           config: .github/kind.yaml
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,10 +23,10 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.13.2
+version: 3.0.0
 
 # The app version is the default version of Redpanda to install.
-appVersion: v22.3.13
+appVersion: v23.1.1
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
 # pre-release. Our "-0" allows pre-releases to be matched.
@@ -50,6 +50,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: vectorized/redpanda:v22.3.13
+      image: vectorized/redpanda:v23.1.1
     - name: busybox
       image: busybox:latest


### PR DESCRIPTION
Update the Redpanda version to v23.1.1. See [release notes](https://github.com/redpanda-data/redpanda/releases/tag/v23.1.1) for details.

New features include:
[Support for Azure Blob Storage](https://docs.redpanda.com/docs/manage/tiered-storage/): Try running Redpanda in your Microsoft Azure environments! With Redpanda’s cloud-first storage capabilities it will reduce storage costs by 10X or more.
[Enterprise authentication with Kerberos](https://docs.redpanda.com/docs/manage/security/authentication/#enable-kerberos): Redpanda makes it easy to integrate with Kerberos.
[Cluster-wide rate limits for reliable scale](https://docs.redpanda.com/docs/reference/cluster-properties/#kafka_throughput_limit_node_in_bps): Enforce the ingress/egress rate limits to manage I/O backoff and backpressure and avoid unexpected traffic spikes.