### PR TITLE
feat: servicemonitor additional labels.

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.30
+version: 4.0.31
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.10

--- a/charts/redpanda/templates/servicemonitor.yaml
+++ b/charts/redpanda/templates/servicemonitor.yaml
@@ -26,6 +26,9 @@ metadata:
 {{- with include "full.labels" . }}
   {{- . | nindent 4 }}
 {{- end }}
+{{- with .Values.monitoring.labels }}
+  {{- . | toYaml | nindent 4 }}
+{{- end }}
 spec:
   endpoints:
   - interval: {{ .Values.monitoring.scrapeInterval }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -245,6 +245,9 @@
         "scrapeInterval": {
           "type": "string",
           "pattern": ".*[smh]$"
+        },
+        "labels": {
+          "type": "object"
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -228,6 +228,7 @@ logging:
 monitoring:
   enabled: false
   scrapeInterval: 30s
+  labels: {}
 
 # -- Pod resource management.
 # This section simplifies resource allocation


### PR DESCRIPTION
Change-Id: I53976b4efcc89544afb541f2c3f9ea173ac1cac7
Prometheus / VictoriaMetrics typically uses labels to discriminate scrapping instance.