### PR TITLE
fix: if ca is not enabled, do not pass the cacert curl flag

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 2.13.2
+version: 2.13.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v22.3.13

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -492,10 +492,15 @@ runAsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityCo
 {{- define "admin-tls-curl-flags" -}}
   {{- $result := "" -}}
   {{- if (include "admin-internal-tls-enabled" . | fromJson).bool -}}
+    {{- $certificate :=  get .Values.tls.certs .Values.listeners.admin.tls.cert -}}
     {{- $path := (printf "/etc/tls/certs/%s" .Values.listeners.admin.tls.cert) -}}
     {{- $result = (printf "--cacert %s/tls.crt" $path) -}}
     {{- if .Values.listeners.admin.tls.requireClientAuth -}}
-      {{- $result = (printf "--cacert %s/ca.crt --cert %s/tls.crt --key %s/tls.key" $path $path $path) -}}
+      {{- if $certificate.caEnabled -}}
+        {{- $result = (printf "--cacert %s/ca.crt --cert %s/tls.crt --key %s/tls.key" $path $path $path) -}}
+      {{- else -}}
+        {{- $result = (printf "--cert %s/tls.crt --key %s/tls.key" $path $path $path) -}}
+      {{- end -}}
     {{- end -}}
   {{- end -}}
   {{- $result -}}


### PR DESCRIPTION
Small bug fix were we should not add cacert flag in the situation where ca is disabled. 

This should be the last small fix that we can commit without causing breaking changes. I will then close PR #289 