### PR TITLE
feat: allow ability to disable external service creation

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.3.1
+version: 5.3.3
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/service.loadbalancer.yaml
+++ b/charts/redpanda/templates/service.loadbalancer.yaml
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if (include "external-loadbalancer-enabled" . | fromJson).bool }}
+{{- if and (include "external-loadbalancer-enabled" . | fromJson).bool (dig "service" "enabled" true .Values.external)}}
   {{- $values := .Values }}
   {{- $root := . }}
   {{- $addresses := dig "addresses" list $values.external }}

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- $values := .Values }}
-{{- if (include "external-nodeport-enabled" . | fromJson).bool }}
+{{- if and (include "external-nodeport-enabled" . | fromJson).bool (dig "service" "enabled" true $values.external) }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -194,6 +194,14 @@
         "enabled": {
           "type": "boolean"
         },
+        "service": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            }
+          }
+        },
         "type": {
           "type": "string",
           "pattern": "^(LoadBalancer|NodePort)$"

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -196,6 +196,12 @@ tls:
 # For details,
 # see the [Networking and Connectivity documentation](https://docs.redpanda.com/docs/manage/kubernetes/networking/networking-and-connectivity/).
 external:
+  # -- Service allows you to manage the creation of an external kubernetes service object
+  service:
+    # -- Enabled if set to false will not create the external service type
+    # You can still set your cluster with external access but not create the supporting service (NodePort/LoadBalander).
+    # Set this to false if you rather manage your own service.
+    enabled: true
   # -- Enable external access for each Service.
   # You can toggle external access for each listener in
   # `listeners.<service name>.external.<listener-name>.enabled`.


### PR DESCRIPTION
Allow us to disable external service creation but while defining external services so we can create our own 

This will require a change to the api, ill add a follow PR to do this. 

Partially Fixes [#13271](https://github.com/redpanda-data/redpanda/issues/13271)