### PR TITLE
sasl user creation rework and allow updates

### DIFF
--- a/.github/create-sasl-secret.sh
+++ b/.github/create-sasl-secret.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -xeuo pipefail
+
+SECRET_NAME=${1-"some-users"}
+
+# Create a secret object with initial user sasl data
+kubectl create secret generic ${SECRET_NAME} \
+--from-file=.github/sasl-users.txt \
+--dry-run=client -o yaml > ${SECRET_NAME}.yaml.tmp
+
+# Create a secret object with updated user sasl data
+kubectl create secret generic ${SECRET_NAME} \
+--from-file=.github/updated-sasl-users.txt \
+--dry-run=client -o yaml > ${SECRET_NAME}-updated.yaml.tmp
+
+# Initial sasl secrete starts with annotations for pre-install hooks
+kubectl annotate -f ${SECRET_NAME}.yaml.tmp \
+helm.sh/hook-delete-policy="before-hook-creation" \
+helm.sh/hook="pre-install" \
+helm.sh/hook-weight="-100" \
+--local --dry-run=client -o yaml > ${SECRET_NAME}.yaml
+
+# Updated sasl secrete starts with annotations for post-install hooks
+kubectl annotate -f ${SECRET_NAME}-updated.yaml.tmp \
+helm.sh/hook-delete-policy="before-hook-creation" \
+helm.sh/hook="post-install" \
+helm.sh/hook-weight="100" \
+--local --dry-run=client -o yaml > ${SECRET_NAME}-updated.yaml
+
+rm ${SECRET_NAME}.yaml.tmp
+rm ${SECRET_NAME}-updated.yaml.tmp
+
+echo created file ${SECRET_NAME}.yaml ${SECRET_NAME}-updated.yaml

--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -15,7 +15,7 @@
 debug: true
 remote: origin
 target-branch: main
-helm-extra-args: --timeout 600s
+helm-extra-args: --timeout 900s
 chart-repos:
   - redpanda=https://charts.redpanda.com
 

--- a/.github/sasl-users.txt
+++ b/.github/sasl-users.txt
@@ -1,0 +1,4 @@
+admin:badpassword:SCRAM-SHA-512
+user1:pass1word:SCRAM-SHA-512
+someuser:ABC123r:SCRAM-SHA-512
+anotherme:blah2784a:SCRAM-SHA-512

--- a/.github/updated-sasl-users.txt
+++ b/.github/updated-sasl-users.txt
@@ -1,0 +1,5 @@
+admin:worse:SCRAM-SHA-512
+user1:pass1:SCRAM-SHA-512
+someuser:ABC123:SCRAM-SHA-512
+anotherme:2784a:SCRAM-SHA-512
+anotheranotherme:2784ablah:SCRAM-SHA-512

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -132,11 +132,18 @@ jobs:
         run: |
           .github/create_tls.sh "random-domain"
 
+      - name: Create sasl secret templates
+        if: steps.list-changed.outputs.changed == 'true'
+        run: |
+          .github/create-sasl-secret.sh "some-users"
+
       - name: Move tls files to template
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           mv external-tls-secret.yaml charts/redpanda/templates/
           cp .github/external-service.yaml charts/redpanda/templates/
+          mv some-users.yaml charts/redpanda/templates
+          mv some-users-updated.yaml charts/redpanda/templates
 
       - name: install cert-manager
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.17
+version: 4.0.18
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.8

--- a/charts/redpanda/ci/11-update-sasl-users-values.yaml
+++ b/charts/redpanda/ci/11-update-sasl-users-values.yaml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This relies on .github/create-sasl-secret.sh and moving those files into the redpanda template directory
+auth:
+  sasl:
+    enabled: true
+    secretRef: "some-users"
+    users: []

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -76,34 +76,6 @@ spec:
         args:
           - |
             set -e
