### PR TITLE
Accept array for topologySpreadConstraints

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.14
+version: 4.0.15
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.8

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -407,13 +407,13 @@ spec:
 {{- end }}
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
       topologySpreadConstraints:
-      - labelSelector:
-          matchLabels: {{ include "statefulset-pod-labels" . | nindent 12 }}
-  {{- with .Values.statefulset.topologySpreadConstraints }}
-        maxSkew: {{ .maxSkew }}
-        topologyKey: {{ .topologyKey }}
-        whenUnsatisfiable: {{ .whenUnsatisfiable }}
-  {{- end }}
+    {{- range $v := .Values.statefulset.topologySpreadConstraints }}
+        - maxSkew: {{ $v.maxSkew }}
+          topologyKey: {{ $v.topologyKey }}
+          whenUnsatisfiable: {{ $v.whenUnsatisfiable }}
+          labelSelector:
+            matchLabels: {{ include "statefulset-pod-labels" $ | nindent 14 }}
+    {{- end }}
 {{- end }}
 {{- with ( include "statefulset-nodeSelectors" . ) }}
       nodeSelector: {{- . | nindent 8 }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -635,22 +635,20 @@
           "type": "array"
         },
         "topologySpreadConstraints": {
-          "type": "object",
-          "required": [
-            "maxSkew",
-            "topologyKey",
-            "whenUnsatisfiable"
-          ],
-          "properties": {
-            "maxSkew": {
-              "type": "integer"
-            },
-            "topologyKey": {
-              "type": "string"
-            },
-            "whenUnsatisfiable": {
-              "type": "string",
-              "pattern": "^(ScheduleAnyway|DoNotSchedule)$"
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "properties": {
+              "maxSkew": {
+                "type": "integer"
+              },
+              "topologyKey": {
+                "type": "string"
+              },
+              "whenUnsatisfiable": {
+                "type": "string",
+                "pattern": "^(ScheduleAnyway|DoNotSchedule)$"
+              }
             }
           }
         },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -530,7 +530,7 @@ statefulset:
   # For details,
   # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/).
   topologySpreadConstraints:
-    maxSkew: 1
+  - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
     whenUnsatisfiable: ScheduleAnyway
   securityContext:


### PR DESCRIPTION
This PR fixes #466 by modifying the StatefulSet template to accept an array of `topologySpreadConstraints` objects. 