### PR TITLE
Omit empty value in Redpanda configuration

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.2
+version: 4.0.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.7

--- a/charts/redpanda/ci/11-none-existent-config-options-with-empty-values.yaml
+++ b/charts/redpanda/ci/11-none-existent-config-options-with-empty-values.yaml
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+license_key: "dGVzdAo=.dGVzdAo="
+
+storage:
+  tieredConfig:
+    cloud_storage_enabled: true
+    false_value: false
+    zero_value: 0
+    null_value: null
+    empty_array_value: []
+    empty_map_value: {}
+    empty_string_value: ""
+
+config:
+  cluster:
+    false_value: false
+    zero_value: 0
+    null_value: null
+    empty_array_value: []
+    empty_map_value: {}
+    empty_string_value: ""
+  tunable:
+    false_value: false
+    zero_value: 0
+    null_value: null
+    empty_array_value: []
+    empty_map_value: {}
+    empty_string_value: ""
+  node:
+    false_value: false
+    zero_value: 0
+    null_value: null
+    empty_array_value: []
+    empty_map_value: {}
+    empty_string_value: ""

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -450,11 +450,20 @@ than 1 core.
 {{- $tunable := dig "tunable" dict .Values.config -}}
 {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool -}}
 {{- toYaml $tunable | nindent 4 -}}
+{{- range $key, $element := $tunable }}
+  {{- if $element }}
+    {{ $key }}: {{ $element | toYaml }}
+  {{- end }}
+{{- end }}
 {{- else if (include "redpanda-atleast-22-2-0" . | fromJson).bool -}}
 {{- $tunable = unset $tunable "log_segment_size_min" -}}
 {{- $tunable = unset $tunable "log_segment_size_max" -}}
 {{- $tunable = unset $tunable "kafka_batch_max_bytes" -}}
-{{- toYaml $tunable | nindent 4 -}}
+{{- range $key, $element := $tunable }}
+  {{- if $element }}
+    {{ $key }}: {{ $element | toYaml }}
+  {{- end }}
+{{- end }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -70,7 +70,11 @@ data:
     superusers: {{ toJson $users }}
   {{- end }}
   {{- with (dig "cluster" dict .Values.config) }}
-    {{- toYaml . | nindent 4 }}
+      {{- range $key, $element := .}}
+        {{- if $element }}
+    {{ $key }}: {{ $element | toYaml }}
+        {{- end }}
+      {{- end }}
   {{- end }}
   {{- include "tunable" . }}
   {{- if and (not (hasKey .Values.config.cluster "storage_min_free_bytes")) ((include "redpanda-atleast-22-2-0" . | fromJson).bool) }}
@@ -79,10 +83,13 @@ data:
 {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
   {{- $tieredStorageConfig := deepCopy .Values.storage.tieredConfig }}
   {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_cache_directory" }}
-  {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
-    {{- toYaml $tieredStorageConfig | nindent 4 }}
-  {{- else }}
-    {{- unset $tieredStorageConfig "cloud_storage_credentials_source" | toYaml | nindent 4 }}
+  {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
+    {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_credentials_source"}}
+  {{- end }}
+  {{- range $key, $element := $tieredStorageConfig}}
+    {{- if $element }}
+    {{ $key }}: {{ $element | toYaml }}
+    {{- end }}
   {{- end }}
 {{- end }}
   redpanda.yaml: |
@@ -107,16 +114,28 @@ data:
       superusers: {{ toJson $users }}
   {{- end }}
   {{- with (dig "cluster" dict .Values.config) }}
-      {{- toYaml . | nindent 6 }}
+      {{- range $key, $element := .}}
+        {{- if $element }}
+      {{ $key }}: {{ $element | toYaml }}
+        {{- end }}
+      {{- end }}
   {{- end }}
   {{- with (dig "tunable" dict .Values.config) }}
-      {{- toYaml . | nindent 6 }}
+      {{- range $key, $element := .}}
+        {{- if $element }}
+      {{ $key }}: {{ $element | toYaml }}
+        {{- end }}
+      {{- end }}
   {{- end }}
   {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
       storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
   {{- end }}
       {{- with dig "node" dict .Values.config }}
-      {{- . | toYaml | nindent 6 }}
+      {{- range $key, $element := .}}
+        {{- if $element }}
+      {{ $key }}: {{ $element | toYaml }}
+        {{- end }}
+      {{- end }}
       {{- end }}
 {{- /* LISTENERS */}}
 {{- /* Admin API */}}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -64,7 +64,9 @@ spec:
           - |
             rpk cluster config import -f /tmp/base-config/bootstrap.yaml {{ $rpkFlags }}
 {{- range $key, $value := .Values.config.cluster }}
+  {{- if $value }}
             rpk cluster config set {{ $key }} {{ $value }} {{ $rpkFlags }}
+  {{- end }}
 {{- end }}
 {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
             rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }} {{ $rpkFlags }}


### PR DESCRIPTION
From go template documentation:
```
The empty values are false, 0, any nil pointer or interface value,
and any array, slice, map, or string of length zero.
```

Fixes https://github.com/redpanda-data/helm-charts/issues/405