### PR TITLE
add a github action to validate no changes to values files

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -40,6 +40,20 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
+  check-values:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: install dyff
+        run: curl -Ls https://github.com/homeport/dyff/releases/download/v1.5.6/dyff_1.5.6_linux_amd64.tar.gz | tar xzv dyff
+      - name: compare redpanda values with main
+        run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/redpanda/values.yaml') charts/redpanda/values.yaml
+      - name: compare console values with main
+        run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/console/values.yaml') charts/console/values.yaml
   test:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
A change to a chart values file will cause this test to fail.

A failure looks like:

```
Run ./dyff --color=off -k between -s <(git show 'origin/main:charts/redpanda/values.yaml') charts/redpanda/values.yaml
     _        __  __
   _| |_   _ / _|/ _|  between /dev/fd/63
 / _' | | | | |_| |_       and charts/redpanda/values.yaml
| (_| | |_| |  _|  _|
 \__,_|\__, |_| |_|   returned one difference
        |___/

nameOverride
  ± value change
    -
    + changedValueToMakePRfail

Error: Process completed with exit code 1.
```

In this example, I changed the default `nameOverrride` to `changedValueToMakePRfail`.