### PR TITLE
chore: operator chart moved

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yaml
@@ -48,6 +48,7 @@ body:
       options:
         - Console
         - Redpanda
+        - Operator
 
   - type: textarea
     id: chartVersion

--- a/.github/workflows/pull_requests-operator.yaml
+++ b/.github/workflows/pull_requests-operator.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Lint and Test Charts
+name: Lint and Test Chart
 
 on:
   pull_request:
@@ -23,9 +23,9 @@ on:
       - .github/*.sh
       - .github/ct.yaml
       - .github/kind.yaml
-      - .github/workflows/pull_requests.yaml
-      - charts/**
-      - '!charts/operator/**'
+      - .github/workflows/pull_requests-operator.yaml
+      - '!charts/**'
+      - 'charts/operator'
       - '!**/*.md'
 jobs:
   lint:
@@ -75,19 +75,8 @@ jobs:
         run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/console/values.yaml') charts/console/values.yaml
   test:
     needs: lint
-    name: "${{ matrix.version }}/${{ matrix.testvaluespattern }}: Run ct tests"
+    name: Run ct tests for operator chart
     strategy:
-      matrix:
-        version:
-          - ""
-          - v22.3.17
-          # - v22.2.x takes too long. Only run nightly.
-        testvaluespattern:
-          - '0[1-3]*'
-          - '0[4-6]*'
-          - '0[7-9]*'
-          - '1[0-2]*'
-          - '1[3-5]*'
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:
@@ -114,17 +103,11 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --excluded-charts console,operator )
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --excluded-charts console,redpanda )
           echo $changed
           if [[ -n "$changed" ]]; then
             echo changed="true" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: Set up for matrix
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          echo bash -O extglob -c "rm -v charts/redpanda/ci/!(${{ matrix.testvaluespattern }})"
-          bash -O extglob -c "rm -v charts/redpanda/ci/!(${{ matrix.testvaluespattern }})"
 
       - name: Create kind cluster
         uses: helm/kind-action@v1.5.0
@@ -140,27 +123,6 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: .github/annotate_kind_nodes.sh chart-testing
 
-    #===== Required Test Files === start
-
-      - name: Create tls helm templates
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          .github/create_tls.sh "random-domain"
-
-      - name: Create sasl secret templates
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          .github/create-sasl-secret.sh "some-users"
-
-      - name: Move files to redpanda template dir
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          mv external-tls-secret.yaml charts/redpanda/templates/
-          cp .github/external-service.yaml charts/redpanda/templates/
-          mv some-users-updated.yaml charts/redpanda/templates/
-
-    #===== Required Test Files === end
-
       - name: install cert-manager
         if: steps.list-changed.outputs.changed == 'true'
         run: |
@@ -169,17 +131,10 @@ jobs:
             --create-namespace --version v1.11.0 jetstack/cert-manager \
             --set installCRDs=true --wait --wait-for-jobs
 
-      - name: install metallb
+      - name: Install CRDs
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          helm repo add metallb https://metallb.github.io/metallb &&
-          helm install metallb metallb/metallb -n metallb-system \
-            --create-namespace --version 0.13.10 --wait --wait-for-jobs
-
-      - name: apply metallb resources
-        if: steps.list-changed.outputs.changed == 'true'
-        run: |
-          kubectl -n metallb-system apply -f .github/metallb-config.yaml
+          kubectl kustomize https://github.com/redpanda-data/redpanda//src/go/k8s/config/crd | kubectl apply -f -        
 
       - name: Run chart-testing (install and upgrade)
         if: steps.list-changed.outputs.changed == 'true'
@@ -190,7 +145,7 @@ jobs:
             --config .github/ct.yaml \
             --helm-extra-set-args="--set=image.tag=${{ matrix.version }}" \
             --skip-missing-values \
-            --excluded-charts console,operator \
+            --excluded-charts console,redpanda \
             --target-branch ${{ github.event.repository.default_branch }}
   summary:
     if: always()

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -23,13 +23,14 @@ on:
       - .github/*.sh
       - .github/ct.yaml
       - .github/kind.yaml
-      - .github/workflows/pull_requests.yaml
+      - .github/workflows/pull_requests_from_origin.yaml
       - charts/**
+      - '!charts/operator/**'
       - '!**/*.md'
 jobs:
   test:
     if: ${{ github.event.pull_request.head.repo.full_name == 'redpanda-data/helm-charts' }}
