### PR TITLE
use vars for consistent naming in tasks

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -3,6 +3,12 @@ version: '3'
 
 dotenv: [".env", '{{.ENV}}/.env.']
 
+vars:
+  NAMESPACE: rn
+  RELEASE: rp
+  HELM_OPTIONS: ""
+  KIND_CLUSTERNAME: rp-helm
+
 # NOTE: Task doesn't allow to override environment variables. Thus, when an
 # environment variable is referenced in a taskfile, it is because we expect it
 # to be defined by the environment where Task is being invoked, in an `.env`
@@ -14,39 +20,53 @@ run: once
 
 tasks:
 
+  up:
+    cmds:
+      - task: kind-create
+      - task: install-redpanda-chart
+
+  install-cert-manager:
+    cmds:
+      - helm install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace
+
   kind-create:
     cmds:
-      - kind create cluster --name rp-helm --config ./.github/kind.yaml
-      - helm install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace
+      - kind create cluster --name {{ .KIND_CLUSTERNAME }} --config ./.github/kind.yaml
+      - task: install-cert-manager
+    status:
+      - "kind get clusters | grep {{ .KIND_CLUSTERNAME }}"
 
   kind-delete:
     cmds:
-      - kind delete cluster --name rp-helm
+      - kind delete cluster --name {{ .KIND_CLUSTERNAME }}
 
   install-redpanda-chart:
+    aliases:
+      - upgrade-redpanda-chart
     cmds:
-      - helm install rp ./charts/redpanda --namespace rn --create-namespace --debug
-
-  upgrade-redpanda-chart:
-    cmds:
-      - helm upgrade --install redpanda ./charts/redpanda --namespace redpanda --create-namespace --debug
+      - >
+        helm upgrade --install {{ .RELEASE }} ./charts/redpanda
+          --namespace {{ .NAMESPACE }}
+          --create-namespace
+          --wait
+          --debug
+          {{ .HELM_OPTIONS }}
 
   uninstall-redpanda-chart:
     cmds:
-      - helm uninstall redpanda -n redpanda || true
-      - kubectl -n redpanda delete pods redpanda-0 redpanda-1 redpanda-2 --grace-period=0 --force --wait=false || true
-      - kubectl -n redpanda delete pvc datadir-redpanda-0 datadir-redpanda-1 datadir-redpanda-2 --force --grace-period=0 --wait=false || true
-      - kubectl delete ns redpanda --wait=false || true
+      - helm uninstall {{ .RELEASE }} -n {{ .NAMESPACE }} --wait || true
+      - kubectl -n {{ .NAMESPACE }} delete pods --all --grace-period=0 --force --wait=false || true
+      - kubectl -n {{ .NAMESPACE }} delete pvc --all --force --grace-period=0 --wait=false || true
+      - kubectl delete ns {{ .NAMESPACE }}
 
   minikube-start:
     cmds:
-      - minikube start --nodes=4 
-      - kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.23/deploy/local-path-storage.yaml 
+      - minikube start --nodes=4
+      - kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.23/deploy/local-path-storage.yaml
       - ./scripts/change-default-sc.sh
-      - helm install cert-manager jetstack/cert-manager --set installCRDs=true --namespace cert-manager --create-namespace
+      - task: install-cert-manager
 
 
   minikube-delete:
     cmds:
       - minikube delete
-


### PR DESCRIPTION
I noticed that the chart install and upgrade used different release names. Moved several things to vars to allow command-line overrides if desired, ie:

```
task kind-create KIND_CLUSTERNAME=foo
```