### PR TITLE
Do not print console secrets for schema registry

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.0.7
+version: 5.0.8
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.2.3

--- a/charts/redpanda/templates/console/deployment.yaml
+++ b/charts/redpanda/templates/console/deployment.yaml
@@ -20,7 +20,7 @@ limitations under the License.
 {{ $extraVolumeMounts := list }}
 {{ $command := list }}
 {{ if (include "sasl-enabled" . | fromJson).bool }}
-  {{ $command = concat $command (list "sh" "-xc") }}
+  {{ $command = concat $command (list "sh" "-c") }}
   {{ $consoleSASLConfig := (printf "set -e; IFS=: read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM < $(find /mnt/users/* -print); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-%s}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;" ( include "sasl-mechanism" . )) }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;" }}


### PR DESCRIPTION
```
kubectl logs redpanda-5q8zf6d6a5-console-59cccf47df-22zp7
+ set -e
+ find /mnt/users/users.txt -print
+ IFS=: read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM
+ KAFKA_SASL_MECHANISM=SCRAM-SHA-256
+ export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM
+ export 'KAFKA_SCHEMAREGISTRY_USERNAME=admin'
+ export 'KAFKA_SCHEMAREGISTRY_PASSWORD=hunter2'
+ /app/console '--config.filepath=/etc/console/configs/config.yaml'
```