### PR TITLE
Fix rack awareness

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.48
+version: 4.0.49
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.13

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -69,6 +69,7 @@ data:
   bootstrap.yaml: |
     kafka_enable_authorization: {{ (include "sasl-enabled" . | fromJson).bool }}
     enable_sasl: {{ (include "sasl-enabled" . | fromJson).bool }}
+    enable_rack_awareness: {{ .Values.rackAwareness.enabled }}
   {{- if $users }}
     superusers: {{ toJson $users }}
   {{- end }}
@@ -108,9 +109,6 @@ data:
     redpanda:
 {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
       empty_seed_starts_cluster: false
-  {{- if .Values.rackAwareness.enabled }}
-      enable_rack_awareness: true
-  {{- end }}
 {{- end }}
       kafka_enable_authorization: {{ (include "sasl-enabled" . | fromJson).bool }}
       enable_sasl: {{ (include "sasl-enabled" . | fromJson).bool }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -191,7 +191,9 @@ spec:
               {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
                 {{- if .Values.rackAwareness.enabled }}
                 # Configure Rack Awareness
+                set +x
                 RACK=$(curl --silent --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt --fail -H 'Authorization: Bearer '$(cat /run/secrets/kubernetes.io/serviceaccount/token) "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}/api/v1/nodes/${KUBERNETES_NODE_NAME}?pretty=true" | grep {{ .Values.rackAwareness.nodeAnnotation | quote | squote }} | grep -v '\"key\":' | sed 's/.*": "\([^"]\+\).*/\1/')
+                set -x
                 rpk --config "$CONFIG" redpanda config set redpanda.rack "${RACK}"
                 {{- end }}
               {{- end }}

--- a/charts/redpanda/templates/tests/test-nodeport-tls.yaml
+++ b/charts/redpanda/templates/tests/test-nodeport-tls.yaml
@@ -30,7 +30,7 @@ metadata:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
-  serviceAccountName: test-nodeport-tls-redpanda
+  serviceAccountName: test-nodeport-tls-redpanda-no-a-test
   restartPolicy: Never
   securityContext:
     runAsUser: 65535
@@ -154,36 +154,33 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: test-nodeport-tls-redpanda
+  name: test-nodeport-tls-redpanda-no-a-test
   annotations:
     helm.sh/hook-weight: "-100"
-    helm.sh/hook: test
     helm.sh/hook-delete-policy: before-hook-creation
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: test-nodeport-tls-redpanda
+  name: test-nodeport-tls-redpanda-no-a-test
   annotations:
     helm.sh/hook-weight: "-100"
-    helm.sh/hook: test
     helm.sh/hook-delete-policy: before-hook-creation
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: test-nodeport-tls-redpanda
+  name: test-nodeport-tls-redpanda-no-a-test
 subjects:
   - kind: ServiceAccount
-    name: test-nodeport-tls-redpanda
+    name: test-nodeport-tls-redpanda-no-a-test
     namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: test-nodeport-tls-redpanda
+  name: test-nodeport-tls-redpanda-no-a-test
   annotations:
     helm.sh/hook-weight: "-100"
-    helm.sh/hook: test
     helm.sh/hook-delete-policy: before-hook-creation
 rules:
   - apiGroups:
@@ -193,5 +190,4 @@ rules:
       - services
     verbs:
       - get
-
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -14,8 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if .Values.rackAwareness.enabled -}}
-  {{- if not (or (include "tls-enabled" . | fromJson).bool (include "sasl-enabled" .)) -}}
+{{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -44,7 +43,52 @@ spec:
       - -c
       - |
         set -e
-        curl --silent --fail --retry 120 --retry-max-time 120 --retry-all-errors http://{{ include "redpanda.fullname" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
-        rpk redpanda admin config print --host {{ include "redpanda.fullname" . }}:{{ .Values.listeners.admin.port }} | grep '"enable_rack_awareness": true'
-  {{- end -}}
-{{- end -}}
+    {{- if .Values.rackAwareness.enabled }}
+        curl --silent --fail --retry 120 \
+          --retry-max-time 120 --retry-all-errors \
+      {{- if (include "tls-enabled" . | fromJson).bool }}
+        {{- range $name, $cert := .Values.tls.certs }}
+          {{- if and $cert.caEnabled (eq $name "default") }}
+          --cacert {{ printf "/etc/tls/certs/%s/ca.crt" $name }} \
+          {{- end }}
+        {{- end }}
+        https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
+      {{- else }}
+        http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
+      {{- end }}
+    {{- end }}
+
+        rpk redpanda admin config print \
+      {{- if (include "tls-enabled" . | fromJson).bool }}
+        {{- range $name, $cert := .Values.tls.certs }}
+          {{- if and $cert.caEnabled (eq $name "default") }}
+          --admin-api-tls-enabled \
+          --admin-api-tls-truststore {{ printf "/etc/tls/certs/%s/ca.crt" $name }} \
+          {{- end }}
+        {{- end }}
+      {{- end }}
+          --host {{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} | grep '"enable_rack_awareness": {{ .Values.rackAwareness.enabled }}'
+
+        rpk cluster config get enable_rack_awareness {{ template "rpk-acl-user-flags" $ }} | grep '{{ .Values.rackAwareness.enabled }}'
+{{- if (include "tls-enabled" . | fromJson).bool }}
+      volumeMounts:
+  {{- range $name, $cert := .Values.tls.certs }}
+    {{- if and $cert.caEnabled (eq $name "default") }}
+        - name: redpanda-{{ $name }}-cert
+          mountPath: {{ printf "/etc/tls/certs/%s" $name }}
+    {{- end }}
+  {{- end }}
+  volumes:
+  {{- range $name, $cert := .Values.tls.certs }}
+  {{- $r :=  set $root "tempCert" ( dict "name" $name "cert" $cert ) }}
+    {{- if and $cert.caEnabled (eq $name "default") }}
+    - name: redpanda-{{ $name }}-cert
+      secret:
+        defaultMode: 420
+        items:
+        - key: ca.crt
+          path: ca.crt
+        secretName: {{ template "cert-secret-name" $r }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -69,11 +69,54 @@ spec:
 
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
-          schemaCurl -X DELETE \
-          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+          max_iteration=10
 
-          schemaCurl -X DELETE \
-          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+          for i in $(seq 1 $max_iteration)
+          do
+            curl -vv -X DELETE \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u $USERNAME:$PASSWORD \
+              {{- end }}
+              http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+            result=$?
+            if [[ $result -eq 0 ]]
+            then
+              echo "Result successful"
+              break
+            else
+              echo "Result unsuccessful"
+              sleep 1
+            fi
+          done
+
+          if [[ $result -ne 0 ]]
+          then
+            echo "All of the trials failed to delete schema!!!"
+          fi
+
+          for i in $(seq 1 $max_iteration)
+          do
+            curl -vv -X DELETE \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u $USERNAME:$PASSWORD \
+              {{- end }}
+              http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+            result=$?
+            if [[ $result -eq 0 ]]
+            then
+              echo "Result successful"
+              break
+            else
+              echo "Result unsuccessful"
+              sleep 1
+            fi
+          done
+
+          if [[ $result -ne 0 ]]
+          then
+            echo "All of the trials failed to permanently delete schema!!!"
+            exit 1
+          fi
       volumeMounts:
       {{- if $sasl.enabled }}
         - name: {{ $sasl.secretRef }}


### PR DESCRIPTION
Stop printing Kubernetes ServiceAccount Bearer token.

Stop reporting node port test resources as individual tests.

Move `enable_rack_awareness` to cluster config rather `redpanda.yaml` which is node config.

Make `enable_rack_awareness` changeable (on/off) using post-install Job as `.bootstrap.yaml` cluster config is loaded only during bootstraping.

Make rack awareness test always executable regardless of input parameters.

Schema registry test reports each HTTP call.

Docs REF:

https://docs.redpanda.com/docs/manage/rack-awareness/
https://docs.redpanda.com/docs/manage/kubernetes/kubernetes-rack-awareness/

Fix #565 