### PR TITLE
Use tpl render on external domain name for providing values dynamically

### DIFF
--- a/charts/redpanda/Chart.lock
+++ b/charts/redpanda/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: console
   repository: https://charts.redpanda.com
-  version: 0.5.0
-digest: sha256:7fd70de57651b2f1857f3eb519c427dbbcad8fc6ea656925651bb0c10839b035
-generated: "2023-02-09T08:51:15.13722333-08:00"
+  version: 0.5.6
+digest: sha256:3d8c8f0fc699655fdc2ec8f3cd414eb46319ccb6191b61a0b788c2736f464ab8
+generated: "2023-03-29T23:32:32.207808971-04:00"

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.7
+version: 3.0.8
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -534,7 +534,7 @@ advertised-host returns a json sring with the data neded for configuring the adv
 {{- define "advertised-host" -}}
   {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
   {{- if .values.external.addresses -}}
-    {{- if .values.external.domain -}}
+    {{- if (tpl ($values.external.domain | default "") $) }}
       {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) (tpl .values.external.domain $)) "port" .port -}}
     {{- else -}}
       {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -534,7 +534,7 @@ advertised-host returns a json sring with the data neded for configuring the adv
 {{- define "advertised-host" -}}
   {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
   {{- if .values.external.addresses -}}
-    {{- if (tpl ($values.external.domain | default "") $) }}
+    {{- if (tpl (.values.external.domain | default "") $) }}
       {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) (tpl .values.external.domain $)) "port" .port -}}
     {{- else -}}
       {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -535,7 +535,7 @@ advertised-host returns a json sring with the data neded for configuring the adv
   {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
   {{- if .values.external.addresses -}}
     {{- if .values.external.domain -}}
-      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) .values.external.domain) "port" .port -}}
+      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) (tpl .values.external.domain $)) "port" .port -}}
     {{- else -}}
       {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}
     {{- end -}}

--- a/charts/redpanda/templates/certs.yaml
+++ b/charts/redpanda/templates/certs.yaml
@@ -49,9 +49,9 @@ spec:
   - {{ printf "*.%s.%s.svc" $service $ns | quote }}
   - {{ printf "*.%s.%s" $service $ns | quote }}
 {{- end }}
-{{- if $values.external.domain }}
-  - "{{ $values.external.domain }}"
-  - "*.{{ $values.external.domain }}"
+{{- if (tpl $values.external.domain $) }}
+  - "{{ tpl $values.external.domain $ }}"
+  - "*.{{ tpl $values.external.domain $ }}"
 {{- end }}
   duration: {{ $d | default "43800h" }}
   isCA: false

--- a/charts/redpanda/templates/certs.yaml
+++ b/charts/redpanda/templates/certs.yaml
@@ -49,7 +49,7 @@ spec:
   - {{ printf "*.%s.%s.svc" $service $ns | quote }}
   - {{ printf "*.%s.%s" $service $ns | quote }}
 {{- end }}
-{{- if (tpl $values.external.domain $) }}
+{{- if (tpl ($values.external.domain | default "") $) }}
   - "{{ tpl $values.external.domain $ }}"
   - "*.{{ tpl $values.external.domain $ }}"
 {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -18,7 +18,7 @@ limitations under the License.
 {{- $values := .Values }}
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
 {{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}
-{{- if $values.external.domain -}}
+{{- if (tpl ($values.external.domain | default "") $) }}
   {{- $externalAdvertiseAddress = printf "$(SERVICE_NAME).%s" (tpl $values.external.domain $) -}}
 {{- end -}}
 {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset -}}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -19,7 +19,7 @@ limitations under the License.
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
 {{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}
 {{- if $values.external.domain -}}
-  {{- $externalAdvertiseAddress = printf "$(SERVICE_NAME).%s" $values.external.domain -}}
+  {{- $externalAdvertiseAddress = printf "$(SERVICE_NAME).%s" (tpl $values.external.domain $) -}}
 {{- end -}}
 {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset -}}
 {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset -}}


### PR DESCRIPTION
## Motivation
External access might require dynamic domain names to be used as the ADVERTISED DOMAIN names

## Approach
Add template rendering using tpl functions for external domain value

## Usecase
- When external access is enabled for the Redpanda service, the domain names are advertised by the brokers based on the Values.external.domain configuration. 
- For internal clients the cluster local endpoints work just fine, but
- Currently we do not have an option to dynamically set the external domains as we might have multiple environments or stacks were Redpanda is deployed (dev/qa/prod etc). 
- Having the external domain name configurable through values file and tpl rendered, we could use helm library functions to override the domain names appropriately for the stacks that we deploy Redpanda.