### PR TITLE
Change slack channel name

### DIFF
--- a/.buildkite/pipeline.yaml
+++ b/.buildkite/pipeline.yaml
@@ -11,7 +11,7 @@ steps:
     plugins:
       - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
           message: ":cloud: test eks cloud storage failed"
-          channel_name: "#kubernetes-tests"
+          channel_name: "kubernetes-tests"
           slack_token_env_var_name: "SLACK_VBOT_TOKEN"
           conditions:
             failed: true
@@ -24,7 +24,7 @@ steps:
     plugins:
       - https://$GITHUB_API_TOKEN@github.com/redpanda-data/step-slack-notify-buildkite-plugin.git#main:
           message: ":cloud: test gke cloud storage failed"
-          channel_name: "#kubernetes-tests"
+          channel_name: "kubernetes-tests"
           slack_token_env_var_name: "SLACK_VBOT_TOKEN"
           conditions:
             failed: true


### PR DESCRIPTION
Now we can see buildkite failures

https://redpandadata.slack.com/archives/C05713BAHA4/p1686818699454309
https://redpandadata.slack.com/archives/C05713BAHA4/p1686818972319629

P.S. Those are success, just to test integration. It was done using https://github.com/redpanda-data/helm-charts/commit/90d9d5daed1d3736936c468ed8952e9505989bdc commit