### PR TITLE
k8s: Rename authorization Redpanda configuration.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ admin.conf
 
 # templated ci values
 charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml
+charts/redpanda/templates/external-service.yaml
+charts/redpanda/templates/external-tls-secret.yaml
+charts/redpanda/templates/some-users-updated.yaml
+charts/redpanda/templates/some-users.yaml

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.23
+version: 4.0.24
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.10

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,7 +23,7 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-flags-no-sasl" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-acl-user-flags" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -105,6 +105,14 @@ Generate configuration needed for rpk
 {{- toJson (dict "bool" (and (dig "tls" "enabled" .Values.tls.enabled $listener) (not (empty (dig "tls" "cert" "" $listener))))) -}}
 {{- end -}}
 
+{{- define "admin-external-tls-enabled" -}}
+{{- toJson (dict "bool" (and (dig "tls" "enabled" (include "admin-internal-tls-enabled" . | fromJson).bool .listener) (not (empty (include "admin-external-tls-cert" .))))) -}}
+{{- end -}}
+
+{{- define "admin-external-tls-cert" -}}
+{{- dig "tls" "cert" .Values.listeners.admin.tls.cert .listener -}}
+{{- end -}}
+
 {{- define "kafka-internal-tls-enabled" -}}
 {{- $listener := .Values.listeners.kafka -}}
 {{- toJson (dict "bool" (and (dig "tls" "enabled" .Values.tls.enabled $listener) (not (empty (dig "tls" "cert" "" $listener))))) -}}
@@ -351,8 +359,12 @@ than 1 core.
   {{- end -}}
 {{- end -}}
 
-{{- define "api-urls" -}}
-{{ include "redpanda.internal.domain" .}}:{{ .Values.listeners.admin.port }}
+{{- define "admin-api-urls" -}}
+{{ printf "${SERVICE_NAME}.%s" (include "redpanda.internal.domain" .) }}:{{.Values.listeners.admin.port }}
+{{- end -}}
+
+{{- define "admin-api-service-url" -}}
+{{ include "redpanda.internal.domain" .}}:{{.Values.listeners.admin.port }}
 {{- end -}}
 
 {{- define "sasl-mechanism" -}}
@@ -362,7 +374,7 @@ than 1 core.
 {{- define "rpk-flags" -}}
   {{- $root := . -}}
   {{- $admin := list -}}
