### PR TITLE
Probes now target their own pod

### DIFF
--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -264,7 +264,7 @@ spec:
                 - -c
                 - |
                   set -e
-                  RESULT=$(curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready")
+                  RESULT=$(curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://localhost:{{.Values.listeners.admin.port }}/v1/status/ready")
                   echo $RESULT
                   echo $RESULT | grep ready
             initialDelaySeconds: {{ .Values.statefulset.startupProbe.initialDelaySeconds }}
@@ -276,7 +276,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready"
+                - curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://localhost:{{.Values.listeners.admin.port }}/v1/status/ready"
             initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.livenessProbe.periodSeconds }}
@@ -291,8 +291,8 @@ spec:
                 - -c
                 - |
                   set -x
-                  rpk cluster health {{ (include "rpk-flags" . | fromJson).admin }}
-                  rpk cluster health {{ (include "rpk-flags" . | fromJson).admin }} | grep 'Healthy:.*true'
+                  rpk cluster health --api-urls localhost:{{.Values.listeners.admin.port }}
+                  rpk cluster health --api-urls localhost:{{.Values.listeners.admin.port }} | grep 'Healthy:.*true'
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}


### PR DESCRIPTION
This means that unresponsiveness is reflected in individual pods' readiness. Anecdotally I see more predictable unreadiness behavior at rolling upgrade.

Closes #584 while it's by design that all pods can go unready based on rpk cluster health.