### PR TITLE
chore: lint filename in ci to ensure they are run

### DIFF
--- a/.github/check-ci-files.sh
+++ b/.github/check-ci-files.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# CI files to run at all must has the right suffix *-values
+# To avoid creating CI cases that will not run in CT we will check using
+# this script if any files added to a folder do not meet the expected suffix
+
+# valid path to files example: "/path/to/ci"
+FILES=${1-"charts/redpanda/ci"}
+
+exitCode=0
+for file in ${FILES}/*
+do
+ echo verifying file: ${file}
+ if [[ $file == *-values.yaml ]] || [[ $file == *-values.yaml.tpl ]]; then
+   continue
+ else
+   echo "- file does not match neither suffix '-values.yaml' nor -values.yaml.tpl'"
+   exitCode=1
+ fi 
+done
+
+exit $exitCode
+

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -35,6 +35,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Run CI file name checker
+        run: .github/check-ci-files.sh charts/redpanda/ci
+
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
@@ -47,6 +50,7 @@ jobs:
 
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct.yaml
+
   check-values:
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
We have had cases where CI wont run, unnoticed test cases because of file names. Here we avoid this pitfall by failing fast. 