### PR TITLE
Exclude testing external certificates in version 22.2.x

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.40
+version: 4.0.41
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.12

--- a/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
+++ b/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
@@ -73,7 +73,7 @@ spec:
           -connect {{ $values.external.domain }}:{{ $port }}
           {{- end }}
 
-          {{- if eq $values.listeners.schemaRegistry.external.default.tls.cert $name }}
+          {{- if and (eq $values.listeners.schemaRegistry.external.default.tls.cert $name) (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
           echo "-----> testing external tls: schema registry"
             {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}
           openssl s_client -verify_return_error -prexit \
@@ -84,7 +84,7 @@ spec:
           -connect {{ $values.external.domain }}:{{ $port }}
           {{- end }}
 
-          {{- if eq $values.listeners.http.external.default.tls.cert $name }}
+          {{- if and (eq $values.listeners.http.external.default.tls.cert $name) (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
           echo "-----> testing external tls: http api"
             {{- $port := ( first $values.listeners.http.external.default.advertisedPorts ) }}
           openssl s_client -verify_return_error -prexit \


### PR DESCRIPTION
Follow up to https://github.com/redpanda-data/helm-charts/pull/544 and https://github.com/redpanda-data/helm-charts/pull/553

The test failed https://github.com/redpanda-data/helm-charts/actions/runs/5298460320/jobs/9590824785 due to inability to verify schema registry as it doesn't exist in Redpanda configuration.