### PR TITLE
Do not attempt to check TLS state for dry-runs

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.29
+version: 4.0.30
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.10

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -32,7 +32,8 @@ limitations under the License.
 {{- $cm := lookup "v1" "ConfigMap" .Release.Namespace (include "redpanda.fullname" .) -}}
 {{- $redpandaYAML := dig "data" "redpanda.yaml" "" $cm | fromYaml -}}
 {{- $currentRPCTLS := dig "redpanda" "rpc_server_tls" "enabled" false $redpandaYAML -}}
-{{- if .Release.IsUpgrade -}}
+{{- /* Lookup will return an empty map when running `helm template` or when `--dry-run` is passed. */ -}}
+{{- if (and .Release.IsUpgrade $cm) -}}
   {{- if ne $currentRPCTLS $wantedRPCTLS -}}
     {{- if eq (get .Values "force" | default false) false -}}
       {{- fail (join "\n" (list


### PR DESCRIPTION
When running `helm template` or passing `--dry-run`, the built-in `lookup` function always returns an empty map. This results in the check thinking that TLS is currently not enabled for RPCs, generating an error.

To reproduce:

```
$ helm install redpanda redpanda/redpanda
...
$ helm upgrade redpanda redpanda/redpanda --dry-run
Error: UPGRADE FAILED: execution error at (redpanda/templates/statefulset.yaml:60:28): 

Error: Cannot do a rolling restart to enable or disable tls at the RPC layer: changing listeners.rpc.tls.enabled (redpanda.yaml:repdanda.rpc_server_tls.enabled) from false to true
***WARNING The following instructions will result in a short period of downtime.
To accept this risk, run the upgrade again adding `--set force=true` and do the following:

While helm is upgrading the release, manually delete ALL the pods:
    kubectl -n infra delete pod -l app.kubernetes.io/component=redpanda-statefulset

If you got here thinking rpc tls was already enabled, see technical service bulletin 2023-01.

$ helm upgrade redpanda redpanda/redpanda
Release "redpanda" has been upgraded. Happy Helming!
...
```