### PR TITLE
operator: Extend namespaced role rules

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.13
+version: 0.3.14
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -375,5 +375,8 @@ rules:
       - get
       - patch
       - update
+  {{- with .Values.additionalNamespacedRoleRules }}
+    {{- toYaml . | nindent 2 }}
+  {{- end }}
   {{- end }}
 {{- end}}

--- a/charts/operator/templates/tests/create-topic-with-client-auth.yaml
+++ b/charts/operator/templates/tests/create-topic-with-client-auth.yaml
@@ -37,6 +37,8 @@ spec:
             kafka_api:
               brokers:
                 - cluster-tls-0.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
+                - cluster-tls-1.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
+                - cluster-tls-2.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
               tls:
                 enabled: true
                 key_file: /tmp/tls.key

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -104,3 +104,17 @@ webhookSecretName: webhook-server-cert
 # scope -- change the scope and therefore the resource the controller will manage
 # only "Cluster" and "Namespace" supported
 scope: Namespace
+
+additionalNamespacedRoleRules: {}
+#  - apiGroups:
+#      - cluster.redpanda.com
+#    resources:
+#      - topics
+#    verbs:
+#      - create
+#      - delete
+#      - get
+#      - list
+#      - patch
+#      - update
+#      - watch


### PR DESCRIPTION
When operator is extended with new controllers and new custom resource definitions there is circular dependency between new RABC rules being added to the role which is then used in E2E tests for operator v2.

This change gives ability to use upstream operator helm chart and open PRs with new custom resource definition and its new RBAC rules.