-  {{- $admin = concat $admin (list "--api-urls" (include "api-urls" . )) -}}
+  {{- $admin = concat $admin (list "--api-urls" (include "admin-api-urls" . )) -}}
   {{- if (include "admin-internal-tls-enabled" . | fromJson).bool -}}
     {{- $admin = concat $admin (list
       "--admin-api-tls-enabled"
@@ -413,6 +425,34 @@ than 1 core.
 {{- define "rpk-flags-no-sasl" -}}
 {{- $flags := fromJson (include "rpk-flags" .) -}}
 {{ join " " (list $flags.brokers $flags.admin $flags.kafka)}}
+{{- end -}}
+
+{{- define "rpk-flags-no-brokers-no-sasl" -}}
+{{- $flags := fromJson (include "rpk-flags" .) -}}
+{{ $flags.admin }}
+{{- end -}}
+
+{{- define "rpk-acl-user-flags" }}
+{{- $root := . -}}
+{{- $admin := list -}}
+  {{- $apiUrls := list -}}
+  {{- range $i := untilStep 0 (.Values.statefulset.replicas|int) 1 -}}
+    {{- $apiUrls = concat $apiUrls (list (printf "%s-%d.%s:%d"
+      (include "redpanda.fullname" $root)
+      $i
+      (include "redpanda.internal.domain" $root)
+      (int $root.Values.listeners.admin.port)))
+    -}}
+  {{- end -}}
+  {{- $admin = concat $admin (list "--api-urls" (join "," $apiUrls)) -}}
+  {{- if (include "admin-internal-tls-enabled" . | fromJson).bool -}}
+    {{- $admin = concat $admin (list
+      "--admin-api-tls-enabled"
+      "--admin-api-tls-truststore"
+      (printf "/etc/tls/certs/%s/ca.crt" .Values.listeners.admin.tls.cert))
+    -}}
+  {{- end -}}
+{{ join " " $admin }}
 {{- end -}}
 
 {{- define "rpk-flags-no-admin-no-sasl" -}}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -14,6 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+{{- $root := . }}
 {{- $values := .Values }}
 
 {{- /*
@@ -48,7 +49,7 @@ limitations under the License.
 {{- end -}}
 
 {{- $users := list -}}
-{{- if .Values.auth.sasl.enabled -}}
+{{- if (include "sasl-enabled" . | fromJson).bool -}}
   {{- range $user := .Values.auth.sasl.users -}}
     {{- $users = append $users $user.name -}}
   {{- end -}}
@@ -65,7 +66,8 @@ metadata:
 {{- end }}
 data:
   bootstrap.yaml: |
-    enable_sasl: {{ dig "sasl" "enabled" false .Values.auth }}
+    kafka_enable_authorization: {{ (include "sasl-enabled" . | fromJson).bool }}
+    enable_sasl: {{ (include "sasl-enabled" . | fromJson).bool }}
   {{- if $users }}
     superusers: {{ toJson $users }}
   {{- end }}
@@ -109,7 +111,8 @@ data:
       enable_rack_awareness: true
   {{- end }}
 {{- end }}
-      enable_sasl: {{ dig "sasl" "enabled" false .Values.auth }}
+      kafka_enable_authorization: {{ (include "sasl-enabled" . | fromJson).bool }}
+      enable_sasl: {{ (include "sasl-enabled" . | fromJson).bool }}
   {{- if $users }}
       superusers: {{ toJson $users }}
   {{- end }}
@@ -141,40 +144,18 @@ data:
 {{- /* Admin API */}}
 {{- $service := .Values.listeners.admin }}
       admin:
-        name: admin
-        address: 0.0.0.0
-        port: {{ $service.port }}
-{{- if (include "admin-internal-tls-enabled" . | fromJson).bool }}
-      admin_api_tls:
-        name: admin
-        enabled: true
-        cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
-        key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
-        require_client_auth: {{ $service.tls.requireClientAuth }}
-  {{- $cert := get .Values.tls.certs $service.tls.cert }}
-  {{- if empty $cert }}
-    {{- fail (printf "Certificate, '%s', used but not defined")}}
-  {{- end }}
-  {{- if $cert.caEnabled }}
-        truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
-  {{- else }}
-        {{- /* This is a required field so we use the default in the redpanda debian container */}}
-        truststore_file: /etc/ssl/certs/ca-certificates.crt
-  {{- end }}
-{{- end }}
-{{- /* Kafka API */}}
-{{- $service = .Values.listeners.kafka }}
-      kafka_api:
         - name: internal
           address: 0.0.0.0
           port: {{ $service.port }}
-{{- range $name, $listener := .Values.listeners.kafka.external }}
+{{- range $name, $listener := $service.external }}
+{{- if and $listener.port $name }}
         - name: {{ $name }}
           address: 0.0.0.0
           port: {{ $listener.port }}
 {{- end }}
-      kafka_api_tls:
-{{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
+{{- end }}
+      admin_api_tls:
+{{- if (include "admin-internal-tls-enabled" . | fromJson).bool }}
         - name: internal
           enabled: true
           cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
@@ -187,11 +168,70 @@ data:
   {{- if $cert.caEnabled }}
           truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
   {{- else }}
-          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+        {{- /* This is a required field so we use the default in the redpanda debian container */}}
           truststore_file: /etc/ssl/certs/ca-certificates.crt
   {{- end }}
 {{- end }}
 {{- range $name, $listener := $service.external }}
+  {{- $k := dict "Values" $values "listener" $listener }}
+  {{- if (include "admin-external-tls-enabled" $k | fromJson).bool }}
+    {{- $mtls := dig "tls" "requireClientAuth" false $listener }}
+    {{- $mtls = dig "tls" "requireClientAuth" $mtls $k }}
+    {{- $certName := include "admin-external-tls-cert" $k }}
+    {{- $certPath := printf "/etc/tls/certs/%s" $certName }}
+    {{- $cert := get $values.tls.certs $certName }}
+    {{- if empty $cert }}
+      {{- fail (printf "Certificate, '%s', used but not defined" $certName)}}
+    {{- end }}
+        - name: {{ $name }}
+          enabled: true
+          cert_file: {{ $certPath }}/tls.crt
+          key_file: {{ $certPath }}/tls.key
+          require_client_auth: {{ $mtls }}
+    {{- if $cert.caEnabled }}
+          truststore_file: {{ $certPath }}/ca.crt
+    {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- /* Kafka API */}}
+{{- $kafkaService := .Values.listeners.kafka }}
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: {{ $kafkaService.port }}
+          {{- if or (include "sasl-enabled" $root | fromJson).bool $kafkaService.authenticationMethod }}
+          authentication_method: {{ default "sasl" $kafkaService.authenticationMethod }}
+          {{- end }}
+{{- range $name, $listener := $kafkaService.external }}
+        - name: {{ $name }}
+          address: 0.0.0.0
+          port: {{ $listener.port }}
+          {{- if or (include "sasl-enabled" $root | fromJson).bool $listener.authenticationMethod }}
+          authentication_method: {{ default "sasl" $listener.authenticationMethod }}
+          {{- end }}
+{{- end }}
+      kafka_api_tls:
+{{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/tls.crt
+          key_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/tls.key
+          require_client_auth: {{ $kafkaService.tls.requireClientAuth }}
+  {{- $cert := get .Values.tls.certs $kafkaService.tls.cert }}
+  {{- if empty $cert }}
+    {{- fail (printf "Certificate, '%s', used but not defined")}}
+  {{- end }}
+  {{- if $cert.caEnabled }}
+          truststore_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/ca.crt
+  {{- else }}
+          {{- /* This is a required field so we use the default in the redpanda debian container */}}
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+  {{- end }}
+{{- end }}
+{{- range $name, $listener := $kafkaService.external }}
   {{- $k := dict "Values" $values "listener" $listener }}
   {{- if (include "kafka-external-tls-enabled" $k | fromJson).bool }}
     {{- $mtls := dig "tls" "requireClientAuth" false $listener }}
@@ -256,43 +296,49 @@ data:
 {{- end }}
 {{- /* Schema Registry API */}}
 {{- if .Values.listeners.schemaRegistry.enabled }}
-  {{- $service = .Values.listeners.schemaRegistry }}
+  {{- $schemaRegistryService := .Values.listeners.schemaRegistry }}
     schema_registry:
       schema_registry_api:
         - name: internal
           address: 0.0.0.0
-          port: {{ $service.port }}
-  {{- range $name, $listener := $service.external }}
+          port: {{ $schemaRegistryService.port }}
+          {{- if or (include "sasl-enabled" $root | fromJson).bool $schemaRegistryService.authenticationMethod }}
+          authentication_method: {{ default "http_basic" $schemaRegistryService.authenticationMethod }}
+          {{- end }}
+  {{- range $name, $listener := $schemaRegistryService.external }}
         - name: {{ $name }}
           address: 0.0.0.0
           {{- /*
             when upgrading from an older version that had a missing port, fail if we cannot guess a default
             this should work in all cases as the older versions would have failed with multiple listeners anyway
           */}}
-          {{- if and (empty $listener.port) (ne (len $service.external) 1) }}
+          {{- if and (empty $listener.port) (ne (len $schemaRegistryService.external) 1) }}
             {{- fail "missing required port for schemaRegistry listener $listener.name" }}
           {{- end }}
           port: {{ $listener.port | default 8084 }}
+          {{- if or (include "sasl-enabled" $root | fromJson).bool $listener.authenticationMethod }}
+          authentication_method: {{ default "http_basic" $listener.authenticationMethod }}
+          {{- end }}
   {{- end }}
       schema_registry_api_tls:
   {{- if (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool }}
         - name: internal
           enabled: true
-          cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
-          key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
-          require_client_auth: {{ $service.tls.requireClientAuth }}
-    {{- $cert := get .Values.tls.certs $service.tls.cert }}
+          cert_file: /etc/tls/certs/{{ $schemaRegistryService.tls.cert }}/tls.crt
+          key_file: /etc/tls/certs/{{ $schemaRegistryService.tls.cert }}/tls.key
+          require_client_auth: {{ $schemaRegistryService.tls.requireClientAuth }}
+    {{- $cert := get .Values.tls.certs $schemaRegistryService.tls.cert }}
     {{- if empty $cert }}
       {{- fail (printf "Certificate, '%s', used but not defined")}}
     {{- end }}
     {{- if $cert.caEnabled }}
-          truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+          truststore_file: /etc/tls/certs/{{ $schemaRegistryService.tls.cert }}/ca.crt
     {{- else }}
           {{- /* This is a required field so we use the default in the redpanda debian container */}}
           truststore_file: /etc/ssl/certs/ca-certificates.crt
     {{- end }}
   {{- end }}
-  {{- range $name, $listener := $service.external }}
+  {{- range $name, $listener := $schemaRegistryService.external }}
     {{- $k := dict "Values" $values "listener" $listener }}
     {{- if (include "schemaRegistry-external-tls-enabled" $k | fromJson).bool }}
       {{- $mtls := dig "tls" "requireClientAuth" false $listener }}
@@ -319,36 +365,42 @@ data:
 {{- end }}
 {{- /* HTTP Proxy */}}
 {{- if .Values.listeners.http.enabled }}
-  {{- $service = .Values.listeners.http }}
+  {{- $HTTPService := .Values.listeners.http }}
     pandaproxy:
       pandaproxy_api:
         - name: internal
           address: 0.0.0.0
-          port: {{ $service.port }}
-  {{- range $name, $listener := $service.external }}
+          port: {{ $HTTPService.port }}
+          {{- if or (include "sasl-enabled" $root | fromJson).bool $HTTPService.authenticationMethod }}
+          authentication_method: {{ default "http_basic" $HTTPService.authenticationMethod }}
+          {{- end }}
+  {{- range $name, $listener := $HTTPService.external }}
         - name: {{ $name }}
           address: 0.0.0.0
           port: {{ $listener.port }}
+          {{- if or (include "sasl-enabled" $root | fromJson).bool $listener.authenticationMethod }}
+          authentication_method: {{ default "http_basic" $listener.authenticationMethod }}
+          {{- end }}
   {{- end }}
       pandaproxy_api_tls:
   {{- if (include "http-internal-tls-enabled" . | fromJson).bool }}
         - name: internal
           enabled: true
-          cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
-          key_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.key
-          require_client_auth: {{ $service.tls.requireClientAuth }}
-    {{- $cert := get .Values.tls.certs $service.tls.cert }}
+          cert_file: /etc/tls/certs/{{ $HTTPService.tls.cert }}/tls.crt
+          key_file: /etc/tls/certs/{{ $HTTPService.tls.cert }}/tls.key
+          require_client_auth: {{ $HTTPService.tls.requireClientAuth }}
+    {{- $cert := get .Values.tls.certs $HTTPService.tls.cert }}
     {{- if empty $cert }}
       {{- fail (printf "Certificate, '%s', used but not defined")}}
     {{- end }}
     {{- if $cert.caEnabled }}
-          truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
+          truststore_file: /etc/tls/certs/{{ $HTTPService.tls.cert }}/ca.crt
     {{- else }}
           {{- /* This is a required field so we use the default in the redpanda debian container */}}
           truststore_file: /etc/ssl/certs/ca-certificates.crt
     {{- end }}
   {{- end }}
-  {{- range $name, $listener := $service.external }}
+  {{- range $name, $listener := $HTTPService.external }}
     {{- $k := dict "Values" $values "listener" $listener }}
     {{- if (include "http-external-tls-enabled" $k | fromJson).bool }}
       {{- $mtls := dig "tls" "requireClientAuth" false $listener }}

--- a/charts/redpanda/templates/console/deployment.yaml
+++ b/charts/redpanda/templates/console/deployment.yaml
@@ -21,7 +21,11 @@ limitations under the License.
 {{ $command := list }}
 {{ if (include "sasl-enabled" . | fromJson).bool }}
   {{ $command = concat $command (list "sh" "-xc") }}
-  {{ $command = append $command (printf "set -e; IFS=: read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM < $(find /mnt/users/* -print); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-%s}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM; /app/console $@" ( include "sasl-mechanism" . )) }}
+  {{ $consoleSASLConfig := (printf "set -e; IFS=: read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM < $(find /mnt/users/* -print); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-%s}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;" ( include "sasl-mechanism" . )) }}
+  {{ $consoleSASLConfig = cat $consoleSASLConfig " export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;" }}
+  {{ $consoleSASLConfig = cat $consoleSASLConfig " export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;" }}
+  {{ $consoleSASLConfig = cat $consoleSASLConfig " /app/console $@" }}
+  {{ $command = append $command $consoleSASLConfig }}
   {{ $command = append $command "--" }}
   {{ $extraVolumes = append $extraVolumes (dict
     "name" (printf "%s-users" (include "redpanda.fullname" .))
@@ -129,7 +133,7 @@ limitations under the License.
 )}}
 {{ $adminAPI = append $adminAPI (dict
   "name" "REDPANDA_ADMINAPI_URLS"
-  "value" (print (include "admin-http-protocol" .) "://" (include "api-urls" .))
+  "value" (print (include "admin-http-protocol" .) "://" (include "admin-api-service-url" .))
 )}}
 
 {{ $extraEnv := concat $kafkaTLS $schemaRegistryTLS $adminAPI}}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.post_upgrade_job.enabled }}
-{{- $rpkFlags := include "rpk-flags-no-sasl" . }}
+{{- $rpkFlags := include "rpk-acl-user-flags" . }}
 {{- $sasl := .Values.auth.sasl }}
 {{- $root := deepCopy . }}
 apiVersion: batch/v1

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -75,7 +75,7 @@ stringData:
     # Setup and export SASL bootstrap-user
     IFS=":" read -r USER_NAME PASSWORD MECHANISM < $(find /etc/secrets/users/* -print)
     MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
-    rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} || true
+    rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-brokers-no-sasl" $ }} || true
 {{- end }}
 
   preStop.sh: |-
@@ -158,7 +158,7 @@ stringData:
     
     ready_result_exit_code=1
     while [[ ${ready_result_exit_code} -ne 0 ]]; do
-      ready_result=$(rpk cluster health {{ (include "rpk-flags" . | fromJson).admin }} | grep 'Healthy:.*true' 2>&1) && ready_result_exit_code=$?
+      ready_result=$(rpk cluster health {{ include "rpk-acl-user-flags" . }} | grep 'Healthy:.*true' 2>&1) && ready_result_exit_code=$?
       sleep 2
     done
     
@@ -192,21 +192,21 @@ stringData:
           fi
           echo "Creating user ${USER_NAME}..."
           MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
-          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ include "rpk-acl-user-flags" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
           if [[ $creation_result_exit_code -ne 0 ]]; then
             # Check if the stderr contains "User already exists"
             # this error occurs when password has changed
             if [[ $creation_result == *"User already exists"* ]]; then
               echo "Update user ${USER_NAME}"
               # we will try to update by first deleting
-              deletion_result=$(rpk acl user delete ${USER_NAME} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              deletion_result=$(rpk acl user delete ${USER_NAME}  {{ include "rpk-acl-user-flags" $ }} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
               if [[ $deletion_result_exit_code -ne 0 ]]; then
                 echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
                 READ_LIST_SUCCESS=1
                 break
               fi
               # Now we update the user
-              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM}  {{ include "rpk-acl-user-flags" $ }} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
               if [[ $update_result_exit_code -ne 0 ]]; then
                 echo "updating user ${USER_NAME} failed: ${update_result}"
                 READ_LIST_SUCCESS=1

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -236,7 +236,7 @@ spec:
                 - -c
                 - |
                   set -e
-                  RESULT=$(curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://localhost:{{ .Values.listeners.admin.port }}/v1/status/ready")
+                  RESULT=$(curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready")
                   echo $RESULT
                   echo $RESULT | grep ready
             initialDelaySeconds: {{ .Values.statefulset.startupProbe.initialDelaySeconds }}
@@ -248,7 +248,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://localhost:{{ .Values.listeners.admin.port }}/v1/status/ready"
+                - curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready"
             initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.livenessProbe.periodSeconds }}

--- a/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
+++ b/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
@@ -56,7 +56,7 @@ spec:
           -CAfile {{ printf "/etc/tls/certs/%s" $name }}/ca.crt \
           {{- end }}
           -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key \
-          -connect {{ include "api-urls" $root }}
+          -connect {{ include "admin-api-urls" $root }}
         {{- end }}
 
         {{- if eq $cert.secretRef.name "external-tls-secret" }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -51,7 +51,7 @@ spec:
         - -c
         - |
           set -xe
-          until rpk acl user delete myuser {{ include "rpk-common-flags" . }}
+          until rpk acl user delete myuser {{ include "rpk-acl-user-flags" . }}
             do sleep 2
           done
           sleep 3
@@ -63,7 +63,7 @@ spec:
           {{ include "rpk-topic-create" $rpk }}
           {{ include "rpk-topic-describe" $rpk }}
           {{ include "rpk-topic-delete" $rpk }}
-          rpk acl user delete myuser {{ include "rpk-common-flags" . }}
+          rpk acl user delete myuser {{ include "rpk-acl-user-flags" . }}
       volumeMounts:
         - name: config
           mountPath: /etc/redpanda

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -53,7 +53,7 @@ spec:
           # check that the users list did update
           ready_result_exit_code=1
           while [[ ${ready_result_exit_code} -ne 0 ]]; do
-            ready_result=$(rpk acl user list {{ (include "rpk-flags" . | fromJson).admin }} | grep anotheranotherme 2>&1) && ready_result_exit_code=$?
+            ready_result=$(rpk acl user list {{ include "rpk-acl-user-flags" . }} | grep anotheranotherme 2>&1) && ready_result_exit_code=$?
             sleep 2
           done
           

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -904,6 +904,10 @@
                       "items": {
                         "type": "integer"
                       }
+                    },
+                    "authenticationMethod": {
+                      "type": ["string", "null"],
+                      "pattern": "sasl|none|mtls_identity"
                     }
                   }
                 }
@@ -926,6 +930,10 @@
                   "type": "boolean"
                 }
               }
+            },
+            "authenticationMethod": {
+              "type": ["string", "null"],
+              "pattern": "sasl|none|mtls_identity"
             }
           }
         },
@@ -949,6 +957,10 @@
               "type": "string",
               "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
             },
+            "authenticationMethod": {
+              "type": ["string", "null"],
+              "pattern": "http_basic|none"
+            },
             "external": {
               "type": "object",
               "minProperties": 1,
@@ -971,6 +983,10 @@
                       "items": {
                         "type": "integer"
                       }
+                    },
+                    "authenticationMethod": {
+                      "type": ["string", "null"],
+                      "pattern": "http_basic|none"
                     }
                   }
                 }
@@ -1046,6 +1062,10 @@
               "type": "string",
               "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
             },
+            "authenticationMethod": {
+              "type": ["string", "null"],
+              "pattern": "http_basic|none"
+            },
             "external": {
               "type": "object",
               "minProperties": 1,
@@ -1065,6 +1085,10 @@
                       "items": {
                         "type": "integer"
                       }
+                    },
+                    "authenticationMethod": {
+                      "type": ["string", "null"],
+                      "pattern": "http_basic|none"
                     }
                   }
                 }

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -647,6 +647,7 @@ listeners:
     external:
       # -- Name of the external listener.
       default:
+        port: 9645
         # Override the global `external.enabled` for only this listener.
         # enabled: true
         # -- The port advertised to this listener's external clients.
@@ -670,6 +671,8 @@ listeners:
   kafka:
     # -- The port for internal client connections.
     port: 9093
+    # default is "sasl"
+    authenticationMethod:
     tls:
       # Optional flag to override the global TLS enabled flag.
       # enabled: true
@@ -686,6 +689,8 @@ listeners:
         tls:
           # enabled: true
           cert: external
+        # default is "sasl"
+        authenticationMethod:
   # -- RPC listener (this is never externally accessible).
   rpc:
     port: 33145
@@ -699,6 +704,8 @@ listeners:
     enabled: true
     port: 8081
     kafkaEndpoint: default
+    # default is "http_basic"
+    authenticationMethod:
     tls:
       # Optional flag to override the global TLS enabled flag.
       # enabled: true
@@ -713,11 +720,15 @@ listeners:
         tls:
           # enabled: true
           cert: external
+        # default is "http_basic"
+        authenticationMethod:
   # -- HTTP API listeners (aka PandaProxy).
   http:
     enabled: true
     port: 8082
     kafkaEndpoint: default
+    # default is "http_basic"
+    authenticationMethod:
     tls:
       # Optional flag to override the global TLS enabled flag.
       # enabled: true
@@ -732,6 +743,8 @@ listeners:
         tls:
           # enabled: true
           cert: external
+        # default is "http_basic"
+        authenticationMethod:
 
 # Expert Config
 # Here be dragons!


### PR DESCRIPTION
The `enable_sasl` config property is old version for kafka listener authorization enablement flag. The `kafka_enable_authorization` should be use insted.

REF:
https://github.com/redpanda-data/redpanda/pull/5292
https://docs.redpanda.com/docs/manage/security/authentication/