### PR TITLE
feat: enable setting ownership via initContainer

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.6
+version: 3.0.7
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -75,6 +75,17 @@ spec:
           resources: {{- toYaml .Values.statefulset.initContainers.tuning.resources | nindent 12 }}
         {{- end }}
 {{- end }}
+{{- if .Values.statefulset.initContainers.setDataDirOwnership.enabled }}
+        - name: set-datadir-ownership
+          image: {{ .Values.statefulset.initContainerImage.repository }}:{{ .Values.statefulset.initContainerImage.tag }}
+          command: ["/bin/sh", "-c", "chown {{ $uid }}:{{ $gid }} -R /var/lib/redpanda/data"]
+          volumeMounts:
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+        {{- if .Values.statefulset.initContainers.setDataDirOwnership.resources }}
+          resources: {{- toYaml .Values.statefulset.initContainers.setDataDirOwnership.resources | nindent 12 }}
+        {{- end }}
+{{- end }}
 {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
         - name: set-tiered-storage-cache-dir-ownership
           image: {{ .Values.statefulset.initContainerImage.repository }}:{{ .Values.statefulset.initContainerImage.tag }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -684,6 +684,17 @@
                 }
               }
             },
+            "setDataDirOwnership": {
+              "type": "object",
+              "properties": {
+                "resources": {
+                  "type": "object"
+                },
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
             "setTieredStorageCacheDirOwnership": {
               "type": "object",
               "properties": {

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -482,6 +482,11 @@ statefulset:
   initContainers:
     tuning:
       resources: {}
+    # In environments where root is not allowed, you cannot change the ownership of files and directories
+    # Please enable when using default minikube cluster configuration
+    setDataDirOwnership:
+      enabled: false
+      resources: {}
     setTieredStorageCacheDirOwnership:
       resources: {}
     configurator:
@@ -489,9 +494,6 @@ statefulset:
   initContainerImage:
     repository: busybox
     tag: latest
-  # In environments where root is not allowed, you cannot change the ownership of files and directories
-  # set this to true to skip this step.
-  skipChown: false
 
 # Service account management
 serviceAccount:


### PR DESCRIPTION
Allow for having an init container when ownership of local path is required. 

Tested this locally and it works, off by default. 

Requires some documentation and this should help out minikube users. 

Fixes #387 