### PR TITLE
Retry resource group deletion as it not always delete resource group

### DIFF
--- a/.buildkite/hooks/pre-exit
+++ b/.buildkite/hooks/pre-exit
@@ -66,6 +66,9 @@ cleanup_aks() {
 
     docker run -v $(realpath .azure):/root/.azure mcr.microsoft.com/azure-cli:2.50.0 \
       az group delete --resource-group $TEST_RESOURCE_GROUP --yes --debug
+
+    docker run -v $(realpath .azure):/root/.azure mcr.microsoft.com/azure-cli:2.50.0 \
+      az group delete --resource-group $TEST_RESOURCE_GROUP --yes --debug || true
 }
 
 cleanup_"${CLOUD_PROVIDER}"


### PR DESCRIPTION
Few resource was left behind even when deletion operation finished. The same command is called to remove the rest leftovers.

REF:

https://buildkite.com/redpanda/helm-charts/builds/470#018985aa-71a4-4331-8f8e-f62c1bb9c054