### PR TITLE
feat(redpanda): add the ability to add annotations to the internal service

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.1.8
+version: 5.2.0
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/service.internal.yaml
+++ b/charts/redpanda/templates/service.internal.yaml
@@ -28,6 +28,9 @@ metadata:
 {{- with include "full.labels" . }}
   {{- . | nindent 4 }}
 {{- end }}
+{{- with dig "service" "internal" "annotations" dict .Values.AsMap }}
+  annotations: {{ toYaml . | nindent 4 }}
+{{- end }}
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -55,6 +55,14 @@
       "properties": {
         "name": {
           "type": "string"
+        },
+        "internal": {
+          "type": "object",
+          "properties": {
+            "annotations": {
+              "type": "object"
+            }
+          }
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -60,6 +60,15 @@ image:
 # service:
 #   -- set service.name to override the default service name
 #   name: redpanda
+#   -- internal Service
+#   internal:
+#     -- add annotations to the internal Service
+#     annotations: {}
+#
+#     -- eg. for a bare metal install using external-dns
+#     annotations:
+#       "external-dns.alpha.kubernetes.io/hostname": redpanda.domain.dom
+#       "external-dns.alpha.kubernetes.io/endpoints-type": HostIP
 
 # -- Pull secrets may be used to provide credentials to image repositories
 # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/


### PR DESCRIPTION
Add service.internal.annotations (optional) to allow adding annotations to the internal service.

Fixes #694 