### PR TITLE
bash does not pass sigterm to child processes

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.10
+version: 3.0.11
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.1

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -464,16 +464,36 @@ than 1 core.
 {{- end -}}
 {{- end -}}
 
+{{- define "fail-on-insecure-sasl-logging" -}}
+{{- if (include "sasl-enabled" .|fromJson).bool -}}
+  {{- $check := list
+      (include "redpanda-atleast-23-1-1" .|fromJson).bool
+      (include "redpanda-22-3-atleast-22-3-13" .|fromJson).bool
+      (include "redpanda-22-2-atleast-22-2-10" .|fromJson).bool
+  -}}
+  {{- if not (mustHas true $check) -}}
+    {{- fail "SASL is enabled and the redpanda version specified leaks secrets to the logs. Please choose a newer version of redpanda." -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda-atleast-22-1-1" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.1.1"))) -}}
 {{- end -}}
-
 {{- define "redpanda-atleast-22-2-0" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.2.0"))) -}}
 {{- end -}}
-
 {{- define "redpanda-atleast-22-3-0" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.3.0"))) -}}
+{{- end -}}
+{{- define "redpanda-atleast-23-1-1" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=23.1.1"))) -}}
+{{- end -}}
+{{- define "redpanda-22-3-atleast-22-3-13" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.3.13,<22.4"))) -}}
+{{- end -}}
+{{- define "redpanda-22-2-atleast-22-2-10" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.2.10,<22.3"))) -}}
 {{- end -}}
 
 # manage backward compatibility with renaming podSecurityContext to securityContext

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -295,16 +295,14 @@ spec:
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
           command:
-            - bash
-            - -c
-            - |
-              rpk redpanda start \
-                --smp={{ include "redpanda-smp" . }} \
-                --memory={{ template "redpanda-memory" . }}M \
-                --reserve-memory={{ template "redpanda-reserve-memory" . }}M \
-                --default-log-level={{ .Values.logging.logLevel }} \
-                --advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }} |
-              sed 's@RP_BOOTSTRAP_USER[^ ]\+@<censored>@g'
+            - rpk
+            - redpanda
+            - start
+            - --smp={{ include "redpanda-smp" . }}
+            - --memory={{ template "redpanda-memory" . }}M
+            - --reserve-memory={{ template "redpanda-reserve-memory" . }}M
+            - --default-log-level={{ .Values.logging.logLevel }}
+            - --advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}
           ports:
 {{- range $name, $listener := .Values.listeners }}
             - name: {{ lower $name }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- include "fail-on-insecure-sasl-logging" . -}}
+
 {{- $values := .Values }}
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
 {{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}


### PR DESCRIPTION
this causes Redpanda to be sigterm'd, which might be causing corrupted
segments.

bash was in use because we were filtering out secret data from the
Redpanda logs. All currently supported versions of Redpanda no longer
leak that data.

This PR adds a test for Redpanda versions that have the secret leak problem and will fail if an insecure version is being used.

Fixes: #433 