### PR TITLE
Add GitHub Action to trigger Helm spec file generation

### DIFF
--- a/.github/workflows/dispatch-helm-docs.yaml
+++ b/.github/workflows/dispatch-helm-docs.yaml
@@ -1,0 +1,20 @@
+# This workflow triggers the actions in redpanda-data/documentation that publishes the Helm specification to the Redpanda documentation.
+
+name: Trigger Helm spec docs
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'charts/**'
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger generate-helm-spec-docs event
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: redpanda-data/documentation
+          event-type: generate-helm-spec-docs


### PR DESCRIPTION
This is part of https://github.com/redpanda-data/documentation/pull/1444.

This workflow is triggered on changes to any file in `/charts`.

We'll need to add a `REPO_ACCESS_TOKEN` secret to this repository. It must contain a PAT with the `repo` permission to the `redpanda-data/documentation` repo.