-    name: Run ct tests for ci values matching ${{ matrix.testvaluespattern }} for Redpanda version ${{ matrix.version }}
+    name: "${{ matrix.version }}/${{ matrix.testvaluespattern }}: Run ct tests"
     strategy:
       matrix:
         version:
@@ -63,7 +64,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --excluded-charts console )
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --excluded-charts console,operator )
           echo $changed
           if [[ -n "$changed" ]]; then
             echo changed="true" >> "$GITHUB_OUTPUT"
@@ -137,5 +138,5 @@ jobs:
             --config .github/ct.yaml \
             --helm-extra-set-args="--set=image.tag=${{ matrix.version }}" \
             --skip-missing-values \
-            --excluded-charts console \
+            --excluded-charts console,operator \
             --target-branch ${{ github.event.repository.default_branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ admin.conf
 # OSX files
 .DS_Store
 
+# asdf
+.tool-versions
+
 # templated ci values
 charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml
 

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: operator
+description: Redpanda operator helm chart
+type: application
+
+# This is the chart version. This is only placeholder that will be set during release process
+version: 0.3.1
+
+# This is the version number of the application being deployed. This is only placeholder that
+# will be set during release process.
+appVersion: v23.2.1-rc9
+
+home: https://vectorized.io
+sources:
+  - https://github.com/redpanda-data/redpanda
+maintainers:
+  - name: Vectorizedio
+    email: support@vectorized.io
+
+dependencies:
+- name: kube-prometheus-stack
+  condition: monitoring.enabled
+  version: 13.13.1
+  repository: https://prometheus-community.github.io/helm-charts

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -1,0 +1,88 @@
+# Redpanda Operator
+
+![Version: 0.1.0](https://img.shields.io/badge/Version-0.1.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v21.3.4](https://img.shields.io/badge/AppVersion-v21.3.4-informational?style=flat-square)
+
+## Installation
+
+### Prerequisite
+
+To deploy operator with webhooks (enabled by default) please install
+cert manager. Please follow
+[the installation guide](https://cert-manager.io/docs/installation/)
+
+The cert manager needs around 1 minute to be ready. The helm chart
+will create Issuer and Certificate custom resource. The
+webhook of cert-manager will prevent from creating mentioned
+resources. To verify that cert manager is ready please follow
+[the verifying the installation](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
+
+The operator by default exposes metrics endpoint. By leveraging prometheus
+operator ServiceMonitor custom resource metrics can be automatically
+discovered.
+
+1. Install Redpanda operator CRDs:
+
+```sh
+kubectl apply -k 'https://github.com/redpanda-data/redpanda/src/go/k8s/config/crd?ref=v21.3.4'
+```
+
+> The CRDs are decoupled from helm chart, so that helm release can be
+> removed without cascading deletion of underling custom resources.
+> Other argument for decoupling is that helm cli can incorrectly
+> patch the Custom Resource Definition.
+
+### Helm installation
+
+1. Install the Redpanda operator:
+
+> The example command should be invoked from `src/go/k8s/helm-chart/charts`
+
+```sh
+helm install --namespace redpanda-system --create-namespace redpanda-system ./redpanda-operator
+```
+
+Alternative installation with kube-prometheus-stack that includes prometheus operator CRD
+```sh
+helm install --dependency-update \
+--namespace redpanda-system \
+--set monitoring.enabled=true \
+--create-namespace redpanda-operator ./redpanda-operator
+```
+
+Other instruction will be visible after installation.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Allows to specify affinity for Redpanda Operator PODs |
+| config.apiVersion | string | `"controller-runtime.sigs.k8s.io/v1alpha1"` |  |
+| config.health.healthProbeBindAddress | string | `":8081"` |  |
+| config.kind | string | `"ControllerManagerConfig"` |  |
+| config.leaderElection.leaderElect | bool | `true` |  |
+| config.leaderElection.resourceName | string | `"aa9fc693.vectorized.io"` |  |
+| config.metrics.bindAddress | string | `"127.0.0.1:8080"` |  |
+| config.webhook.port | int | `9443` |  |
+| configurator.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Redpanda configurator image |
+| configurator.repository | string | `"vectorized/configurator"` | Repository that Redpanda configurator image is available |
+| configurator.tag | string | `"{{ .Chart.AppVersion }}"` | Define the Redpanda configurator container tag |
+| clusterDomain | string | `cluster.local` | Defines Kubernetes Cluster Domain |
+| fullnameOverride | string | `""` | Override the fully qualified app name |
+| image.pullPolicy | string | `"IfNotPresent"` | Define the pullPolicy for Redpanda Operator image |
+| image.repository | string | `"vectorized/redpanda-operator"` | Repository that Redpanda Operator image is available |
+| image.tag | string | `"{{ .Chart.AppVersion }}"` | Define the Redpanda Operator container tag |
+| imagePullSecrets | list | `[]` | Redpanda Operator container registry pullSecret (ex: specify docker registry credentials) |
+| labels | string | `nil` | Allows to assign labels to the resources created by this helm chart |
+| logLevel | string | `"info"` | Set Redpanda Operator log level (debug, info, error, panic, fatal) |
+| monitoring | object | `{"enabled":false}` | Add service monitor to the deployment |
+| nameOverride | string | `""` | Override name of app |
+| nodeSelector | object | `{}` | Allows to schedule Redpanda Operator on specific nodes |
+| podAnnotations | object | `{}` | Allows setting additional annotations for Redpanda Operator PODs |
+| podLabels | object | `{}` | Allows setting additional labels for for Redpanda Operator PODs |
+| rbac.create | bool | `true` | Specifies whether the RBAC resources should be created |
+| replicaCount | int | `1` | Number of instances of Redpanda Operator |
+| resources | object | `{}` | Set resources requests/limits for Redpanda Operator PODs |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `nil` | The name of the service account to use. If not set name is generated using the fullname template |
+| tolerations | list | `[]` | Allows to schedule Redpanda Operator on tainted nodes |
+| webhook.enabled | bool | `true` |  |

--- a/charts/operator/README.md.gotmpl
+++ b/charts/operator/README.md.gotmpl
@@ -1,0 +1,54 @@
+# Redpanda Operator
+
+{{ template "chart.versionBadge" . }}{{ template "chart.typeBadge" . }}{{ template "chart.appVersionBadge" . }}
+
+## Installation
+
+### Prerequisite
+
+To deploy operator with webhooks (enabled by default) please install
+cert manager. Please follow
+[the installation guide](https://cert-manager.io/docs/installation/)
+
+The cert manager needs around 1 minute to be ready. The helm chart
+will create Issuer and Certificate custom resource. The
+webhook of cert-manager will prevent from creating mentioned
+resources. To verify that cert manager is ready please follow
+[the verifying the installation](https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation)
+
+The operator by default exposes metrics endpoint. By leveraging prometheus
+operator ServiceMonitor custom resource metrics can be automatically
+discovered.
+
+1. Install Redpanda operator CRDs:
+
+```sh
+kubectl apply -k 'https://github.com/redpanda-data/redpanda/src/go/k8s/config/crd?ref={{ template "chart.appVersion" . }}'
+```
+
+> The CRDs are decoupled from helm chart, so that helm release can be
+> removed without cascading deletion of underling custom resources.
+> Other argument for decoupling is that helm cli can incorrectly
+> patch the Custom Resource Definition.
+
+### Helm installation
+
+1. Install the Redpanda operator:
+
+> The example command should be invoked from `src/go/k8s/helm-chart/charts`
+
+```sh
+helm install --namespace redpanda-system --create-namespace redpanda-operator ./redpanda-operator
+```
+
+Alternative installation with kube-prometheus-stack that includes prometheus operator CRD
+```sh
+helm install --dependency-update \
+--namespace redpanda-system \
+--set monitoring.enabled=true \
+--create-namespace redpanda-operator ./redpanda-operator
+```
+
+Other instruction will be visible after installation.
+
+{{ template "chart.valuesSection" . }}

--- a/charts/operator/ci/01-namespaced.yaml
+++ b/charts/operator/ci/01-namespaced.yaml
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# This is left empty to test the default values

--- a/charts/operator/ci/02-cluster.yaml
+++ b/charts/operator/ci/02-cluster.yaml
@@ -12,25 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-name: Lint and Test Charts
-
-on:
-  pull_request:
-    branches:
-      - "**"
-    paths-ignore:
-      - .github/*.sh
-      - .github/ct.yaml
-      - .github/kind.yaml
-      - .github/workflows/pull_requests.yaml
-      - charts/**
-jobs:
-  lint:
-    runs-on: ubuntu-22.04
-    steps:
-      - run: true
-  summary:
-    runs-on: ubuntu-22.04
-    steps:
-      - run: true
+---
+scope: Cluster
+webhook:
+  enabled: true

--- a/charts/operator/files/three_node_cluster.yaml
+++ b/charts/operator/files/three_node_cluster.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: redpanda.vectorized.io/v1alpha1
+kind: Cluster
+metadata:
+  name: cluster-tls
+spec:
+  image: "docker.redpanda.com/redpandadata/redpanda"
+  version: "latest"
+  replicas: 3
+  resources:
+    requests:
+      cpu: 100m
+      memory: 100Mi
+    limits:
+      cpu: 1
+      memory: 1.2Gi
+  configuration:
+    rpcServer:
+      port: 33145
+    kafkaApi:
+      - port: 9092
+        tls:
+          enabled: true
+          requireClientAuth: true
+    adminApi:
+    - port: 9644
+    pandaproxyApi:
+    - port: 8082
+    developerMode: true

--- a/charts/operator/files/three_node_redpanda.yaml
+++ b/charts/operator/files/three_node_redpanda.yaml
@@ -1,0 +1,80 @@
+apiVersion: cluster.redpanda.com/v1alpha1
+kind: Redpanda
+metadata:
+  name: cluster-tls
+spec:
+  chartRef:
+    chartVersion: ">4.0.0"
+  clusterSpec:
+    console:
+      enabled: false
+    image:
+      repository: docker.redpanda.com/redpandadata/redpanda
+      tag: v23.1.13
+    listeners:
+      admin:
+        external: {}
+        port: 9644
+        tls:
+          cert: ""
+          enabled: false
+          requireClientAuth: false
+      http:
+        authenticationMethod: none
+        enabled: true
+        external: {}
+        kafkaEndpoint: kafka-default
+        port: 8082
+        tls:
+          cert: ""
+          enabled: false
+          requireClientAuth: false
+      kafka:
+        authenticationMethod: none
+        external: {}
+        port: 9092
+        tls:
+          cert: kafka-internal-0
+          enabled: true
+          requireClientAuth: true
+      rpc:
+        port: 33145
+    logging:
+      logLevel: trace
+      usageStats:
+        enabled: false
+    resources:
+      cpu:
+        cores: 1
+      memory:
+        container:
+          max: 2Gi
+          min: 2Gi
+    statefulset:
+      replicas: 3
+    storage:
+      persistentVolume:
+        enabled: true
+        size: 100Gi
+    tls:
+      certs:
+        kafka-internal-0:
+          caEnabled: true
+      enabled: true
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: cluster-tls-user-client
+spec:
+  emailAddresses:
+    - test@domain.dom
+  duration: 43800h0m0s
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: cluster-tls-kafka-internal-0-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: cluster-tls-user-client

--- a/charts/operator/templates/NOTES.txt
+++ b/charts/operator/templates/NOTES.txt
@@ -1,0 +1,18 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+Congratulations on installing {{ .Chart.Name }}!
+
+The pods will rollout in a few seconds. To check the status:
+
+  kubectl -n {{ .Release.Namespace }} rollout status -w deployment/{{ template "redpanda-operator.fullname" . }}
+
+Now you can install a Redpanda resource!

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "redpanda-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "redpanda-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "redpanda-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{- define "redpanda-operator.webhook-cert" -}}
+{{- printf .Values.webhookSecretName }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "redpanda-operator.labels" -}}
+app.kubernetes.io/name: {{ include "redpanda-operator.name" . }}
+helm.sh/chart: {{ include "redpanda-operator.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "redpanda-operator.serviceAccountName" -}}
+{{ default (include "redpanda-operator.fullname" .) .Values.serviceAccount.name }}
+{{- end -}}
+
+{{- define "operator.tag" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- $matchString := "^v(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$|^latest$" -}}
+{{- $match := mustRegexMatch $matchString $tag -}} 
+{{- if not $match -}}
+  {{/*
+  This error message is for end users. This can also occur if
+  AppVersion doesn't start with a 'v' in Chart.yaml.
+  */}}
+  {{ fail "image.tag must start with a 'v' and be valid semver" }}
+{{- end -}} 
+{{- $tag -}}
+{{- end -}}

--- a/charts/operator/templates/certificate.yaml
+++ b/charts/operator/templates/certificate.yaml
@@ -1,0 +1,29 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if .Values.webhook.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-serving-cert
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+spec:
+  dnsNames:
+    - {{ include "redpanda-operator.name" . }}-webhook-service.{{ .Release.Namespace }}.svc
+    - {{ include "redpanda-operator.name" . }}-webhook-service.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
+  issuerRef:
+    kind: Issuer
+    name: {{ include "redpanda-operator.fullname" . }}-selfsigned-issuer
+  secretName: {{ include "redpanda-operator.webhook-cert" . }}
+  privateKey:
+    rotationPolicy: Never
+{{- end }}

--- a/charts/operator/templates/clusterrole.yaml
+++ b/charts/operator/templates/clusterrole.yaml
@@ -1,0 +1,246 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - cert-manager.io
+  resources:
+  - certificates
+  - clusterissuers
+  - issuers
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - pods/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - services
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - clusters/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - consoles
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - consoles/finalizers
+  verbs:
+  - update
+- apiGroups:
+  - redpanda.vectorized.io
+  resources:
+  - consoles/status
+  verbs:
+  - get
+  - patch
+  - update
+{{- end -}}

--- a/charts/operator/templates/clusterrole_binding.yaml
+++ b/charts/operator/templates/clusterrole_binding.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redpanda-operator.fullname" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ template "redpanda-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/operator/templates/clusterrole_metrics.yaml
+++ b/charts/operator/templates/clusterrole_metrics.yaml
@@ -1,0 +1,24 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-metrics-reader
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get
+{{- end -}}

--- a/charts/operator/templates/clusterrole_proxy.yaml
+++ b/charts/operator/templates/clusterrole_proxy.yaml
@@ -1,0 +1,32 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-proxy-role
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create
+{{- end -}}

--- a/charts/operator/templates/clusterrole_proxy_binding.yaml
+++ b/charts/operator/templates/clusterrole_proxy_binding.yaml
@@ -1,0 +1,27 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-proxy-role
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redpanda-operator.fullname" . }}-proxy-role
+subjects:
+- kind: ServiceAccount
+  name: {{ template "redpanda-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/operator/templates/configmap.yaml
+++ b/charts/operator/templates/configmap.yaml
@@ -1,0 +1,20 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-config
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+data:
+  controller_manager_config.yaml: |
+    {{ .Values.config }}

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -1,0 +1,118 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}
+  labels:
+    {{ include "redpanda-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "redpanda-operator.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "redpanda-operator.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- if .Values.podLabels }}
+        {{ toYaml .Values.podLabels | nindent 8 }}
+        {{- end }}
+      annotations:
+        {{- if .Values.podAnnotations }}
+        {{ toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ include "redpanda-operator.serviceAccountName" . }}
+      containers:
+      - name: manager
+        image: "{{ .Values.image.repository }}:{{ include "operator.tag" . }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args:
+        - --health-probe-bind-address=:8081
+        - --metrics-bind-address=127.0.0.1:8080
+        - --leader-elect
+        {{- if and .Values.webhook.enabled (eq .Values.scope "Cluster" ) }}
+        - --webhook-enabled=true
+        {{- else }}
+        - --webhook-enabled=false
+        {{- end }}
+        {{- if eq .Values.scope "Namespace" }}
+        - --namespace={{ .Release.Namespace }}
+        - --log-level={{ .Values.logLevel }}
+        {{- end }}
+        command:
+        - /manager
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz/
+            port: 8081
+          initialDelaySeconds: 15
+          periodSeconds: 20
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: 8081
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        securityContext:
+          allowPrivilegeEscalation: false
+        {{- if .Values.webhook.enabled }}
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources | nindent 12 }}
+      - name: kube-rbac-proxy
+        args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=10
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        ports:
+        - containerPort: 8443
+          name: https
+      securityContext:
+        runAsUser: 65532
+      terminationGracePeriodSeconds: 10
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.webhook.enabled }}
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: {{ include "redpanda-operator.webhook-cert" . }}
+      {{- end }}

--- a/charts/operator/templates/extra_role.yaml
+++ b/charts/operator/templates/extra_role.yaml
@@ -1,0 +1,46 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{/* 
+This is really only used for tests so far
+*/}}
+
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-pvc
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - persistentvolumeclaims
+  verbs:
+  - list
+  - delete
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-pvc
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "redpanda-operator.fullname" . }}-pvc
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "redpanda-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/operator/templates/issuer.yaml
+++ b/charts/operator/templates/issuer.yaml
@@ -1,0 +1,21 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if .Values.webhook.enabled }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-selfsigned-issuer
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+spec:
+  selfSigned: {}
+{{- end }}

