### PR TITLE
Exclude schema registry and HTTP proxy config from 22.2.X deployment

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.38
+version: 4.0.39
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.12

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -538,6 +538,14 @@ than 1 core.
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "docker.redpanda.com/redpandadata/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.2.10-0,<22.3"))) -}}
 {{- end -}}
 
+{{- define "redpanda-22-2-x-without-sasl" -}}
+{{- $result :=  (include "redpanda-atleast-22-3-0" . | fromJson).bool -}}
+{{- if or (include "sasl-enabled" . | fromJson).bool .Values.listeners.kafka.authenticationMethod -}}
+{{-   $result := false -}}
+{{- end -}}
+{{- toJson (dict "bool" $result) -}}
+{{- end -}}
+
 # manage backward compatibility with renaming podSecurityContext to securityContext
 {{- define "pod-security-context" -}}
 fsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -296,7 +296,7 @@ data:
   {{- end }}
 {{- end }}
 {{- /* Schema Registry API */}}
-{{- if .Values.listeners.schemaRegistry.enabled }}
+{{- if and .Values.listeners.schemaRegistry.enabled (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
   {{- $schemaRegistryService := .Values.listeners.schemaRegistry }}
     schema_registry:
       schema_registry_api:
@@ -365,7 +365,7 @@ data:
   {{- end }}
 {{- end }}
 {{- /* HTTP Proxy */}}
-{{- if .Values.listeners.http.enabled }}
+{{- if and .Values.listeners.http.enabled (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
   {{- $HTTPService := .Values.listeners.http }}
     pandaproxy:
       pandaproxy_api:

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -14,10 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "http-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
+{{- if and (include "http-internal-tls-enabled" . | fromJson).bool .Values.listeners.http.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool -}}
   {{- $service := .Values.listeners.http -}}
   {{- $cert := get .Values.tls.certs $service.tls.cert -}}
   {{- $root := deepCopy . }}
+  {{- $sasl := .Values.auth.sasl }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -41,35 +42,49 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-      command:
-        - curl
-        - -svm3
-        - --fail
-        - --retry
-        - "120"
-        - --retry-max-time
-        - "120"
-        - --retry-all-errors
-        - --ssl-reqd
-  {{- if $cert.caEnabled }}
-        - --cacert
-        - /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
-  {{- end }}
-        - https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.http.port }}/brokers
+      command: [ "/bin/bash", "-c" ]
+      args:
+        - |
+          {{- if $sasl.enabled }}
+          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
+          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+          {{- end }}
+
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
+          -u $USERNAME:$PASSWORD \
+          {{- end }}
+          {{- if $cert.caEnabled }}
+          --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+          {{- end }}
+          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.http.port }}/brokers
+
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
+          -u $USERNAME:$PASSWORD \
+          {{- end }}
+          {{- if $cert.caEnabled }}
+          --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+          {{- end }}
+          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.http.port }}/topics
       volumeMounts:
-        - name: config
-          mountPath: /etc/redpanda
-  {{- range $name, $cert := .Values.tls.certs }}
+      {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
-  {{- end }}
+      {{- end }}
+      {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+      {{- end}}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
   volumes:
-    - name: {{ template "redpanda.fullname" . }}
-      configMap:
-        name: {{ template "redpanda.fullname" . }}
-    - name: config
-      emptyDir: {}
+  {{- if $sasl.enabled }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
+  {{- end }}
   {{- if (include "tls-enabled" . | fromJson).bool }}
     {{- range $name, $cert := .Values.tls.certs }}
       {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -14,7 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if not (or (include "tls-enabled" . | fromJson).bool (include "sasl-enabled" . | fromJson).bool) -}}
+{{- if and (not (include "http-internal-tls-enabled" . | fromJson).bool) .Values.listeners.http.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool -}}
+  {{- $sasl := .Values.auth.sasl }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -38,14 +39,36 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-      command:
-        - curl
-        - -svm3
-        - --fail
-        - --retry
-        - "120"
-        - --retry-max-time
-        - "120"
-        - --retry-all-errors
-        - http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.http.port }}/brokers
+      command: [ "/bin/bash", "-c" ]
+      args:
+        - |
+          {{- if $sasl.enabled }}
+          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
+          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+          {{- end }}
+
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
+          -u $USERNAME:$PASSWORD \
+          {{- end }}
+          http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.http.port }}/brokers
+
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
+          -u $USERNAME:$PASSWORD \
+          {{- end }}
+          http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.http.port }}/topics
+      volumeMounts:
+      {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+      {{- end}}
+  volumes:
+  {{- if $sasl.enabled }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
+  {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -14,10 +14,11 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" .|fromJson).bool) -}}
+{{- if and (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool .Values.listeners.schemaRegistry.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool -}}
   {{- $service := .Values.listeners.schemaRegistry -}}
   {{- $cert := get .Values.tls.certs $service.tls.cert -}}
   {{- $root := deepCopy . }}
+  {{- $sasl := .Values.auth.sasl }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -41,40 +42,70 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-      command:
-        - curl
-        - -svm3
-        - --fail
-        - --retry
-        - "120"
-        - --retry-max-time
-        - "120"
-        - --retry-all-errors
-        - --ssl-reqd
-  {{- if $cert.caEnabled }}
-        - --cacert
-        - /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
-  {{- end }}
-        - https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+      command: ["/bin/bash", "-c"]
+      args:
+        - |
+          {{- if $sasl.enabled }}
+          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
+          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+          {{- end }}
+
+          schemaCurl () {
+            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+            {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+            -u $USERNAME:$PASSWORD \
+            {{- end }}
+            {{- if $cert.caEnabled }}
+            --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+            {{- end }}
+            $*
+          }
+
+          schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
+          -d '{"schema": "{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
+          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+          -u $USERNAME:$PASSWORD \
+          {{- end }}
+          {{- if $cert.caEnabled }}
+          --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+          {{- end }}
+          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+
+          schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
+
+          schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+
+          schemaCurl -X DELETE \
+          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+
+          schemaCurl -X DELETE \
+          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
       volumeMounts:
-        - name: config
-          mountPath: /etc/redpanda
-  {{- range $name, $cert := .Values.tls.certs }}
+      {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert
           mountPath: {{ printf "/etc/tls/certs/%s" $name }}
-  {{- end }}
+      {{- end }}
+      {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+      {{- end}}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
   volumes:
-    - name: {{ template "redpanda.fullname" . }}
-      configMap:
-        name: {{ template "redpanda.fullname" . }}
-    - name: config
-      emptyDir: {}
   {{- range $name, $cert := .Values.tls.certs }}
     {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
     - name: redpanda-{{ $name }}-cert
       secret:
         defaultMode: 0644
         secretName: {{ template "cert-secret-name" $r }}
+  {{- end }}
+  {{- if $sasl.enabled }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
   {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -14,7 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if not (or (include "tls-enabled" . | fromJson).bool (include "sasl-enabled" . | fromJson).bool) }}
+{{- if and (not (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool) .Values.listeners.schemaRegistry.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool }}
+  {{- $sasl := .Values.auth.sasl }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -38,14 +39,52 @@ spec:
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-      command:
-        - curl
-        - -svm3
-        - --fail
-        - --retry
-        - "120"
-        - --retry-max-time
-        - "120"
-        - --retry-all-errors
-        - http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+      command: [ "/bin/bash", "-c" ]
+      args:
+        - |
+          {{- if $sasl.enabled }}
+          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
+          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+          {{- end }}
+
+          schemaCurl () {
+            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+            {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+            -u $USERNAME:$PASSWORD \
+            {{- end }}
+            $*
+          }
+
+          schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/types
+
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
+          -d '{"schema":"{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
+          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+          -u $USERNAME:$PASSWORD \
+          {{- end }}
+          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+
+          schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
+
+          schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+
+          schemaCurl -X DELETE \
+          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+
+          schemaCurl -X DELETE \
+          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+      volumeMounts:
+      {{- if $sasl.enabled }}
+        - name: {{ $sasl.secretRef }}
+          mountPath: "/etc/secrets/users"
+          readOnly: true
+      {{- end}}
+  volumes:
+  {{- if $sasl.enabled }}
+    - name: {{ $sasl.secretRef }}
+      secret:
+        secretName: {{ $sasl.secretRef }}
+        optional: false
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
As version 22.2.X does not provide basic auth configuration option in both schema registry and panda proxy the client configuration for both services needs SASL credentails to be explicitly set in Redpanda configuration. That Redpanda configuration is generated in helm and sotred as config map which should not hold any credentails.

Newer version can take HTTP basic auth header to impersonate user and authenticate against Redpanda Kafka listener.

Additionally HTTP proxy and schema registry tests now are run when SASL is enabled