### PR TITLE
charts/redpanda: Fix CAP_SYS_RESOURCE name

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.7
+version: 4.0.8
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.7

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -68,7 +68,7 @@ spec:
               rpk redpanda tune all
           securityContext:
             capabilities:
-              add: ["CAP_SYS_RESOURCE"]
+              add: ["SYS_RESOURCE"]
             privileged: true
             runAsUser: 0
             runAsGroup: 0


### PR DESCRIPTION
All linux capabilities in k8s security context drop the CAP prefix.

Ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-capabilities-for-a-container

> Note: Linux capability constants have the form CAP_XXX. But when you list capabilities in your container manifest, you must omit the CAP_ portion of the constant. For example, to add CAP_SYS_TIME, include SYS_TIME in your list of capabilities.