--- a/charts/operator/templates/mutating_webhook.yaml
+++ b/charts/operator/templates/mutating_webhook.yaml
@@ -1,0 +1,41 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.webhook.enabled (eq .Values.scope "Cluster" ) -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/redpanda-serving-cert
+  name: {{ include "redpanda-operator.fullname" . }}-mutating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "redpanda-operator.name" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /mutate-redpanda-vectorized-io-v1alpha1-cluster
+    failurePolicy: Fail
+    name: mcluster.kb.io
+    rules:
+    - apiGroups:
+      - redpanda.vectorized.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - clusters
+    sideEffects: None
+{{- end }}

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -1,0 +1,320 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-election-role
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+- apiGroups:
+  - ""
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+{{- if eq .Values.scope "Namespace" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - deployments
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - certificates
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - cert-manager.io
+    resources:
+      - issuers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - cluster.redpanda.com
+    resources:
+      - redpandas
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - cluster.redpanda.com
+    resources:
+      - redpandas/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - cluster.redpanda.com
+    resources:
+      - redpandas/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - serviceaccounts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - helm.toolkit.fluxcd.io
+    resources:
+      - helmreleases/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - buckets
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - gitrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmcharts/status
+    verbs:
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/finalizers
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - source.toolkit.fluxcd.io
+    resources:
+      - helmrepositories/status
+    verbs:
+      - get
+      - patch
+      - update
+  {{- end }}
+{{- end}}

--- a/charts/operator/templates/role_binding.yaml
+++ b/charts/operator/templates/role_binding.yaml
@@ -1,0 +1,44 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if .Values.rbac.create -}}
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-election-rolebinding
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "redpanda-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ include "redpanda-operator.fullname" . }}-election-role
+  apiGroup: rbac.authorization.k8s.io
+  {{- if eq .Values.scope "Namespace" }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "redpanda-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "redpanda-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+  {{- end }}
+{{- end -}}

--- a/charts/operator/templates/service_account.yaml
+++ b/charts/operator/templates/service_account.yaml
@@ -1,0 +1,19 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "redpanda-operator.serviceAccountName" . }}
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+{{- end -}}

