### PR TITLE
fix: should check initContainer field exists first to support upgrades

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.1
+version: 3.0.2
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/cr.yaml
+++ b/charts/redpanda/cr.yaml
@@ -1,0 +1,6 @@
+owner: redpanda-data
+git-repo: redpanda-data/helm-charts
+token: lab
+make-release-latest: true
+generate-release-notes: true
+package-path: ./charts/

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -479,7 +479,7 @@ than 1 core.
 # manage backward compatibility with renaming podSecurityContext to securityContext
 {{- define "pod-security-context" -}}
 fsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
-fsGroupChangePolicy: {{ dig "podSecurityContext" "fsGroupChangePolicy" .Values.statefulset.securityContext.fsGroupChangePolicy .Values.statefulset }}
+fsGroupChangePolicy: {{ dig "securityContext" "fsGroupChangePolicy" "OnRootMismatch" .Values.statefulset }}
 {{- end -}}
 
 # for backward compatibility, force a default on releases that didn't

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -71,7 +71,7 @@ spec:
           volumeMounts:
             - name: {{ template "redpanda.fullname" . }}
               mountPath: /etc/redpanda
-        {{- if .Values.statefulset.initContainers.tuning.resources }}
+        {{- if get .Values.statefulset.initContainers.tuning "resources" }}
           resources: {{- toYaml .Values.statefulset.initContainers.tuning.resources | nindent 12 }}
         {{- end }}
 {{- end }}
@@ -82,7 +82,7 @@ spec:
           volumeMounts:
             - name: tiered-storage-dir
               mountPath: {{ template "tieredStorage.cacheDirectory" . }}
-        {{- if .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership.resources }}
+        {{- if get .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership "resources" }}
           resources: {{- toYaml .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership.resources | nindent 12 }}
         {{- end }}
 {{- end }}
@@ -176,7 +176,7 @@ spec:
               mountPath: /tmp/base-config
             - name: config
               mountPath: /etc/redpanda
-        {{- if .Values.statefulset.initContainers.configurator.resources }}
+        {{- if get .Values.statefulset.initContainers.configurator "resources" }}
           resources: {{- toYaml .Values.statefulset.initContainers.configurator.resources | nindent 12 }}
         {{- end }}
       containers:

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -658,8 +658,7 @@
           "type": "object",
           "required": [
             "fsGroup",
-            "runAsUser",
-            "fsGroupChangePolicy"
+            "runAsUser"
           ],
           "properties": {
             "fsGroup": {


### PR DESCRIPTION
Bug introduced for not checking from previous revisions if the initContainer.container field exists before checking if the subfield exists.

In addition we should also not require a new field as this will cause problems on upgrades with --reuse-values flag set. 