### PR TITLE
fix: skip from release failing on existing releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,9 @@
 # specific language governing permissions and limitations
 # under the License.
 
+# FOR MORE DETAILS ON CR AND ENVIRONMENT VARS:
+#https://github.com/helm/chart-releaser#environment-variables
+
 name: release
 on:
   push:
@@ -51,3 +54,4 @@ jobs:
           charts_repo_url: https://charts.redpanda.com
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          CR_SKIP_EXISTING: true


### PR DESCRIPTION
Should Resolve Issues like: https://github.com/redpanda-data/helm-charts/actions/runs/4671600518/jobs/8272787822