### PR TITLE
Decrease cloud_storage_cache_size default value

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.26
+version: 4.0.27
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.10

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -411,7 +411,7 @@ storage:
     # -- Maximum size of the disk cache used by Tiered Storage.
     # Default is 20 GiB.
     # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_cache_size).
-    cloud_storage_cache_size: 21474836480
+    cloud_storage_cache_size: 5368709120
     # cloud_storage_cache_directory: ""
     # cloud_storage_cache_check_interval: 30000
     # cloud_storage_initial_backoff_ms: 100


### PR DESCRIPTION
Closes #416 

This value at it's current default of 20Gi is set to the same size as the default value for a persistent volume's size. This means that if consumers start consuming data from offset 0 and there is enough cloud storage data (over 20Gi), then the disk would be entirely consumed by cloud storage alone and crash the broker.

This PR sets the cloud storage cache storage value to a better default of 5Gi.