### PR TITLE
Templating should occur external to a helper function

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -51,6 +51,7 @@ jobs:
           - '0[1-3]*'
           - '0[4-6]*'
           - '0[7-9]*'
+          - '1[0-2]*'
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -73,6 +73,7 @@ jobs:
           - '0[1-3]*'
           - '0[4-6]*'
           - '0[7-9]*'
+          - '1[0-2]*'
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.9
+version: 3.0.10
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/ci/10-external-addresses.yaml
+++ b/charts/redpanda/ci/10-external-addresses.yaml
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# the number of replicas should match the length of the addresses
+statefulset:
+  replicas: 3
+
+external:
+  enabled: true
+  type: LoadBalancer
+  domain: my-domain
+  addresses:
+    - redpanda-1
+    - 127.0.0.1
+    - 192.168.0.1

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -529,13 +529,13 @@ but not enough ports for the number of replicas requested.
 {{- end -}}
 
 {{- /*
-advertised-host returns a json sring with the data neded for configuring the advertised listener
+advertised-host returns a json string with the data needed for configuring the advertised listener
 */ -}}
 {{- define "advertised-host" -}}
   {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
   {{- if .values.external.addresses -}}
-    {{- if (tpl (.values.external.domain | default "") $) }}
-      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) (tpl .values.external.domain $)) "port" .port -}}
+    {{- if ( .values.external.domain | default "" ) }}
+      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) (.values.external.domain)) "port" .port -}}
     {{- else -}}
       {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}
     {{- end -}}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -117,7 +117,7 @@ spec:
         {{- range $externalName, $externalVals := $listenerVals.external }}
           {{- $tmplVals := dict "listenerVals" $listenerVals "externalVals" $externalVals "replicaIndex" $replicaIndex "externalName" $externalName "externalAdvertiseAddress" $externalAdvertiseAddress "values" $values }}
           {{- $port := int (include "advertised-port" $tmplVals) }}
-          {{- $host := include "advertised-host" (mustMerge $tmplVals (dict "port" $port)) }}
+          {{- $host := tpl (include "advertised-host" (mustMerge $tmplVals (dict "port" $port)) ) $ }}
           {{- $listenerList = mustAppend $listenerList $host }}
         {{- end }}
     {{- end }}


### PR DESCRIPTION
We have seen an issue trying to set the external.addresses in the values file:

```
redpanda/templates/statefulset.yaml:120:23: executing "redpanda/templates/statefulset.yaml" at <include "advertised-host" (mustMerge $tmplVals (dict "port" $port))>: error calling include: template: redpanda/templates/_helpers.tpl:537:12: executing "advertised-host" at <tpl (.values.external.domain | default "") $>: error calling tpl: cannot retrieve Template.Basepath from values inside tpl function: : "BasePath" is not a value
```

This seems to be because 

https://github.com/helm/helm/issues/4166#issuecomment-497430905

It is not possible to get the BasePath scope into the template file. To fix that we move the templating above to the statefulset. I also added a test to help catch issues in the future on this particular code path. 