### PR TITLE
Testing external listeners with secret certs

### DIFF
--- a/.github/create_tls.sh
+++ b/.github/create_tls.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+DOMAIN=${1-}
+
+rm tls.crt tls.csr tls.key \
+  ca.crt ca.key cert.conf csr.conf \
+  ca.srl || true
+
+# if domain was clean, we wanted to just clean everything.
+if [ "${DOMAIN}" = "clean" ]; then
+  rm external-tls-secret.yaml internal-tls-secret.yaml || true
+  exit 0
+fi
+
+# check here if we have openssl, exit immediately if not
+if ! command -v openssl &> /dev/null
+then
+  echo "cannot run without 'openssl' installed"
+  exit 1
+fi
+
+# assume we are creating an external tls secret first
+SECRET_NAME=external-tls-secret
+ALT_NAMES="DNS.1 = ${DOMAIN}
+DNS.2 = *.${DOMAIN}
+"
+
+# if we do not have a domain, then assume we are creating an internal tls secret
+if [ -z ${DOMAIN} ]; then
+   echo "internal tls requested"
+   SECRET_NAME=internal-tls-secret
+   ALT_NAMES='
+DNS.1 = "*.svc.cluster.local"
+DNS.2 = "svc.cluster.local"
+DNS.3 = "*.svc.cluster.local."
+DNS.4 = "svc.cluster.local."
+   '
+fi
+
+# create CA crt here
+openssl req -x509 -sha256 -days 365 -nodes -newkey rsa:2048 -subj "/C=US" -keyout ca.key -out ca.crt
+# create TLS key
+openssl genrsa -out tls.key 2048
+
+# creating Certificate Signing Request (CSR) configuration file
+cat > csr.conf <<EOF
+[ req ]
+default_bits = 2048
+prompt = no
+default_md = sha256
+req_extensions = req_ext
+distinguished_name = dn
+
+[ dn ]
+C = US
+
+[ req_ext ]
+subjectAltName = @alt_names
+
+[ alt_names ]
+${ALT_NAMES}
+
+EOF
+
+# with the CSR create a TLS CSR
+openssl req -new -key tls.key -out tls.csr -config csr.conf
+
+# create a Certificate Configuration file
+cat > cert.conf <<EOF
+
+authorityKeyIdentifier=keyid,issuer
+basicConstraints=CA:FALSE
+keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+subjectAltName = @alt_names
+
+[alt_names]
+${ALT_NAMES}
+
+EOF
+
+# Use the configuration file to create the tls.crt and sign it with the ca.crt
+openssl x509 -req -in tls.csr -CA ca.crt -CAkey ca.key -CAcreateserial -out tls.crt -days 365 -sha256 -extfile cert.conf
+
+# Create a secret object store to file at first
+kubectl create secret generic ${SECRET_NAME} \
+--from-file=ca.crt=ca.crt \
+--from-file=tls.crt=tls.crt \
+--from-file=tls.key=tls.key \
+--dry-run=client -o yaml > ${SECRET_NAME}.yaml.tmp
+
+kubectl annotate -f ${SECRET_NAME}.yaml.tmp \
+helm.sh/hook-delete-policy="before-hook-creation" \
+helm.sh/hook="pre-install,pre-upgrade" \
+helm.sh/hook-weight="-100" \
+--local --dry-run=none -o yaml > ${SECRET_NAME}.yaml
+
+rm ${SECRET_NAME}.yaml.tmp
+
+echo ${SECRET_NAME}

