### PR TITLE
feat: allowing secretRef for tls

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.3
+version: 4.0.4
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.7

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -617,3 +617,14 @@ return a warning if the chart is configured with insufficient CPU
   {{- end -}}
   {{- toJson $brokers -}}
 {{- end -}}
+
+{{/*
+return correct secretName to use based if secretRef exists
+*/}}
+{{- define "cert-secret-name" -}}
+  {{- if .tempCert.cert.secretRef -}}
+    {{- .tempCert.cert.secretRef.name -}}
+  {{- else }}
+    {{- include "redpanda.fullname" . }}-{{ .tempCert.name }}-cert
+  {{- end }}
+{{- end -}}

--- a/charts/redpanda/templates/cert-issuers.yaml
+++ b/charts/redpanda/templates/cert-issuers.yaml
@@ -21,8 +21,8 @@ limitations under the License.
   {{- range $name, $data := $values.tls.certs }}
     {{/* If issuerRef is defined, use the specified issuer for the certs
          If it's not defined, create and use our own issuer. */}}
-    {{- $r := $data.issuerRef }}
-    {{- if not $r }}
+  {{- if and ( not (hasKey $data "issuerRef") ) ( not (hasKey $data "secretRef") ) }}
+
 ---
 # The self-signed issuer is used to create the self-signed CA
 apiVersion: cert-manager.io/v1

--- a/charts/redpanda/templates/certs.yaml
+++ b/charts/redpanda/templates/certs.yaml
@@ -22,7 +22,9 @@ limitations under the License.
   {{- $listeners := .Values.listeners -}}
   {{- $values := .Values }}
   {{- range $name, $data := .Values.tls.certs }}
+  {{- if (empty $data.secretRef ) }}
     {{- $d := $data.duration }}
+
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -68,6 +70,7 @@ spec:
     name: {{ template "redpanda.fullname" $ }}-{{ $name }}-root-issuer
     kind: Issuer
     group: cert-manager.io
