### PR TITLE
Fix Redpanda cloud E2E tests

### DIFF
--- a/.buildkite/scripts/cloud-test.sh
+++ b/.buildkite/scripts/cloud-test.sh
@@ -8,7 +8,7 @@ set
 PATH="$(realpath .local/bin):${PATH}"
 bash -O extglob -c "rm -v charts/redpanda/ci/!(2)[0-9]-*"
 
-ct install --config .github/ct.yaml --upgrade --skip-missing-values | sed 's/>>> /~~~ /'
+ct install --config .github/ct-redpanda.yaml --upgrade --skip-missing-values | sed 's/>>> /~~~ /'
 
 eks() {
   echo '--- testing that there is data in the s3 bucket'

--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -20,6 +20,7 @@ on:
     branches:
       - "**"
     paths:
+      - .buildkite/*
       - .github/*.sh
       - .github/ct.yaml
       - .github/kind.yaml


### PR DESCRIPTION
```
Error: failed loading configuration: failed loading config file: open .github/ct.yaml: no such file or directory
failed loading configuration: failed loading config file: open .github/ct.yaml: no such file or directory
```

https://buildkite.com/redpanda/helm-charts/builds/475#0189a9b5-6e65-4969-b60d-bd5d6531bfe6/607-796

REF:
https://github.com/redpanda-data/helm-charts/pull/618