### PR TITLE
feat: allow additional flags to be added to main command

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.4
+version: 4.0.5
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.7

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -265,6 +265,9 @@ spec:
             - --reserve-memory={{ template "redpanda-reserve-memory" . }}M
             - --default-log-level={{ .Values.logging.logLevel }}
             - --advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}
+            {{- with .Values.statefulset.additionalRedpandaCmdFlags }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
           ports:
 {{- range $name, $listener := .Values.listeners }}
             - name: {{ lower $name }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -712,6 +712,9 @@
               }
             }
           }
+        },
+        "additionalRedpandaCmdFlags": {
+          "type": "array"
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -552,6 +552,9 @@ statefulset:
   initContainerImage:
     repository: busybox
     tag: latest
+  # -- Additional flags to pass to redpanda,
+  additionalRedpandaCmdFlags: []
+#    - --unsafe-bypass-fsync
 
 # -- Service account management.
 serviceAccount:


### PR DESCRIPTION
Fixes #445 

Allow arbitrary flags to be passed to the redpanda command.