### PR TITLE
add a test summary that we can mark as a blocker

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -162,3 +162,13 @@ jobs:
             --skip-missing-values \
             --excluded-charts console \
             --target-branch ${{ github.event.repository.default_branch }}
+  summary:
+    if: always()
+    needs:
+      - test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Summarize the results of the test matrix pass/fail
+        uses: re-actors/alls-green@release/v1
+        with:
+          jobs: ${{ toJSON(needs)}}

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -166,7 +166,7 @@ jobs:
     if: always()
     needs:
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Summarize the results of the test matrix pass/fail
         uses: re-actors/alls-green@release/v1


### PR DESCRIPTION
This adds a "summary" job that will pass or fail depending on the pass/fail state of all the matrix tests. The summary test can then be added to the required status checks.