### PR TITLE
bump redpanda appVersion from 23.1.1 to 23.1.7

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -45,7 +45,7 @@ jobs:
       matrix:
         version:
           - ""
-          - v22.3.15
+          - v22.3.16
           - v22.2.11
         testvaluespattern:
           - '0[1-3]*'

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -67,8 +67,8 @@ jobs:
       matrix:
         version:
           - ""
-          - v22.3.15
-          # - v22.2.11 takes too long. Only run nightly.
+          - v22.3.16
+          # - v22.2.x takes too long. Only run nightly.
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 version: 3.0.12
 
 # The app version is the default version of Redpanda to install.
-appVersion: v23.1.1
+appVersion: v23.1.7
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
 # pre-release. Our "-0" allows pre-releases to be matched.

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.12
+version: 4.0.0
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.7

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -489,6 +489,9 @@ than 1 core.
 {{- define "redpanda-atleast-23-1-1" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=23.1.1"))) -}}
 {{- end -}}
+{{- define "redpanda-atleast-23-1-2" -}}
+{{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=23.1.2"))) -}}
+{{- end -}}
 {{- define "redpanda-22-3-atleast-22-3-13" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "vectorized/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.3.13,<22.4"))) -}}
 {{- end -}}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -15,6 +15,38 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- $values := .Values }}
+
+{{- /*
+  It's impossible to do a rolling upgrade from not-tls-enabled rpc to tls-enabled rpc.
+*/ -}}
+{{- $check := list
+    (include "redpanda-atleast-23-1-2" .|fromJson).bool
+    (include "redpanda-22-3-atleast-22-3-13" .|fromJson).bool
+    (include "redpanda-22-2-atleast-22-2-10" .|fromJson).bool
+-}}
+{{- $wantedRPCTLS := (include "rpc-tls-enabled" . | fromJson).bool -}}
+{{- if and (not (mustHas true $check)) $wantedRPCTLS -}}
+  {{- fail (printf "Redpanda version v%s does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01." (include "redpanda.semver" .)) -}}
+{{- end -}}
+{{- $cm := lookup "v1" "ConfigMap" .Release.Namespace (include "redpanda.fullname" .) -}}
+{{- $redpandaYAML := dig "data" "redpanda.yaml" "" $cm | fromYaml -}}
+{{- $currentRPCTLS := dig "redpanda" "rpc_server_tls" "enabled" false $redpandaYAML -}}
+{{- if .Release.IsUpgrade -}}
+  {{- if ne $currentRPCTLS $wantedRPCTLS -}}
+    {{- if eq (get .Values "force" | default false) false -}}
+      {{- fail (join "\n" (list
+          (printf "\n\nError: Cannot do a rolling restart to enable or disable tls at the RPC layer: changing listeners.rpc.tls.enabled (redpanda.yaml:repdanda.rpc_server_tls.enabled) from %v to %v" $currentRPCTLS $wantedRPCTLS)
+          "***WARNING The following instructions will result in a short period of downtime."
+          "To accept this risk, run the upgrade again adding `--set force=true` and do the following:\n"
+          "While helm is upgrading the release, manually delete ALL the pods:"
+          (printf "    kubectl -n %s delete pod -l app.kubernetes.io/component=redpanda-statefulset" .Release.Namespace)
+          "\nIf you got here thinking rpc tls was already enabled, see technical service bulletin 2023-01."
+          ))
+      -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- $users := list -}}
 {{- if .Values.auth.sasl.enabled -}}
   {{- range $user := .Values.auth.sasl.users -}}


### PR DESCRIPTION
This PR will not pass CI as it requires manual steps.

If this chart is run with a Redpanda version affected by TSB 2023-01 and rpc tls is enabled, it will fail:
```
Error: UPGRADE FAILED: execution error at (redpanda/templates/statefulset.yaml:50:28): Redpanda version v23.1.1 does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01.
```

If this chart is run that tries to change the rpc tls enablement, it will fail:
```
Error: UPGRADE FAILED: execution error at (redpanda/templates/statefulset.yaml:50:28): 

Error: Cannot do a rolling restart to enable or disable tls at the RPC layer: changing listeners.rpc.tls.enabled (redpanda.yaml:repdanda.rpc_server_tls.enabled) from false to true
***WARNING The following instructions will result in a short period of downtime.
To accept this risk, run the upgrade again adding `--set force=true` and do the following:

While helm is upgrading the release, manually delete ALL the pods:
    kubectl -n rn delete pod -l app.kubernetes.io/component=redpanda-statefulset

If you got here thinking rpc tls was already enabled, see technical service bulletin 2023-01.
```

If they follow these instructions, the upgrade will succeed.

CI will fail because the prior redpanda version that is being tested could not set the rpc tls correctly.

Fixes #442 