### PR TITLE
Change the test super user SASL mechanism

### DIFF
--- a/.github/updated-sasl-users.txt
+++ b/.github/updated-sasl-users.txt
@@ -1,5 +1,5 @@
-admin:badpassword:SCRAM-SHA-512
+admin:badpassword:SCRAM-SHA-256
 user1:pass1:SCRAM-SHA-512
 someuser:ABC123:SCRAM-SHA-512
-anotherme:2784a:SCRAM-SHA-512
+anotherme:2784a:SCRAM-SHA-256
 anotheranotherme:2784ablah:SCRAM-SHA-512

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.36
+version: 4.0.37
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.12

--- a/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
@@ -23,6 +23,7 @@ auth:
     users:
       - name: admin
         password: hunter2
+        mechanism: SCRAM-SHA-256
 
 storage:
   persistentVolume:

--- a/charts/redpanda/ci/11-update-sasl-users-values.yaml
+++ b/charts/redpanda/ci/11-update-sasl-users-values.yaml
@@ -21,7 +21,7 @@ auth:
     users:
       - name: admin
         password: badpassword
-        mechanism: SCRAM-SHA-512
+        mechanism: SCRAM-SHA-256
       - name: user1
         password: pass1word
         mechanism: SCRAM-SHA-512


### PR DESCRIPTION
The PR https://github.com/redpanda-data/helm-charts/pull/544 does not pass tests due to bug in Redpanda. The pandaproxy fix will be backported eventually https://github.com/redpanda-data/redpanda/pull/11425, but to unblock the nightly build the test SASL mechanism should be change from `SCRAM-SHA-512` to `SCRAM-SHA-256`.