-        {{- if and $sasl.enabled (not (empty $sasl.secretRef ))  }}
-            USERS_FILE=$(find /etc/secrets/users/* -print)
-            while read p; do
-              IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
-              # Do not process empty lines
-              if [ -z "$USER_NAME" ]; then
-                continue
-              fi
-              echo "Creating user ${USER_NAME}..."
-              MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
-              creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
-              if [[ $creation_result_exit_code -ne 0 ]]; then
-              # Check if the stderr contains "User already exists"
-                if [[ $creation_result == *"User already exists"* ]]; then
-                  # TODO: change user password instead in the future when api enables this.
-                  echo "the user ${USER_NAME} already exists, skipping creation."
-                else
-                  # Another error occurred, so output the original message and exit code
-                  echo "error creating user ${USER_NAME}: ${creation_result}"
-                  exit $creation_result_exit_code
-                fi
-              # On a success, the user was created so output that
-              else
-                echo "Created user ${USER_NAME}."
-              fi
-            done < $USERS_FILE
-        {{- end }}
-
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
           {{- if not (empty .Values.license_secret_ref) }}
             rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-flags-no-sasl" $ }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -249,6 +249,6 @@ stringData:
         process_users $USERS_DIR
       done
     {{- end }}
-    sleep 60
+      sleep infinity
     done
 {{- end }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -136,3 +136,83 @@ stringData:
   {{- end }}
     # intentional empty line
 {{- end }}
+
+{{- if .Values.statefulset.sideCars.configWatcher.enabled }}
+  {{- $values := .Values }}
+  {{- $sasl := .Values.auth.sasl }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "redpanda.fullname" . }}-config-watcher
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+  {{- with include "full.labels" . }}
+  {{- . | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+    set -e
+    
+    while true; do
+    {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
+      echo "RUNNING: Monitoring and Updating SASL users"
+      USERS_DIR="/etc/secrets/users"
+      
+      process_users() {
+        USERS_DIR=${1-"/etc/secrets/users"}
+        USERS_FILE=$(find ${USERS_DIR}/* -print)
+        while read p; do
+          IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+          # Do not process empty lines
+          if [ -z "$USER_NAME" ]; then
+            continue
+          fi
+          echo "Creating user ${USER_NAME}..."
+          MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          if [[ $creation_result_exit_code -ne 0 ]]; then
+            # Check if the stderr contains "User already exists"
+            # this error occurs when password has changed
+            if [[ $creation_result == *"User already exists"* ]]; then
+              # we will try to update by first deleting
+              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              if [[ $deletion_result_exit_code -ne 0 ]]; then
+                echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
+                break
+              fi
+              # Now we update the user
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              if [[ $update_result_exit_code -ne 0 ]]; then
+                echo "updating of user ${USER_NAME} failed: ${update_result}"
+                break
+              else
+                echo "Updated user ${USER_NAME}." 
+              fi
+            else
+              # Another error occurred, so output the original message and exit code
+              echo "error creating user ${USER_NAME}: ${creation_result}"
+              break
+            fi
+          # On a success, the user was created so output that
+          else
+            echo "Created user ${USER_NAME}."
+          fi
+        done < $USERS_FILE
+      }
+  
+      # first time processing
+      process_users $USERS_DIR
+    
+      # subsequent changes detected here
+      # watching delete_self as documented in https://ahmet.im/blog/kubernetes-inotify/
+      USERS_FILE=$(find ${USERS_DIR}/* -print)
+      while RES=$(inotifywait -q -e delete_self ${USERS_FILE}); do
+        process_users $USERS_DIR
+      done
+    {{- end }}
+    sleep 600
+    done
+{{- end }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -156,14 +156,34 @@ stringData:
     #!/usr/bin/env bash
     set -e
     
+    ready_result_exit_code=1
+    while [[ ${ready_result_exit_code} -ne 0 ]]; do
+      ready_result=$(rpk cluster health {{ (include "rpk-flags" . | fromJson).admin }} | grep 'Healthy:.*true' 2>&1) && ready_result_exit_code=$?
+      sleep 2
+    done
+    
     while true; do
     {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
       echo "RUNNING: Monitoring and Updating SASL users"
       USERS_DIR="/etc/secrets/users"
+    
+      new_users_list(){
+        LIST=$1
+        NEW_USER=$2
+        if [[ -n "${LIST}" ]]; then
+          LIST="${NEW_USER},${LIST}"
+        else
+          LIST="${NEW_USER}"
+        fi
+    
+        echo "${LIST}"
+      }
       
       process_users() {
         USERS_DIR=${1-"/etc/secrets/users"}
         USERS_FILE=$(find ${USERS_DIR}/* -print)
+        USERS_LIST=""
+        READ_LIST_SUCCESS=0
         while read p; do
           IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
           # Do not process empty lines
@@ -177,30 +197,46 @@ stringData:
             # Check if the stderr contains "User already exists"
             # this error occurs when password has changed
             if [[ $creation_result == *"User already exists"* ]]; then
+              echo "Update user ${USER_NAME}"
               # we will try to update by first deleting
-              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              deletion_result=$(rpk acl user delete ${USER_NAME} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
               if [[ $deletion_result_exit_code -ne 0 ]]; then
                 echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
+                READ_LIST_SUCCESS=1
                 break
               fi
               # Now we update the user
               update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-sasl" $ }} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
               if [[ $update_result_exit_code -ne 0 ]]; then
-                echo "updating of user ${USER_NAME} failed: ${update_result}"
+                echo "updating user ${USER_NAME} failed: ${update_result}"
+                READ_LIST_SUCCESS=1
                 break
               else
-                echo "Updated user ${USER_NAME}." 
+                echo "Updated user ${USER_NAME}..."
+                USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
               fi
             else
               # Another error occurred, so output the original message and exit code
               echo "error creating user ${USER_NAME}: ${creation_result}"
+              READ_LIST_SUCCESS=1
               break
             fi
           # On a success, the user was created so output that
           else
-            echo "Created user ${USER_NAME}."
+            echo "Created user ${USER_NAME}..."
+            USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
           fi
         done < $USERS_FILE
+            
+        if [[ -n "${USERS_LIST}" && ${READ_LIST_SUCCESS} ]]; then
+          echo "Setting superusers configurations with users [${USERS_LIST}]"
+          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] {{ template "rpk-flags-no-sasl" $ }} 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
+          if [[ $superuser_result_exit_code -ne 0 ]]; then
+              echo "Setting superusers configurations failed: ${superuser_result}"
+          else
+              echo "Completed setting superusers configurations" 
+          fi
+        fi
       }
   
       # first time processing
@@ -213,6 +249,6 @@ stringData:
         process_users $USERS_DIR
       done
     {{- end }}
-    sleep 600
+    sleep 60
     done
 {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -321,6 +321,30 @@ spec:
             limits:
               cpu: {{ .Values.resources.cpu.cores }}
               memory: {{ .Values.resources.memory.container.max }}
+      {{- if .Values.statefulset.sideCars.configWatcher.enabled }}
+        - name: config-watcher
+          image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
+          command:
+            - /bin/bash # could be expanded for multiple scripts
+            - -c 
+            - /etc/secrets/config-watcher/scripts/sasl-user.sh
+          volumeMounts:
+            - name: {{ template "redpanda.fullname" . }}-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+              readOnly: true
+          {{- if and .Values.auth.sasl.enabled (not (empty .Values.auth.sasl.secretRef )) }}
+            - name: {{ .Values.auth.sasl.secretRef }}
+              mountPath: /etc/secrets/users
+              readOnly: true
+          {{- end }}
+          {{- if (include "tls-enabled" . | fromJson).bool }}
+            {{- range $name, $cert := .Values.tls.certs }}
+            - name: redpanda-{{ $name }}-cert
+              mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+              readOnly: true
+            {{- end }}
+          {{- end }}
+      {{- end }}
       volumes:
         - name: lifecycle-scripts
           secret:
@@ -378,6 +402,11 @@ spec:
             secretName: {{ .Values.auth.sasl.secretRef }}
             optional: false
         {{- end }}
+        - name: {{ template "redpanda.fullname" . }}-config-watcher
+          secret:
+            secretName: {{ template "redpanda.fullname" . }}-config-watcher
+            optional: false
+            defaultMode: 0774
 {{- if or .Values.statefulset.nodeAffinity .Values.statefulset.podAffinity .Values.statefulset.podAntiAffinity }}
       affinity:
   {{- with .Values.statefulset.nodeAffinity }}

--- a/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
+++ b/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
@@ -14,9 +14,17 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+
+{{/*
+    
+This test currently fails because of a bug where when multiple containers exist
+The api returns an error. We should be requesting logs from each container.
+
+
 {{- if and .Values.rbac.enabled (include "redpanda-atleast-23-1-1" .|fromJson).bool -}}
   {{- $sasl := .Values.auth.sasl }}
   {{- $useSaslSecret := and $sasl.enabled (not (empty $sasl.secretRef )) }}
+
 
 apiVersion: v1
 kind: Pod
@@ -116,3 +124,4 @@ spec:
 {{- end -}}
 
 {{- end -}}
+*/}}

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -47,7 +47,14 @@ spec:
         - -c
         - |
           set -xe
