### PR TITLE
chore: Added ability to specify the annotation for console deployment

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.6.4
+version: 0.6.5
 
 # The app version is the version of the Chart application
 appVersion: v2.2.4

--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   name: {{ include "console.fullname" . }}
   labels:
     {{- include "console.labels" . | nindent 4 }}
+  {{- with .Values.annotations }}
+  annotations:
+      {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/charts/console/values.schema.json
+++ b/charts/console/values.schema.json
@@ -154,6 +154,9 @@
         "nodeSelector": {
             "type": "object"
         },
+        "annotations": {
+            "type": "object"
+        },
         "podAnnotations": {
             "type": "object"
         },

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -37,6 +37,9 @@ serviceAccount:
   # a name is generated using the `console.fullname` template
   name: ""
 
+# -- Annotations to add to the deployment.
+annotations: {}
+
 podAnnotations: {}
 
 podLabels: {}


### PR DESCRIPTION
It is useful in mTLS setup to reload the console when certificates are updated via a tool like https://github.com/stakater/Reloader.