### PR TITLE
Increase default memory limit for connectors

### DIFF
--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.1.3
+version: 0.1.4
 
 # The app version is the default version of Redpanda Connectors to install.
 appVersion: v1.0.2

--- a/charts/connectors/values.yaml
+++ b/charts/connectors/values.yaml
@@ -149,10 +149,10 @@ container:
   resources:
     request:
       cpu: 1
-      memory: 2Gi
+      memory: 2350Mi
     limits:
       cpu: 1
-      memory: 2Gi
+      memory: 2350Mi
     # -- Java maximum heap size can not be greater than $container.resources.limits.memory
     javaMaxHeapSize: 2G
   javaGCLogEnabled: "false"


### PR DESCRIPTION
The connectors in the TLS setup often run out of memory. The problem was in the memory limits set in the Deployment manifest vs what JVM has configured.