### PR TITLE
Disable schema registry in console configuration for 22.2.x Redpanda version

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.39
+version: 4.0.40
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.12

--- a/charts/redpanda/templates/console/configmap.yaml
+++ b/charts/redpanda/templates/console/configmap.yaml
@@ -51,7 +51,7 @@ limitations under the License.
 {{ $schemaRegistryTLS := dict "enabled" (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool }}
 
 {{ $kafkaSchemaRegistry := dict
-      "enabled" .Values.listeners.schemaRegistry.enabled
+      "enabled" (and .Values.listeners.schemaRegistry.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool)
       "urls" $urls
       "tls" $schemaRegistryTLS
 }}


### PR DESCRIPTION
Follow up https://github.com/redpanda-data/helm-charts/pull/544 as 22.2.X tests are not executed during PR.

Nightly build is testing version 22.2.11 and the console is enabled by default. As schema registry is disabled, so that console configuration should not have it enabled.

REF: 
https://github.com/redpanda-data/helm-charts/actions/runs/5296983406