### PR TITLE
Remove unused chart releaser definition

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.0.2
+version: 5.0.3
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.2.2

--- a/charts/redpanda/cr.yaml
+++ b/charts/redpanda/cr.yaml
@@ -1,6 +1,0 @@
-owner: redpanda-data
-git-repo: redpanda-data/helm-charts
-token: lab
-make-release-latest: true
-generate-release-notes: true
-package-path: ./charts/


### PR DESCRIPTION
```
Notice that if no config file is specified, cr.yaml (or any of the supported formats) is loaded from the current directory, $HOME/.cr, or /etc/cr, in that order, if found.
```