### PR TITLE
Move 1 hour later nightly test with Redpanda tip of dev

### DIFF
--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -18,7 +18,7 @@ name: Nightly - Lint/Test Redpanda-Chart With Nightly Redpanda
 
 on:
   schedule:
-    - cron: '0 1 * * 1-5'  # 01:00 AM UTC Monday - Friday
+    - cron: '0 2 * * 1-5'  # 01:00 AM UTC Monday - Friday
   workflow_dispatch: {}
 jobs:
   test-redpanda-nightly:


### PR DESCRIPTION
https://github.com/redpanda-data/helm-charts/actions/runs/5481779562/jobs/9986455088#step:19:270

```
    Warning  Failed     13m (x4 over 14m)     kubelet            Failed to pull image "redpandadata/redpanda-nightly:v0.0.0-20230707gitbac6f43": rpc error: code = NotFound desc = failed to pull and unpack image "docker.io/redpandadata/redpanda-nightly:v0.0.0-20230707gitbac6f43": failed to resolve reference "docker.io/redpandadata/redpanda-nightly:v0.0.0-20230707gitbac6f43": docker.io/redpandadata/redpanda-nightly:v0.0.0-20230707gitbac6f43: not found
```

The hypothesis that this pull image is failing is that container registry configured in kind cluster is different, from what `docker-tag-list` program returns. The create kind cluster github action step does not change kind configuration:
https://github.com/helm/kind-action/blob/1307bb2fdec64b9400f7865196ea57b0f2efb30f/kind.sh

When test is re-tried few hours later, test passes.