### PR TITLE
feat: make login-jwt-secret configurable

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.6.1
+version: 0.6.2
 
 # The app version is the version of the Chart application
 appVersion: v2.2.3

--- a/charts/console/templates/secret.yaml
+++ b/charts/console/templates/secret.yaml
@@ -22,7 +22,7 @@ data:
   kafka-schemaregistry-tls-key: {{ .Values.secret.kafka.schemaRegistryTlsKey | default "" | b64enc | quote }}
 
   # Login
-  login-jwt-secret: {{ randAlphaNum 32 | b64enc | quote }}
+  login-jwt-secret: {{ .Values.secret.login.jwtSecret | default (randAlphaNum 32) | b64enc | quote }}
   login-google-oauth-client-secret: {{ .Values.secret.login.google.clientSecret | default "" | b64enc | quote }}
   login-google-groups-service-account.json: {{ .Values.secret.login.google.groupsServiceAccount | default "" | b64enc | quote }}
   login-github-oauth-client-secret: {{ .Values.secret.login.github.clientSecret | default "" | b64enc | quote }}

--- a/charts/console/values.schema.json
+++ b/charts/console/values.schema.json
@@ -209,6 +209,9 @@
                 "login": {
                     "type": "object",
                     "properties": {
+                        "jwtSecret": {
+                            "type": "string"
+                        },
                         "github": {
                             "type": "object"
                         },

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -177,6 +177,8 @@ secret:
   # Enterprise version secrets
   # - SSO secrets (Enterprise version).
   login:
+    # Configurable JWT value
+    jwtSecret: ""
     google: {}
       # clientSecret:
       # groupsServiceAccount:


### PR DESCRIPTION
Required in GitOps tools such as ArgoCD https://argo-cd.readthedocs.io/en/stable/user-guide/helm/#random-data

The random value is regenerated every time the comparison is made, any application which makes use of the randAlphaNum function will always be in an OutOfSync state.