### PR TITLE
fix: restrict test scope for 22.2.x 

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -105,7 +105,7 @@ jobs:
         run: |
           .github/create-sasl-secret.sh "some-users"
 
-      - name: Move tls files to template
+      - name: Move files to redpanda template dir
         run: |
           mv external-tls-secret.yaml charts/redpanda/templates/
           cp .github/external-service.yaml charts/redpanda/templates/

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -90,7 +90,7 @@ jobs:
         run: |
           .github/create-sasl-secret.sh "some-users"
 
-      - name: Move tls files to template
+      - name: Move files to redpanda template dir
         run: |
           mv external-tls-secret.yaml charts/redpanda/templates/
           cp .github/external-service.yaml charts/redpanda/templates/

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -151,7 +151,7 @@ jobs:
         run: |
           .github/create-sasl-secret.sh "some-users"
 
-      - name: Move files to template
+      - name: Move files to redpanda template dir
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           mv external-tls-secret.yaml charts/redpanda/templates/

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -110,7 +110,7 @@ jobs:
 
       #===== Required Test Files === start
 
-      - name: Move files to template
+      - name: Move files to redpanda template dir
         if: steps.list-changed.outputs.changed == 'true'
         run: |
           cp .github/elevated-sa.yaml charts/redpanda/templates/

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.44
+version: 4.0.45
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.12

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -539,7 +539,7 @@ than 1 core.
 {{- end -}}
 
 {{- define "redpanda-22-2-x-without-sasl" -}}
-{{- $result :=  (include "redpanda-atleast-22-2-0" . | fromJson).bool -}}
+{{- $result :=  (include "redpanda-atleast-22-3-0" . | fromJson).bool -}}
 {{- if or (include "sasl-enabled" . | fromJson).bool .Values.listeners.kafka.authenticationMethod -}}
 {{-   $result := false -}}
 {{- end -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -539,7 +539,7 @@ than 1 core.
 {{- end -}}
 
 {{- define "redpanda-22-2-x-without-sasl" -}}
-{{- $result :=  (include "redpanda-atleast-22-3-0" . | fromJson).bool -}}
+{{- $result :=  (include "redpanda-atleast-22-2-0" . | fromJson).bool -}}
 {{- if or (include "sasl-enabled" . | fromJson).bool .Values.listeners.kafka.authenticationMethod -}}
 {{-   $result := false -}}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-loadbalancer-tls.yaml
+++ b/charts/redpanda/templates/tests/test-loadbalancer-tls.yaml
@@ -84,7 +84,6 @@ spec:
       {{- if eq $values.listeners.kafka.external.default.tls.cert $name }}
           echo "-----> testing external tls: kafka api"
           {{- $port := ( first $values.listeners.kafka.external.default.advertisedPorts ) }}
-          # for now static list of ips, limited by what we have in metallb-config
 
           for ip in $ip_list
           do
@@ -96,6 +95,7 @@ spec:
           done
       {{- end }}
 
+    {{- if (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
       {{- if eq $values.listeners.schemaRegistry.external.default.tls.cert $name }}
           echo "-----> testing external tls: schema registry"
           {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}
@@ -121,6 +121,7 @@ spec:
               -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key -connect $ip:{{ $port }}
           done
       {{- end }}
+    {{- end }}
 
     {{- end }}
   {{- end }}

--- a/charts/redpanda/templates/tests/test-nodeport-tls.yaml
+++ b/charts/redpanda/templates/tests/test-nodeport-tls.yaml
@@ -94,6 +94,7 @@ spec:
           done
           {{- end }}
 
+    {{- if (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
           {{- if eq $values.listeners.schemaRegistry.external.default.tls.cert $name }}
           echo "-----> testing external tls: schema registry"
           {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}
@@ -121,6 +122,7 @@ spec:
             -connect ${ip}:{{ $port }}
           done
           {{- end }}
+    {{- end }}
 
     {{- end }}
     {{- end }}


### PR DESCRIPTION
Attempting to fix nightly from test that fails on 22.2.x :

https://github.com/redpanda-data/helm-charts/actions/runs/5345274216/jobs/9690733032