--- a/charts/operator/templates/service_metrics.yaml
+++ b/charts/operator/templates/service_metrics.yaml
@@ -1,0 +1,25 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redpanda-operator.name" . }}-metrics-service
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: https
+  selector:
+    app.kubernetes.io/name: {{ include "redpanda-operator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/operator/templates/service_webhook.yaml
+++ b/charts/operator/templates/service_webhook.yaml
@@ -1,0 +1,26 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.webhook.enabled (eq .Values.scope "Cluster" ) -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "redpanda-operator.name" . }}-webhook-service
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    app.kubernetes.io/name: {{ include "redpanda-operator.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}

--- a/charts/operator/templates/servicemonitor.yaml
+++ b/charts/operator/templates/servicemonitor.yaml
@@ -1,0 +1,33 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if .Values.monitoring.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "redpanda-operator.name" . }}-metrics-monitor
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    path: /metrics
+    port: https
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+{{ include "redpanda-operator.labels" . | indent 6 }}
+{{- end -}}

--- a/charts/operator/templates/tests/create-topic-with-client-auth.yaml
+++ b/charts/operator/templates/tests/create-topic-with-client-auth.yaml
@@ -1,0 +1,71 @@
+{{- $file := "files/three_node_redpanda.yaml" -}}
+{{- $resourceType := "redpanda" -}}
+{{- if and .Values.webhook.enabled (eq .Values.scope "Cluster" ) -}}
+  {{- $file = "files/three_node_cluster.yaml" -}}
+  {{- $resourceType := "cluster" -}}
+{{- else if ne .Values.scope "Namespace" -}}
+  {{ fail "invalid combination of scope and webhook.enabled" }}
+{{- end -}}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: create-test-topic-tls
+  annotations:
+    helm.sh/hook: test
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "2"
+spec:
+  serviceAccount: {{ include "redpanda-operator.fullname" . }}
+  containers:
+    - name: rpk
+      image: docker.redpanda.com/redpandadata/redpanda:latest
+      env:
+        - name: KUBECTL_VERSION
+          value: v1.27.4
+      command:
+        - /bin/bash
+        - -c
+        - |
+          set -xeuo pipefail
+
+          # Setup for the test
+          mkdir -p /etc/redpanda
+          cat > /etc/redpanda/redpanda.yaml << EOF
+          redpanda:
+          rpk:
+            kafka_api:
+              brokers:
+                - cluster-tls-0.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
+              tls:
+                enabled: true
+                key_file: /tmp/tls.key
+                cert_file: /tmp/tls.crt
+                truststore_file: /tmp/ca.crt
+          EOF
+          curl -Ls https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/amd64/kubectl -o /tmp/kubectl-${KUBECTL_VERSION}
+          echo "$(curl -Ls https://dl.k8s.io/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256) /tmp/kubectl-${KUBECTL_VERSION}" | sha256sum --check
+          chmod +x /tmp/kubectl-${KUBECTL_VERSION}
+          KUBECTL=/tmp/kubectl-${KUBECTL_VERSION}
+
+          # Create the Redpanda resource
+          $KUBECTL -n {{ .Release.Namespace }} apply -f - <<EOF
+{{- .Files.Get $file | nindent 10 }}
+          EOF
+
+          # Wait for things to be ready
+          $KUBECTL -n {{ .Release.Namespace }} wait --for=condition=Ready --timeout=10m {{ $resourceType }}/cluster-tls
+          $KUBECTL -n {{ .Release.Namespace }} wait --for=jsonpath='{.metadata.name}'=cluster-tls-user-client --timeout=10m secret/cluster-tls-user-client
+          $KUBECTL -n {{ .Release.Namespace }} get secret cluster-tls-user-client -o go-template='{{ `{{ base64decode (index .data "tls.crt") }}` }}' > /tmp/tls.crt
+          $KUBECTL -n {{ .Release.Namespace }} get secret cluster-tls-user-client -o go-template='{{ `{{ base64decode (index .data "tls.key") }}` }}' > /tmp/tls.key
+          $KUBECTL -n {{ .Release.Namespace }} get secret cluster-tls-user-client -o go-template='{{ `{{ base64decode (index .data "ca.crt") }}` }}' > /tmp/ca.crt
+
+          # Make sure Redpanda works
+          rpk topic create test -v
+
+          # Clean up
+          $KUBECTL -n {{ .Release.Namespace }} delete -f - <<EOF
+{{- .Files.Get $file | nindent 10 }}
+          EOF
+          $KUBECTL -n {{ .Release.Namespace }} delete pvc --all
+  restartPolicy: Never

