### PR TITLE
add topologySpreadConstraints to deployment

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.5.9
+version: 0.6.0
 
 # The app version is the version of the Chart application
 appVersion: v2.2.3
@@ -44,4 +44,4 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/vectorized/console:v2.1.1
+      image: docker.redpanda.com/redpandadata/console:v2.2.3

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -257,6 +257,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 image:
   registry: docker.redpanda.com
   # -- Docker repository from which to pull the Redpanda Docker image.
-  repository: vectorized/console
+  repository: redpandadata/console
   # -- The imagePullPolicy.
   pullPolicy: IfNotPresent
   # -- The Redpanda Console version.
@@ -98,6 +98,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+topologySpreadConstraints: {}
 
 console:
   # -- Settings for the `Config.yaml` (required).


### PR DESCRIPTION
Add topologySpreadConstraints to the deployment template and values files to allow them to be defined.

Fixes #460