### PR TITLE
operator: Add all brokers into test rpk configuration

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.14
+version: 0.3.15
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/operator/templates/tests/create-topic-with-client-auth.yaml
+++ b/charts/operator/templates/tests/create-topic-with-client-auth.yaml
@@ -37,6 +37,8 @@ spec:
             kafka_api:
               brokers:
                 - cluster-tls-0.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
+                - cluster-tls-1.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
+                - cluster-tls-2.cluster-tls.{{ .Release.Namespace }}.svc.cluster.local:9092
               tls:
                 enabled: true
                 key_file: /tmp/tls.key


### PR DESCRIPTION
The operator E2E tests fails sometimes.

```
rpk topic create test -v
  09:44:36.848  DEBUG  opening connection to broker  {"addr": "cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local:9092", "broker": "seed_0"}
  09:44:36.861  WARN  unable to open connection to broker  {"addr": "cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local:9092", "broker": "seed_0", "err": "dial tcp: lookup cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local on 10.96.0.10:53: no such host"}
  09:44:36.861  DEBUG  opening connection to broker  {"addr": "cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local:9092", "broker": "seed_0"}
  09:44:36.873  WARN  unable to open connection to broker  {"addr": "cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local:9092", "broker": "seed_0", "err": "dial tcp: lookup cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local on 10.96.0.10:53: no such host"}
  unable to create topics [test]: unable to dial: dial tcp: lookup cluster-tls-0.cluster-tls.operator-1azamhsqno.svc.cluster.local on 10.96.0.10:53: no such host
```

https://github.com/redpanda-data/helm-charts/actions/runs/6130129339/job/16638935698#step:12:16056