### PR TITLE
Allows some more default values, based on an example values file

### DIFF
--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -2,7 +2,6 @@
   "$schema": "http://json-schema.org/schema#",
   "type": "object",
   "required": [
-    "image"
   ],
   "properties": {
     "nameOverride": {
@@ -527,21 +526,7 @@
     "statefulset": {
       "type": "object",
       "required": [
-        "replicas",
-        "updateStrategy",
-        "budget",
-        "annotations",
-        "startupProbe",
-        "livenessProbe",
-        "readinessProbe",
-        "podAffinity",
-        "podAntiAffinity",
-        "nodeSelector",
-        "priorityClassName",
-        "tolerations",
-        "topologySpreadConstraints",
-        "securityContext",
-        "sideCars"
+        "replicas"
       ],
       "properties": {
         "replicas": {
@@ -791,8 +776,7 @@
     "rbac": {
       "type": "object",
       "required": [
-        "enabled",
-        "annotations"
+        "enabled"
       ],
       "properties": {
         "enabled": {
@@ -829,11 +813,6 @@
     "listeners": {
       "type": "object",
       "required": [
-        "admin",
-        "kafka",
-        "http",
-        "rpc",
-        "schemaRegistry"
       ],
       "properties": {
         "admin": {
@@ -892,8 +871,7 @@
           "type": "object",
           "required": [
             "port",
-            "external",
-            "tls"
+            "external"
           ],
           "properties": {
             "port": {
@@ -906,7 +884,6 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
                   "required": [
-                    "port"
                   ],
                   "properties": {
                     "enabled": {
@@ -957,11 +934,8 @@
         "http": {
           "type": "object",
           "required": [
-            "enabled",
             "port",
-            "kafkaEndpoint",
-            "external",
-            "tls"
+            "external"
           ],
           "properties": {
             "enabled": {
@@ -985,7 +959,6 @@
                 "^[A-Za-z_][A-Za-z0-9_]*$": {
                   "type": "object",
                   "required": [
-                    "port"
                   ],
                   "properties": {
                     "enabled": {

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -1109,9 +1109,6 @@
     "config": {
       "type": "object",
       "required": [
-        "cluster",
-        "tunable",
-        "node"
       ],
       "properties": {
         "cluster": {


### PR DESCRIPTION
When editing a values file in VSCode with [yaml](https://github.com/redhat-developer/vscode-yaml) and `# yaml-language-server: $schema=https://github.com/redpanda-data/helm-charts/raw/redpanda-4.0.52/charts/redpanda/values.schema.json` quite a few values that do have defaults show up as required.

Here I have only removed `required` entries for the example yaml given in the first commit comment, which as far as I can see produces a working cluster.

Using defaults as much as possible is an important strategy for depending on helm charts. Validating values files using the schema helps a lot too.

Or is the schema meant for CI to validate the default values file? If so would it be possible to somehow maintain two variants of the schema?