### PR TITLE
Update reference to docs repository

### DIFF
--- a/.github/workflows/dispatch-helm-docs.yaml
+++ b/.github/workflows/dispatch-helm-docs.yaml
@@ -16,5 +16,5 @@ jobs:
         uses: peter-evans/repository-dispatch@v2
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
-          repository: redpanda-data/documentation
+          repository: redpanda-data/documentation-private
           event-type: generate-helm-spec-docs


### PR DESCRIPTION
The docs repository was renamed to `documentation-private` this PR reconfigures the GitHub Action to trigger the Helm spec generation in that repo.