### PR TITLE
fix typo

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.51
+version: 4.0.52
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.13
@@ -50,7 +50,7 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.1.10
+      image: docker.redpanda.com/redpandadata/redpanda:v23.1.13
     - name: busybox
       image: busybox:latest
     - name: mintel/docker-alpine-bash-curl-jq

--- a/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
+++ b/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (include "tls-enabled" . | fromJson).bool ( eq .Values.external.types "NodePort" ) }}
+{{- if and (include "tls-enabled" . | fromJson).bool ( eq .Values.external.type "NodePort" ) }}
   {{- $values := .Values }}
   {{- $root := deepCopy . }}
 apiVersion: v1


### PR DESCRIPTION
Fix typo where `external.types` should be `external.type`