### PR TITLE
Fix chart testing configuration per individual Github action pipeline

### DIFF
--- a/.github/ct-kminion.yaml
+++ b/.github/ct-kminion.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+debug: true
+remote: origin
+target-branch: main
+helm-extra-args: --timeout 900s
+chart-repos:
+  - redpanda=https://charts.redpanda.com
+charts:
+  - charts/kminion

--- a/.github/ct-operator.yaml
+++ b/.github/ct-operator.yaml
@@ -18,4 +18,5 @@ target-branch: main
 helm-extra-args: --timeout 900s
 chart-repos:
   - redpanda=https://charts.redpanda.com
-
+charts:
+  - charts/operator

--- a/.github/ct-redpanda.yaml
+++ b/.github/ct-redpanda.yaml
@@ -1,0 +1,22 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+debug: true
+remote: origin
+target-branch: main
+helm-extra-args: --timeout 900s
+chart-repos:
+  - redpanda=https://charts.redpanda.com
+charts:
+  - charts/redpanda

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -43,7 +43,7 @@ jobs:
           version: v3.8.0-1
 
       - name: Run chart-testing (lint)
-        run: ct lint --all --config .github/ct.yaml
+        run: ct lint --all --config .github/ct-redpanda.yaml
   test:
     name: Run ct tests for ci values matching ${{ matrix.testvaluespattern }} for Redpanda version ${{ matrix.version }}
     strategy:
@@ -136,7 +136,6 @@ jobs:
           ct install \
             --github-groups \
             --upgrade \
-            --config .github/ct.yaml \
+            --config .github/ct-redpanda.yaml \
             --helm-extra-set-args="--set=image.tag=${{ matrix.version }}" \
-            --skip-missing-values \
-            --charts=charts/redpanda
+            --skip-missing-values

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -119,7 +119,6 @@ jobs:
         run: |
           ct install \
             --github-groups \
-            --config .github/ct.yaml \
+            --config .github/ct-redpanda.yaml \
             --helm-extra-set-args="--set=image.tag=${{ steps.latestTag.outputs.TAG }} --set=image.repository=redpandadata/redpanda-nightly" \
-            --skip-missing-values \
-            --charts=charts/redpanda
+            --skip-missing-values

--- a/.github/workflows/pull_requests-operator.yaml
+++ b/.github/workflows/pull_requests-operator.yaml
@@ -52,7 +52,7 @@ jobs:
           version: v3.8.0-1
 
       - name: Run chart-testing (lint)
-        run: ct lint --config .github/ct.yaml --github-groups --chart-dirs=charts/operator
+        run: ct lint --config .github/ct-operator.yaml --github-groups
 
   check-values:
     runs-on: ubuntu-22.04
@@ -102,7 +102,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=charts/operator )
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           echo $changed
           if [[ -n "$changed" ]]; then
             echo changed="true" >> "$GITHUB_OUTPUT"
@@ -141,9 +141,8 @@ jobs:
           ct install \
             --github-groups \
             --upgrade \
-            --config .github/ct.yaml \
+            --config .github/ct-operator.yaml \
             --skip-missing-values \
-            --chart-dirs=charts/operator \
             --target-branch ${{ github.event.repository.default_branch }}
   summary:
     if: always()

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -53,7 +53,7 @@ jobs:
           version: v3.8.0-1
 
       - name: Run chart-testing (lint)
-        run: ct lint --config .github/ct.yaml --github-groups
+        run: ct lint --config .github/ct-redpanda.yaml --github-groups
 
   check-values:
     runs-on: ubuntu-22.04
@@ -114,7 +114,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=charts/redpanda )
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           echo $changed
           if [[ -n "$changed" ]]; then
             echo changed="true" >> "$GITHUB_OUTPUT"
@@ -187,7 +187,7 @@ jobs:
           ct install \
             --github-groups \
             --upgrade \
-            --config .github/ct.yaml \
+            --config .github/ct-redpanda.yaml \
             --helm-extra-set-args="--set=image.tag=${{ matrix.version }}" \
             --skip-missing-values \
             --chart-dirs=charts/redpanda \

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -64,7 +64,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=charts/redpanda )
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           echo $changed
           if [[ -n "$changed" ]]; then
             echo changed="true" >> "$GITHUB_OUTPUT"
@@ -135,8 +135,7 @@ jobs:
           ct install \
             --github-groups \
             --upgrade \
-            --config .github/ct.yaml \
+            --config .github/ct-redpanda.yaml \
             --helm-extra-set-args="--set=image.tag=${{ matrix.version }}" \
             --skip-missing-values \
-            --chart-dirs=charts/redpanda \
             --target-branch ${{ github.event.repository.default_branch }}

--- a/.github/workflows/pull_requests_kminion.yaml
+++ b/.github/workflows/pull_requests_kminion.yaml
@@ -52,7 +52,7 @@ jobs:
           version: v3.8.0-1
 
       - name: Run chart-testing (lint)
-        run: ct lint --config .github/ct.yaml --github-groups --chart-dirs=charts/kminion
+        run: ct lint --config .github/ct-kminion.yaml --github-groups
 
   check-values:
     runs-on: ubuntu-22.04
@@ -98,7 +98,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --chart-dirs=charts/kminion )
+          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }})
           echo $changed
           if [[ -n "$changed" ]]; then
             echo changed="true" >> "$GITHUB_OUTPUT"
@@ -143,7 +143,6 @@ jobs:
           ct install \
             --github-groups \
             --upgrade \
-            --config .github/ct.yaml \
+            --config .github/ct-kminion.yaml \
             --skip-missing-values \
-            --chart-dirs=charts/kminion \
             --target-branch ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
`--chart-dirs` was not working as I would think.

REF:
https://github.com/redpanda-data/helm-charts/actions/runs/5678517663/job/15388898267#step:7:14

```
$ ct lint --config .github/ct.yaml --github-groups --chart-dirs=charts/kminion
Linting charts...
>>> helm version --template {{ .Version }}
>>> git rev-parse --is-inside-work-tree
>>> git rev-parse --verify main
>>> git merge-base origin/main HEAD
>>> git diff --find-renames --name-only aba186603a055[2](https://github.com/redpanda-data/helm-charts/actions/runs/5678517663/job/15388898267#step:7:2)a0d65d8df9d8c4a[3](https://github.com/redpanda-data/helm-charts/actions/runs/5678517663/job/15388898267#step:7:3)8cde70b9[5](https://github.com/redpanda-data/helm-charts/actions/runs/5678517663/job/15388898267#step:7:5)3 -- charts/kminion
Directory "charts/kminion/ci" is not a valid chart directory. Skipping...
Test Results
  No chart changes detected.
All charts linted successfully
```

https://github.com/redpanda-data/helm-charts/pull/616/files