### PR TITLE
Update internal service to include other listeners also. 

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.24
+version: 5.6.23
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.22
+version: 5.6.24
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/service.internal.yaml
+++ b/charts/redpanda/templates/service.internal.yaml
@@ -37,7 +37,11 @@ spec:
   clusterIP: None
   selector: {{ (include "statefulset-pod-labels" .) | nindent 4 }}
   ports:
-    - name: admin
+  {{- range $name, $listener := .Values.listeners }}
+    {{- if dig "enabled" true $listener}}
+    - name: {{ lower $name }}
       protocol: TCP
-      targetPort: {{ .Values.listeners.admin.port }}
-      port: {{ .Values.listeners.admin.port }}
+      port: {{ $listener.port }}
+      targetPort: {{ $listener.port }}
+    {{- end }}
+  {{- end }}


### PR DESCRIPTION
Expand internal service to include all listeners:

```
kind: Service
metadata:
  name: redpanda
  namespace: "redpanda"
  labels:
    monitoring.redpanda.com/enabled: "false"
    app.kubernetes.io/component: redpanda
    app.kubernetes.io/instance: redpanda
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/name: redpanda
    helm.sh/chart: redpanda-5.1.9
spec:
  type: ClusterIP
  publishNotReadyAddresses: true
  clusterIP: None
  selector:
    app.kubernetes.io/name: redpanda
    app.kubernetes.io/instance: "redpanda"
  ports:
    - name: admin
      protocol: TCP
      port: 9644
      targetPort: 9644
    - name: http
      protocol: TCP
      port: 8082
      targetPort: 8082
    - name: kafka
      protocol: TCP
      port: 9093
      targetPort: 9093
    - name: rpc
      protocol: TCP
      port: 33145
      targetPort: 33145
    - name: schemaregistry
      protocol: TCP
      port: 8081
      targetPort: 8081
```