+    {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -17,6 +17,8 @@ limitations under the License.
 {{- if .Values.post_install_job.enabled }}
 {{- $values := .Values }}
 {{- $sasl := $values.auth.sasl }}
+{{- $root := deepCopy . }}
+
 ---
 apiVersion: batch/v1
 kind: Job
@@ -136,8 +138,9 @@ spec:
             name: {{ template "redpanda.fullname" . }}
         - name: config
           emptyDir: {}
-      {{- if (include "tls-enabled" . | fromJson).bool }}
-        {{- range $name, $cert := .Values.tls.certs }}
+{{- if (include "tls-enabled" . | fromJson).bool }}
+  {{- range $name, $cert := .Values.tls.certs }}
+      {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
         - name: redpanda-{{ $name }}-cert
           secret:
             defaultMode: 420
@@ -146,13 +149,13 @@ spec:
               path: tls.key
             - key: tls.crt
               path: tls.crt
-          {{- if $cert.caEnabled }}
+      {{- if $cert.caEnabled }}
             - key: ca.crt
               path: ca.crt
-          {{- end }}
-            secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
-        {{- end }}
-      {{- end -}}
+      {{- end }}
+            secretName: {{ template "cert-secret-name" $r }}
+  {{- end }}
+{{- end -}}
       {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
         - name: {{ $sasl.secretRef }}
           secret:

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -17,6 +17,7 @@ limitations under the License.
 {{- if .Values.post_upgrade_job.enabled }}
 {{- $rpkFlags := include "rpk-flags-no-sasl" . }}
 {{- $sasl := .Values.auth.sasl }}
+{{- $root := deepCopy . }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -108,6 +109,7 @@ spec:
           emptyDir: {}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
+    {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
         - name: redpanda-{{ $name }}-cert
           secret:
             defaultMode: 420
@@ -120,7 +122,7 @@ spec:
             - key: ca.crt
               path: ca.crt
     {{- end }}
-            secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+            secretName: {{ template "cert-secret-name" $r }}
   {{- end }}
 {{- end -}}
         {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -25,6 +25,7 @@ limitations under the License.
 {{- end -}}
 {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset -}}
 {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset -}}
+{{- $root := deepCopy . }}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -342,6 +343,7 @@ spec:
           emptyDir: {}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
+  {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
         - name: redpanda-{{ $name }}-cert
           secret:
             defaultMode: 420
@@ -354,7 +356,7 @@ spec:
             - key: ca.crt
               path: ca.crt
     {{- end }}
-            secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+            secretName: {{ template "cert-secret-name" $r }}
   {{- end }}
 {{- end }}
         {{- if and .Values.auth.sasl.enabled (not (empty .Values.auth.sasl.secretRef )) }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -139,9 +139,28 @@ tls:
       # issuerRef:
       #   name: redpanda-default-root-issuer
       #   kind: Issuer   # Can be Issuer or ClusterIssuer
+      # -- To use a secret with custom tls files,
+      # secretRef:
+      #  name: my-tls-secret
       # -- Set the `caEnabled` flag to `true` only for Certificates
       # that are not authenticated using public authorities.
       caEnabled: true
+      # duration: 43800h
+    # -- Example external tls configuration
+    # uncomment and set the right key to the listeners that require them
+    # also enable the tls setting for those listeners.
+    # external:
+      # -- To use a custom pre-installed Issuer,
+      # add its name and kind to the `issuerRef` object.
+      # issuerRef:
+      #   name: redpanda-default-root-issuer
+      #   kind: Issuer   # Can be Issuer or ClusterIssuer
+      # -- To use a secret with custom tls files,
+      # secretRef:
+      #   name: my-tls-secret
+      # -- Set the `caEnabled` flag to `true` only for Certificates
+      # that are not authenticated using public authorities.
+      # caEnabled: true
       # duration: 43800h
 
 # -- External access settings.
@@ -275,7 +294,7 @@ resources:
     # 3. Other container processes (whatever small amount remains)
     # redpanda:
       # Memory for the Redpanda process.
-      # This must be lower the container's memory (resources.memory.container.min if provided, otherwise
+      # This must be lower than the container's memory (resources.memory.container.min if provided, otherwise
       # resources.memory.container.max).
       # Equivalent to --memory.
       # For production, use 8Gi or greater.
@@ -295,7 +314,7 @@ storage:
   # If specified but `persistentVolume.enabled` is true, `storage.hostPath` has no effect.
   hostPath: ""
   # -- If `persistentVolume.enabled` is true, a PersistentVolumeClaim is created and
-  # used to store Redpanda's data. Otherwise `storage.hostPath` is used.
+  # used to store Redpanda's data. Otherwise, `storage.hostPath` is used.
   persistentVolume:
     enabled: true
     size: 20Gi
@@ -437,6 +456,7 @@ post_upgrade_job:
   # extraEnvFrom:
   #   - secretRef:
   #       name: redpanda-aws-secrets
+
 statefulset:
   # -- Number of Redpanda brokers (Redpanda Data recommends setting this to the number of worker nodes in the cluster)
   replicas: 3
@@ -543,6 +563,7 @@ serviceAccount:
   # If not set and `serviceAccount.create` is `true`,
   # a name is generated using the `redpanda.fullname` template.
   name: ""
+
 # -- Role Based Access Control.
 rbac:
   # -- Enable for features that need extra privileges.
@@ -629,6 +650,7 @@ listeners:
     # -- The port for internal client connections.
     port: 9093
     tls:
+      # Optional flag to override the global TLS enabled flag.
       # enabled: true
       cert: default
       requireClientAuth: false
@@ -640,25 +662,16 @@ listeners:
         # -- If undefined, `listeners.kafka.external.default.port` is used.
         advertisedPorts:
         - 31092
-  # -- HTTP API listeners (aka PandaProxy).
-  http:
-    enabled: true
-    port: 8082
-    kafkaEndpoint: default
-    tls:
-      # enabled: true
-      cert: default
-      requireClientAuth: false
-    external:
-      default:
-        # enabled: true
-        port: 8083
-        advertisedPorts:
-        - 30082
+        # -- Uncomment to define external tls
+        # tls:
+        #   # Optional flag to override the global TLS enabled flag.
+        #   # enabled: true
+        #   cert: external
   # -- RPC listener (this is never externally accessible).
   rpc:
     port: 33145
     tls:
+      # Optional flag to override the global TLS enabled flag.
       # enabled: true
       cert: default
       requireClientAuth: false
@@ -668,6 +681,7 @@ listeners:
     port: 8081
     kafkaEndpoint: default
     tls:
+      # Optional flag to override the global TLS enabled flag.
       # enabled: true
       cert: default
       requireClientAuth: false
@@ -677,6 +691,32 @@ listeners:
         port: 8084
         advertisedPorts:
         - 30081
+        # -- Uncomment to define external tls
+        # tls:
+        #   # Optional flag to override the global TLS enabled flag.
+        #   # enabled: true
+        #   cert: external
+  # -- HTTP API listeners (aka PandaProxy).
+  http:
+    enabled: true
+    port: 8082
+    kafkaEndpoint: default
+    tls:
+      # Optional flag to override the global TLS enabled flag.
+      # enabled: true
+      cert: default
+      requireClientAuth: false
+    external:
+      default:
+        # enabled: true
+        port: 8083
+        advertisedPorts:
+          - 30082
+        # -- Uncomment to define external tls
+        # tls:
+        # #  Optional flag to override the global TLS enabled flag.
+        # #  enabled: true
+        #   cert: external
 
 # Expert Config
 # Here be dragons!


### PR DESCRIPTION
Allow for secretRefs in tls definitions for certs to work without using cert-manager. Must create proper CA and tls certs to work. 

Fixes #352