### PR TITLE
chores: set default log level to debug

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -4,7 +4,7 @@ description: Redpanda operator helm chart
 type: application
 
 # This is the chart version. This is only placeholder that will be set during release process
-version: 0.3.9
+version: 0.3.10
 
 # This is the version number of the application being deployed. This is only placeholder that
 # will be set during release process.

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -47,7 +47,7 @@ config:
 imagePullSecrets: []
 
 # logLevel -- Set Redpanda Operator log level (debug, info, error, panic, fatal)
-logLevel: "info"
+logLevel: "debug"
 
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created


### PR DESCRIPTION
The helm operators from flux require that we have at least a debug log level in order to see the progress and errors happening when the helmrelease controller is trying to reconcile. Having this set by default will help with us with customer issues in the near future. 