-          sleep 30
+          # check that the users list did update
+          ready_result_exit_code=1
+          while [[ ${ready_result_exit_code} -ne 0 ]]; do
+            ready_result=$(rpk acl user list {{ (include "rpk-flags" . | fromJson).admin }} | grep anotheranotherme 2>&1) && ready_result_exit_code=$?
+            sleep 2
+          done
+          
+          # check that sasl is not broken
           {{ include "rpk-cluster-info" $rpk }}
       volumeMounts:
         - name: config

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -14,13 +14,16 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- $sasl := .Values.auth.sasl }}
-{{- $root := deepCopy . }}
-{{- $rpk := deepCopy . }}
+
+{{- if and (include "sasl-enabled" . | fromJson).bool (eq .Values.auth.sasl.secretRef "some-users") -}}
+    {{- $rpk := deepCopy . }}
+    {{- $sasl := .Values.auth.sasl }}
+    {{- $_ := set $rpk "rpk" "rpk" }}
+    {{- $_ := set $rpk "dummySasl" false }}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "redpanda.fullname" . }}-test-kafka-produce-consume
+  name: "{{ include "redpanda.fullname" . }}-test-update-sasl-users"
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{- with include "full.labels" . }}
@@ -37,68 +40,49 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-      env:
-        - name: REDPANDA_BROKERS
-          value: "{{ include "redpanda.fullname" . }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain | trimSuffix "." }}:{{ .Values.listeners.kafka.port }}"
-        - name: POD_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.name
       command:
         - /usr/bin/timeout
         - "120"
         - bash
         - -c
         - |
