### PR TITLE
use the correct named template for the service account name in the rolebinding

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -3,20 +3,21 @@ name: operator
 description: Redpanda operator helm chart
 type: application
 
-# This is the chart version. This is only placeholder that will be set during release process
-version: 0.3.10
+# The chart version and the app version are not the same and will not track
+# together. The chart version is a semver representation of changes to this
+# chart.
+version: 0.3.11
 
-# This is the version number of the application being deployed. This is only placeholder that
-# will be set during release process.
-appVersion: v23.2.4
+# This is the default version of the operator being deployed.
+# ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
+appVersion: v23.2.5
 
-home: https://vectorized.io
 sources:
   - https://github.com/redpanda-data/helm-charts
 icon: https://go.redpanda.com/hubfs/Redpandas/operator-panda.png
 maintainers:
-  - name: Vectorizedio
-    email: support@vectorized.io
+  - name: redpanda-data
+    url: https://github.com/orgs/redpanda-data/people
 
 dependencies:
 - name: kube-prometheus-stack
@@ -33,9 +34,9 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.2
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.5
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
+      image: docker.redpanda.com/redpandadata/redpanda:v23.2.5
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
   artifacthub.io/crds: |
@@ -45,4 +46,4 @@ annotations:
       displayName: Redpanda
       description: Define a Redpanda cluster
   artifacthub.io/operator: "true"
-  artifacthub.io/operatorCapabilities: Basic Install
+  artifacthub.io/operatorCapabilities: Seamless Upgrades

--- a/charts/operator/templates/clusterrole_binding.yaml
+++ b/charts/operator/templates/clusterrole_binding.yaml
@@ -22,6 +22,6 @@ roleRef:
   name: {{ include "redpanda-operator.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ template "redpanda-operator.serviceAccountName" . }}
+  name: {{ include "redpanda-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/operator/templates/clusterrole_proxy_binding.yaml
+++ b/charts/operator/templates/clusterrole_proxy_binding.yaml
@@ -22,6 +22,6 @@ roleRef:
   name: {{ include "redpanda-operator.fullname" . }}-proxy-role
 subjects:
 - kind: ServiceAccount
-  name: {{ template "redpanda-operator.serviceAccountName" . }}
+  name: {{ include "redpanda-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/operator/templates/extra_role.yaml
+++ b/charts/operator/templates/extra_role.yaml
@@ -41,6 +41,6 @@ roleRef:
   name: {{ include "redpanda-operator.fullname" . }}-pvc
 subjects:
   - kind: ServiceAccount
-    name: {{ template "redpanda-operator.serviceAccountName" . }}
+    name: {{ include "redpanda-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{ end }}

--- a/charts/operator/templates/role_binding.yaml
+++ b/charts/operator/templates/role_binding.yaml
@@ -38,7 +38,7 @@ roleRef:
   name: {{ include "redpanda-operator.fullname" . }}
 subjects:
   - kind: ServiceAccount
-    name: {{ template "redpanda-operator.serviceAccountName" . }}
+    name: {{ include "redpanda-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
   {{- end }}
 {{- end -}}

--- a/charts/operator/templates/service_account.yaml
+++ b/charts/operator/templates/service_account.yaml
@@ -13,7 +13,7 @@ by the Apache License, Version 2.0
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "redpanda-operator.serviceAccountName" . }}
+  name: {{ include "redpanda-operator.serviceAccountName" . }}
   labels:
 {{ include "redpanda-operator.labels" . | indent 4 }}
 {{- end -}}

--- a/charts/operator/templates/tests/create-topic-with-client-auth.yaml
+++ b/charts/operator/templates/tests/create-topic-with-client-auth.yaml
@@ -16,7 +16,7 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "2"
 spec:
-  serviceAccount: {{ include "redpanda-operator.fullname" . }}
+  serviceAccount: {{ include "redpanda-operator.serviceAccountName" . }}
   containers:
     - name: rpk
       image: docker.redpanda.com/redpandadata/redpanda:latest


### PR DESCRIPTION
Also use `include` instead of `template` for consistency.

Associated with redpanda-data/cloudv2/issues/7740