### PR TITLE
use org bot credentials

### DIFF
--- a/.github/workflows/dispatch-helm-docs.yaml
+++ b/.github/workflows/dispatch-helm-docs.yaml
@@ -15,6 +15,6 @@ jobs:
       - name: Trigger generate-helm-spec-docs event
         uses: peter-evans/repository-dispatch@v2
         with:
-          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           repository: redpanda-data/documentation
           event-type: generate-helm-spec-docs


### PR DESCRIPTION
redpanda-data already has credentials that can be used for this. This uses those credentials rather than adding new ones.