### PR TITLE
Report more information during schema deletion (follow up)

### DIFF
--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -78,11 +78,60 @@ spec:
 
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
-          schemaCurl -X DELETE \
-          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+          max_iteration=10
 
-          schemaCurl -X DELETE \
-          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+          for i in $(seq 1 $max_iteration)
+          do
+            curl -vv -X DELETE \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u $USERNAME:$PASSWORD \
+              {{- end }}
+              {{- if $cert.caEnabled }}
+              --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+              {{- end }}
+              https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+            result=$?
+            if [[ $result -eq 0 ]]
+            then
+              echo "Result successful"
+              break
+            else
+              echo "Result unsuccessful"
+              sleep 1
+            fi
+          done
+
+          if [[ $result -ne 0 ]]
+          then
+            echo "All of the trials failed to delete schema!!!"
+          fi
+
+          for i in $(seq 1 $max_iteration)
+          do
+            curl -vv -X DELETE \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u $USERNAME:$PASSWORD \
+              {{- end }}
+              {{- if $cert.caEnabled }}
+              --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+              {{- end }}
+              https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+            result=$?
+            if [[ $result -eq 0 ]]
+            then
+              echo "Result successful"
+              break
+            else
+              echo "Result unsuccessful"
+              sleep 1
+            fi
+          done
+
+          if [[ $result -ne 0 ]]
+          then
+            echo "All of the trials failed to permanently delete schema!!!"
+            exit 1
+          fi
       volumeMounts:
       {{- range $name, $cert := .Values.tls.certs }}
         - name: redpanda-{{ $name }}-cert


### PR DESCRIPTION
In one of the PR test fail again, but with `--retry` flag it is imposible to know why.

```
  > DELETE /subjects/sensor-value/versions/1?permanent=true HTTP/1.1
  > Host: redpanda-0kcbqw5kyp.redpanda-0kcbqw5kyp.svc.cluster.local.:8081
  > Authorization: Basic YWRtaW46YmFkcGFzc3dvcmQ=
  > User-Agent: curl/7.88.1
  > Accept: */*
  >
  * Operation timed out after 3000 milliseconds with 0 bytes received
```

REF:

- https://github.com/redpanda-data/helm-charts/commit/cea5b4dd
- https://github.com/redpanda-data/helm-charts/actions/runs/5681813097/job/15399918195#step:17:33885