### PR TITLE
fix: upgrade error message

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.1.0
+version: 5.1.1
 
 # The app version is the default version of Redpanda to install.
 appVersion: v23.2.4

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -39,7 +39,7 @@ limitations under the License.
       {{- fail (join "\n" (list
           (printf "\n\nError: Cannot do a rolling restart to enable or disable tls at the RPC layer: changing listeners.rpc.tls.enabled (redpanda.yaml:repdanda.rpc_server_tls.enabled) from %v to %v" $currentRPCTLS $wantedRPCTLS)
           "***WARNING The following instructions will result in a short period of downtime."
-          "To accept this risk, run the upgrade again adding `--set force=true` and do the following:\n"
+          "To accept this risk, run the upgrade again adding `--force=true` and do the following:\n"
           "While helm is upgrading the release, manually delete ALL the pods:"
           (printf "    kubectl -n %s delete pod -l app.kubernetes.io/component=redpanda-statefulset" .Release.Namespace)
           "\nIf you got here thinking rpc tls was already enabled, see technical service bulletin 2023-01."

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -30,7 +30,7 @@ limitations under the License.
 {{- if not (include "redpanda-atleast-22-2-0" . | fromJson).bool -}}
   {{- if eq (get .Values "force" | default false) false -}}
     {{- fail (
-    printf "\n\nError: The Redpanda version (%s) is no longer supported \nTo accept this risk, run the upgrade again adding `--set force=true`\n" (( include "redpanda.semver" . ))
+    printf "\n\nError: The Redpanda version (%s) is no longer supported \nTo accept this risk, run the upgrade again adding `--force=true`\n" (( include "redpanda.semver" . ))
         )
     -}}
   {{- end -}}


### PR DESCRIPTION
An error message is displayed when trying to make changes like setting tls off once it was turned on. The message says something like   '--set force=true' which does not make sense. I believe the actual wording is  adding '--force=true' to the upgrade command.
