### PR TITLE
test: add rpk debug bundle test

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.2
+version: 3.0.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
+++ b/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
@@ -1,0 +1,117 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- $sasl := .Values.auth.sasl }}
+{{- $useSaslSecret := and $sasl.enabled (not (empty $sasl.secretRef )) }}
+{{- if .Values.rbac.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "redpanda.fullname" . }}-test-rpk-debug-bundle
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{- with include "full.labels" . }}
+  {{- . | nindent 4 }}
+{{- end }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  restartPolicy: Never
+  securityContext:
+    fsGroup: 101
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              statefulset.kubernetes.io/pod-name: {{ include "redpanda.fullname" . }}-0
+          topologyKey: kubernetes.io/hostname
+  initContainers:
+    - name: {{ template "redpanda.name" . }}
+      image: {{ .Values.image.repository}}:{{ template "redpanda.tag" . }}
+      volumeMounts:
+        - name: shared-data
+          mountPath: /usr/share/redpanda/test
+        - name: config
+          mountPath: /etc/redpanda
+        - name: datadir
+          mountPath: /var/lib/redpanda/data
+{{- if (include "tls-enabled" . | fromJson).bool -}}
+  {{- range $name, $cert := .Values.tls.certs }}
+        - name: redpanda-{{ $name }}-cert
+          mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+  {{- end }}
+{{- end }}
+{{- if $useSaslSecret }}
+        - name: {{ $sasl.secretRef }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+{{- end}}
+      command:
+      - /bin/bash
+      - -c
+      - |
+        set -e
+        rpk debug bundle -o /usr/share/redpanda/test/debug-test.zip -n {{ .Release.Namespace }} {{ include "rpk-common-flags" . }}
+  containers:
+    - name: {{ template "redpanda.name" . }}-tester
+      image: busybox:latest
+      volumeMounts:
+        - name: shared-data
+          mountPath: /test
+      command:
+      - /bin/ash
+      - -c
+      - |
+        set -e
+        unzip /test/debug-test.zip -d /tmp/bundle
+
+        test -f /tmp/bundle/logs/{{ .Release.Namespace }}-0.txt
+        test -f /tmp/bundle/logs/{{ .Release.Namespace }}-1.txt
+        test -f /tmp/bundle/logs/{{ .Release.Namespace }}-2.txt
+        
+        test -d /tmp/bundle/controller
+
+        test -f /tmp/bundle/k8s/pods.json
+        test -f /tmp/bundle/k8s/configmaps.json
+  volumes:
+    - name: shared-data
+      emptyDir: {}  
+    - name: config
+      emptyDir: {}
+    - name: {{ template "redpanda.fullname" . }}
+      configMap:
+        name: {{ template "redpanda.fullname" . }}
+    - name: datadir
+      persistentVolumeClaim:
+        claimName: datadir-{{ include "redpanda.fullname" . }}-0     
+{{- if $useSaslSecret }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
+{{- end }}
+{{- if (include "tls-enabled" . | fromJson).bool }}
+  {{- range $name, $cert := .Values.tls.certs }}
+    - name: redpanda-{{ $name }}-cert
+      secret:
+        defaultMode: 0644
+        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+  {{- end }}
+{{- end -}}
+
+{{- end -}}


### PR DESCRIPTION
This test needs to peak the cluster data-dir
that's why we mount to the redpanda pvc.

We don't test every single file, instead we check
for existence of some important files that were
added to the k8s-rpk debug bundle.