### PR TITLE
Fix: Duplicated securityContext fails on helm template/ kustomize build

### DIFF
--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -159,6 +159,5 @@ spec:
             secretName: {{ $sasl.secretRef }}
             optional: false
       {{- end }}
-      securityContext: {{ include "container-security-context" . | nindent 8 }}
       serviceAccountName: {{ include "redpanda.serviceAccountName" . }}
 {{- end -}}


### PR DESCRIPTION
kustomize build app --enable-helm 
Error: map[string]interface {}(nil): yaml: unmarshal errors:
  line 62: mapping key "securityContext" already defined at line 27
error: no objects passed to apply