### PR TITLE
Do not test node_config in v22.2.11

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.50
+version: 4.0.51
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.13

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -43,7 +43,7 @@ spec:
       - -c
       - |
         set -e
-    {{- if .Values.rackAwareness.enabled }}
+    {{- if and .Values.rackAwareness.enabled (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
         curl --silent --fail --retry 120 \
           --retry-max-time 120 --retry-all-errors \
       {{- if (include "tls-enabled" . | fromJson).bool }}


### PR DESCRIPTION
In v22.2.11 the node config does not return enable rack awareness property.

https://github.com/redpanda-data/helm-charts/actions/runs/5418326297/jobs/9850304789#step:16:17462