### PR TITLE
chore: allow schema for kafkaEndpoint to allow dashes

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 4.0.53
+version: 4.0.54
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.1.13

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -972,7 +972,7 @@
             },
             "kafkaEndpoint": {
               "type": "string",
-              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+              "pattern": "^[A-Za-z_-][A-Za-z0-9_-]*$"
             },
             "authenticationMethod": {
               "type": ["string", "null"],
@@ -1077,7 +1077,7 @@
             },
             "kafkaEndpoint": {
               "type": "string",
-              "pattern": "^[A-Za-z_][A-Za-z0-9_]*$"
+              "pattern": "^[A-Za-z_-][A-Za-z0-9_-]*$"
             },
             "authenticationMethod": {
               "type": ["string", "null"],


### PR DESCRIPTION
The schema for kafkaEndpoints should also allow dashes, here we add them. 