--- a/charts/operator/templates/validating_webhook.yaml
+++ b/charts/operator/templates/validating_webhook.yaml
@@ -1,0 +1,41 @@
+{{/*
+Copyright 2020 Redpanda Data, Inc.
+
+Use of this software is governed by the Business Source License
+included in the file licenses/BSL.md
+
+As of the Change Date specified in that file, in accordance with
+the Business Source License, use of this software will be governed
+by the Apache License, Version 2.0
+*/}}
+
+{{- if and .Values.webhook.enabled (eq .Values.scope "Cluster" ) -}}
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  annotations:
+    cert-manager.io/inject-ca-from: {{ .Release.Namespace }}/redpanda-serving-cert
+  name: {{ include "redpanda-operator.fullname" . }}-validating-webhook-configuration
+webhooks:
+  - admissionReviewVersions:
+    - v1
+    - v1beta1
+    clientConfig:
+      service:
+        name: {{ include "redpanda-operator.name" . }}-webhook-service
+        namespace: {{ .Release.Namespace }}
+        path: /validate-redpanda-vectorized-io-v1alpha1-cluster
+    failurePolicy: Fail
+    name: mcluster.kb.io
+    rules:
+    - apiGroups:
+      - redpanda.vectorized.io
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - clusters
+    sideEffects: None
+{{- end -}}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -1,0 +1,102 @@
+# Default values for redpanda-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# nameOverride -- Override name of app
+nameOverride: ""
+
+# fullnameOverride -- Override the fully qualified app name
+fullnameOverride: ""
+
+# replicaCount -- Number of instances of Redpanda Operator
+replicaCount: 1
+
+# Kubernetes Cluster Domain
+clusterDomain: cluster.local
+
+image:
+  # image.repository -- Repository that Redpanda Operator image is available
+  repository: docker.redpanda.com/redpandadata/redpanda-operator
+  # image.tag -- Define the Redpanda Operator container tag
+  # tag:
+  # image.pullPolicy -- Define the pullPolicy for Redpanda Operator image
+  pullPolicy: IfNotPresent
+
+configurator:
+  # configurator.repository -- Repository that Redpanda configurator image is available
+  repository: docker.redpanda.com/redpandadata/configurator
+  # configurator.tag -- Define the Redpanda configurator container tag
+  # tag:
+  # configurator.pullPolicy -- Define the pullPolicy for Redpanda configurator image
+  pullPolicy: IfNotPresent
+
+config:
+  apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+  kind: ControllerManagerConfig
+  health:
+    healthProbeBindAddress: :8081
+  metrics:
+    bindAddress: 127.0.0.1:8080
+  webhook:
+    port: 9443
+  leaderElection:
+    leaderElect: true
+    resourceName: aa9fc693.vectorized.io
+
+# imagePullSecrets -- Redpanda Operator container registry pullSecret (ex: specify docker registry credentials)
+imagePullSecrets: []
+
+# logLevel -- Set Redpanda Operator log level (debug, info, error, panic, fatal)
+logLevel: "info"
+
+rbac:
+  # rbac.create -- Specifies whether the RBAC resources should be created
+  create: true
+
+webhook:
+  # webhook.create -- Specifies whether the Webhook resources should configured
+  enabled: false
+
+serviceAccount:
+  # serviceAccount.create -- Specifies whether a service account should be created
+  create: true
+  # serviceAccount.name -- The name of the service account to use. If not set name is generated using the fullname template
+  name:
+
+# resources -- Set resources requests/limits for Redpanda Operator PODs
+resources: {}
+# We usually recommend not to specify default resources and to leave this as a conscious
+# choice for the user. This also increases chances charts run on environments with little
+# resources, such as Minikube. If you do want to specify resources, uncomment the following
+# lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+#  limits:
+#   cpu: 100m
+#   memory: 30Mi
+#  requests:
+#   cpu: 100m
+#   memory: 20Mi
+
+# nodeSelector -- Allows to schedule Redpanda Operator on specific nodes
+nodeSelector: {}
+# tolerations -- Allows to schedule Redpanda Operator on tainted nodes
+tolerations: []
+# affinity -- Allows to specify affinity for Redpanda Operator PODs
+affinity: {}
+
+# podAnnotations -- Allows setting additional annotations for Redpanda Operator PODs
+podAnnotations: {}
+# podLabels -- Allows setting additional labels for for Redpanda Operator PODs
+podLabels: {}
+
+# labels -- Allows to assign labels to the resources created by this helm chart
+labels:
+
+# monitoring -- Add service monitor to the deployment
+monitoring:
+  enabled: false
+
+webhookSecretName: webhook-server-cert
+
+# scope -- change the scope and therefore the resource the controller will manage
+# only "Cluster" and "Namespace" supported
+scope: Namespace


### PR DESCRIPTION
Migration of this chart operator chart originally found in the redpanda dev branch. 

TODO:
- Migrate history?
- Make clean up changes to chart
- Determine if we are want this to be a breaking change with no expectations of upgrades possible
- Update testing if necessary
- Make necessary changes to the github workflows

