### PR TITLE
redpanda: do not set azure keys to empty strings

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.4
+version: 3.0.5
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -334,11 +334,11 @@ storage:
     cloud_storage_secret_key: ""
     cloud_storage_api_endpoint: ""
     # Required for ABS.
-    cloud_storage_azure_container: ""
+    cloud_storage_azure_container: null
     # Required for ABS.
-    cloud_storage_azure_storage_account: ""
+    cloud_storage_azure_storage_account: null
     # Required for ABS.
-    cloud_storage_azure_shared_key: ""
+    cloud_storage_azure_shared_key: null
     # Available starting from 22.3.X
     # Required for AWS and GCS authentication with IAM roles.
     cloud_storage_credentials_source: config_file


### PR DESCRIPTION
Redpanda does not interpret empty strings as being unset. Must use null.