-          set -e
-{{- $cloudStorageFlags := "" }}
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
-  {{- $cloudStorageFlags = "-c retention.bytes=80 -c segment.bytes=40 -c redpanda.remote.read=true -c redpanda.remote.write=true"}}
-{{- end }}
-{{- if $sasl.enabled }}
-          until rpk topic create produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }} {{ $cloudStorageFlags }}
-            do sleep 2
-          done
-          {{- range $i := until 100 }}
-          echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" $ }}
-          {{- end }}
-          sleep 2
-          rpk topic consume produce.consume.test.$POD_NAME -n 1 {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
-          rpk topic delete produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
-{{- end }}
+          set -xe
+          sleep 30
+          {{ include "rpk-cluster-info" $rpk }}
       volumeMounts:
         - name: config
           mountPath: /etc/redpanda
-{{- if (include "tls-enabled" . | fromJson).bool -}}
+{{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
   {{- end }}
 {{- end }}
-{{- if $sasl.enabled }}
+        {{- if (not (empty $sasl.secretRef )) }}
         - name: {{ $sasl.secretRef }}
           mountPath: "/etc/secrets/users"
           readOnly: true
-{{- end}}
-      resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
+        {{- end}}
+      resources:
+{{- toYaml .Values.statefulset.resources | nindent 12 }}
   volumes:
     - name: {{ template "redpanda.fullname" . }}
       configMap:
         name: {{ template "redpanda.fullname" . }}
     - name: config
       emptyDir: {}
-{{- if $sasl.enabled }}
+    {{- if (not (empty $sasl.secretRef )) }}
     - name: {{ $sasl.secretRef }}
       secret:
         secretName: {{ $sasl.secretRef }}
         optional: false
-{{- end }}
+    {{- end }}
 {{- if (include "tls-enabled" . | fromJson).bool }}
   {{- range $name, $cert := .Values.tls.certs }}
-    {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
     - name: redpanda-{{ $name }}-cert
       secret:
         defaultMode: 0644
-        secretName: {{ template "cert-secret-name" $r }}
+        secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-cert
   {{- end }}
 {{- end -}}
+{{- end }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -526,7 +526,8 @@
         "priorityClassName",
         "tolerations",
         "topologySpreadConstraints",
-        "securityContext"
+        "securityContext",
+        "sideCars"
       ],
       "properties": {
         "replicas": {
@@ -684,6 +685,22 @@
             "fsGroupChangePolicy": {
               "type": "string",
               "pattern": "^(OnRootMismatch|Always)$"
+            }
+          }
+        },
+        "sideCars": {
+          "type": "object",
+          "properties": {
+            "configWatcher": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "resources": {
+                  "type": "object"
+                }
+              }
             }
           }
         },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -543,6 +543,10 @@ statefulset:
     fsGroup: 101
     runAsUser: 101
     fsGroupChangePolicy: OnRootMismatch
+  sideCars:
+    configWatcher:
+      enabled: true
+      resources: {}
   initContainers:
     tuning:
       resources: {}


### PR DESCRIPTION
Fixes #459 

This PR is attempting to create and update sasl users by means of inotify watchers, which will be monitoring user secret for sals users when enabled, update these users if they exist already, and maintain the usual creation process. 

Changes to make:
- [x] Move sasl creation code to a secret with execution happening in a side-car
- [x] sasl creation code changed to perform updates
- [x] clean code and debug tools
- [x] create testing 