--- a/.github/external-service.yaml
+++ b/.github/external-service.yaml
@@ -1,0 +1,31 @@
+# This service is to help simulate calling external services but within the pod
+# In addition, it takes advantage of the dns properties of a cluster
+# where one could call <name-of-service>:<port> to contact an endpoint
+# thus dns can also be tested with this service.
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.external.domain | default "random-domain" }}
+  annotations:
+    helm.sh/hook: pre-install,pre-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-100"
+spec:
+  ports:
+    - name: kafka-default
+      protocol: TCP
+      targetPort: {{ .Values.listeners.kafka.external.default.port }}
+      port: {{ first .Values.listeners.kafka.external.default.advertisedPorts }}
+    - name: http-default
+      protocol: TCP
+      targetPort: {{ .Values.listeners.http.external.default.port }}
+      port: {{ first .Values.listeners.http.external.default.advertisedPorts }}
+    - name: schema-default
+      protocol: TCP
+      targetPort: {{ .Values.listeners.schemaRegistry.external.default.port }}
+      port: {{ first .Values.listeners.schemaRegistry.external.default.advertisedPorts }}
+  selector:
+    app.kubernetes.io/name: {{ template "redpanda.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -125,6 +125,17 @@ jobs:
         run: .github/annotate_kind_nodes.sh chart-testing
         if: steps.list-changed.outputs.changed == 'true'
 
+      - name: Create tls helm templates
+        run: |
+          .github/create_tls.sh "random-domain"
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Move tls files to template
+        run: |
+          mv external-tls-secret.yaml charts/redpanda/templates/
+          cp .github/external-service.yaml charts/redpanda/templates/
+        if: steps.list-changed.outputs.changed == 'true'
+
       - name: install cert-manager
         run: |
           helm repo add jetstack https://charts.jetstack.io &&

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ ansible/playbooks/grafana_dashboards/redpanda-grafana.json
 
 charts/*/charts/*.tgz
 admin.conf
+
+# OSX files
+.DS_Store

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.13
+version: 4.0.14
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.8

--- a/charts/redpanda/ci/12-external-cert-secrets-values.yaml
+++ b/charts/redpanda/ci/12-external-cert-secrets-values.yaml
@@ -1,0 +1,92 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+tls:
+  enabled: true
+  certs:
+    # in the future we want to also add the
+    default:
+      caEnabled: true
+    external:
+      secretRef:
+        name: external-tls-secret
+      caEnabled: true
+
+external:
+  enabled: true
+  type: NodePort
+  domain: random-domain
+
+listeners:
+  # NOT including admin-api listeners because it only has one and it is using internal
+  # tls certs by default.
+  # -- Kafka API listeners.
+  kafka:
+    # -- The port for internal client connections.
+    port: 9093
+    tls:
+      # Optional flag to override the global TLS enabled flag.
+      # enabled: true
+      cert: default
+      requireClientAuth: false
+    external:
+      default:
+        # enabled: true
+        # -- The port used for external client connections.
+        port: 9094
+        # -- If undefined, `listeners.kafka.external.default.port` is used.
+        advertisedPorts:
+          - 30090
+        tls:
+          # enabled: true
+          cert: external
+  # -- Schema registry listeners.
+  schemaRegistry:
+    enabled: true
+    port: 8081
+    kafkaEndpoint: default
+    tls:
+      # Optional flag to override the global TLS enabled flag.
+      # enabled: true
+      cert: default
+      requireClientAuth: false
+    external:
+      default:
+        # enabled: true
+        port: 8084
+        advertisedPorts:
+          - 30080
+        tls:
+          # enabled: true
+          cert: external
+  # -- HTTP API listeners (aka PandaProxy).
+  http:
+    enabled: true
+    port: 8082
+    kafkaEndpoint: default
+    tls:
+      # Optional flag to override the global TLS enabled flag.
+      # enabled: true
+      cert: default
+      requireClientAuth: false
+    external:
+      default:
+        # enabled: true
+        port: 8083
+        advertisedPorts:
+          - 30070
+        tls:
+          # enabled: true
+          cert: external

--- a/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
+++ b/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
@@ -1,0 +1,122 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+{{- if (include "tls-enabled" . | fromJson).bool }}
+  {{- $values := .Values }}
+  {{- $root := deepCopy . }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "redpanda.fullname" . }}-test-internal-externals-cert-secrets
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+  {{- with include "full.labels" . }}
+    {{- . | nindent 4 }}
+  {{- end }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  restartPolicy: Never
+  securityContext:
+    runAsUser: 65535
+    runAsGroup: 65535
+  containers:
+    - name: {{ template "redpanda.name" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
+      command:
+        - bash
+        - -c
+        - |
+          set -ex
+    {{- range $name, $cert := $values.tls.certs }}
+      {{- if $cert.secretRef }}
+          echo testing cert: {{ $name | quote }}
+
+        {{- if eq $cert.secretRef.name "internal-tls-secret" }}
+          echo "---> testing internal tls"
+          openssl s_client -verify_return_error -prexit \
+          {{- if $cert.caEnabled }}
+          -CAfile {{ printf "/etc/tls/certs/%s" $name }}/ca.crt \
+          {{- end }}
+          -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key \
+          -connect {{ include "api-urls" $root }}
+        {{- end }}
+
+        {{- if eq $cert.secretRef.name "external-tls-secret" }}
+          echo "---> testing external tls"
+
+          {{- if eq $values.listeners.kafka.external.default.tls.cert $name }}
+          echo "-----> testing external tls: kafka api"
+            {{- $port := ( first $values.listeners.kafka.external.default.advertisedPorts ) }}
+          openssl s_client -verify_return_error -prexit \
+            {{- if $cert.caEnabled }}
+          -CAfile {{ printf "/etc/tls/certs/%s" $name }}/ca.crt \
+            {{- end }}
+          -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key \
+          -connect {{ $values.external.domain }}:{{ $port }}
+          {{- end }}
+
+          {{- if eq $values.listeners.schemaRegistry.external.default.tls.cert $name }}
+          echo "-----> testing external tls: schema registry"
+            {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}
+          openssl s_client -verify_return_error -prexit \
+            {{- if $cert.caEnabled }}
+          -CAfile {{ printf "/etc/tls/certs/%s" $name }}/ca.crt \
+            {{- end }}
+          -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key \
+          -connect {{ $values.external.domain }}:{{ $port }}
+          {{- end }}
+
+          {{- if eq $values.listeners.http.external.default.tls.cert $name }}
+          echo "-----> testing external tls: http api"
+            {{- $port := ( first $values.listeners.http.external.default.advertisedPorts ) }}
+          openssl s_client -verify_return_error -prexit \
+            {{- if $cert.caEnabled }}
+          -CAfile {{ printf "/etc/tls/certs/%s" $name }}/ca.crt \
+            {{- end }}
+          -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key \
+          -connect {{ $values.external.domain }}:{{ $port }}
+          {{- end }}
+
+        {{- end }}
+          echo "----"
+
+      {{- end }}
+    {{- end }}
+      volumeMounts:
+      {{- range $name, $cert := .Values.tls.certs }}
+        - name: redpanda-{{ $name }}-cert
+          mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+      {{- end }}
+  volumes:
+  {{- range $name, $cert := .Values.tls.certs }}
+    {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
+    - name: redpanda-{{ $name }}-cert
+      secret:
+        defaultMode: 420
+        items:
+          - key: tls.key
+            path: tls.key
+          - key: tls.crt
+            path: tls.crt
+          {{- if $cert.caEnabled }}
+          - key: ca.crt
+            path: ca.crt
+          {{- end }}
+        secretName: {{ template "cert-secret-name" $r }}
+    {{- end }}
+{{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- $service := .Values.listeners.kafka -}}
-{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 {{- if and (include "kafka-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
+  {{- $service := .Values.listeners.kafka -}}
+  {{- $cert := get .Values.tls.certs $service.tls.cert -}}
+  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -71,9 +72,10 @@ spec:
     - name: config
       emptyDir: {}
   {{- range $name, $cert := .Values.tls.certs }}
+    {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
     - name: redpanda-{{ $name }}-cert
       secret:
         defaultMode: 0644
-        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+        secretName: {{ template "cert-secret-name" $r }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- $sasl := .Values.auth.sasl }}
+{{- $root := deepCopy . }}
 {{- $useSaslSecret := and $sasl.enabled (not (empty $sasl.secretRef )) }}
 apiVersion: v1
 kind: Pod
@@ -87,9 +88,10 @@ spec:
 {{- end }}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
+    {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
     - name: redpanda-{{ $name }}-cert
       secret:
         defaultMode: 0644
-        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+        secretName: {{ template "cert-secret-name" $r }}
   {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- $service := .Values.listeners.http -}}
-{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 {{- if and (include "http-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
+  {{- $service := .Values.listeners.http -}}
+  {{- $cert := get .Values.tls.certs $service.tls.cert -}}
+  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -68,10 +69,11 @@ spec:
       emptyDir: {}
   {{- if (include "tls-enabled" . | fromJson).bool }}
     {{- range $name, $cert := .Values.tls.certs }}
+      {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
     - name: redpanda-{{ $name }}-cert
       secret:
         defaultMode: 0644
-        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+        secretName: {{ template "cert-secret-name" $r }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -14,9 +14,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- $service := .Values.listeners.schemaRegistry -}}
-{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 {{- if and (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" .|fromJson).bool) -}}
+  {{- $service := .Values.listeners.schemaRegistry -}}
+  {{- $cert := get .Values.tls.certs $service.tls.cert -}}
+  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -67,9 +68,10 @@ spec:
     - name: config
       emptyDir: {}
   {{- range $name, $cert := .Values.tls.certs }}
+    {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
     - name: redpanda-{{ $name }}-cert
       secret:
         defaultMode: 0644
-        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
+        secretName: {{ template "cert-secret-name" $r }}
   {{- end }}
 {{- end -}}


### PR DESCRIPTION
Fixes #448 

Adds ability to test using certificates on listeners.

A CI entry that adds (and can be expanded to) external ~and internal tls~ backed by secrets. These are referenced in the modified listeners (changed in this custom values file). 

The secrets are created in a PR where a script is called, if there is a domain passed it is assumed that it is for an external listener. The script also adds annotations to the secrets so that they will be created before the launch of other resources in a helm hook. Finally, the PR code will move these into the template directory, including a service yaml file (discussed below).

The service file that is also added to the templates directory was necessary to test the listeners from the inside of the a pod. The service targets the listener endpoints and is named in the same way as the domain defined in the CI file. The naming is to take advantage of the kubernetes internal dns with respect to services, since internally we can simply call `<service-name>:<port>` which is then routed to the targetPort of the pods defined in the proper selectors. That helps in ensuring the certificates have the correct alt-names defined.

The new test added, allows us to use opessl `s_client` to verify that each listener is using the correct certificate (internally and externally) and that they have the correct certificate and the the right key works as intended.

Finally an outcome of this testing has been multiple fixes, one additional issue was discovered where we need to also have the tests pick up certificate files correctly if they are from secrets. We include those fixes here. 

This is a first step change. We should include additional tests soon but for now this covers a wide range of possible certificate cases. Though we are not really testing externally, the use of an internal service that points to the same external endpoints should work as a close analog and so we expect to capture any issues in the future if they arise. 

