### PR TITLE
redpanda/feat: Allow to set affinity for jobs

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.3.3
+version: 5.3.4
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -59,7 +59,7 @@ spec:
     {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.post_install_job.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
       restartPolicy: Never

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -59,6 +59,9 @@ spec:
     {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+    {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
     {{- with .Values.imagePullSecrets }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -54,6 +54,9 @@ spec:
     {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+    {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}
       serviceAccountName: {{ include "redpanda.serviceAccountName" . }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -54,7 +54,7 @@ spec:
     {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.affinity }}
+    {{- with .Values.post_upgrade_job.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
       restartPolicy: Never

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -23,6 +23,9 @@
     "tolerations": {
       "type": "array"
     },
+    "affinity": {
+      "type": "object"
+    },
     "image": {
       "description": "Values used to define the container image to be used for Redpanda",
       "type": "object",

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -23,9 +23,6 @@
     "tolerations": {
       "type": "array"
     },
-    "affinity": {
-      "type": "object"
-    },
     "image": {
       "description": "Values used to define the container image to be used for Redpanda",
       "type": "object",
@@ -508,6 +505,9 @@
               }
             }
           }
+        },
+        "affinity": {
+          "type": "object"
         }
       }
     },
@@ -548,6 +548,9 @@
         },
         "extraEnvFrom": {
           "type": ["array", "string"]
+        },
+        "affinity": {
+          "type": "object"
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -41,6 +41,10 @@ nodeSelector: {}
 # For details,
 # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
 tolerations: []
+# -- Allows to specify affinity for Jobs.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
+affinity: {}
 
 # -- Redpanda Docker image settings.
 image:

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -41,10 +41,6 @@ nodeSelector: {}
 # For details,
 # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).
 tolerations: []
-# -- Allows to specify affinity for Jobs.
-# For details,
-# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
-affinity: {}
 
 # -- Redpanda Docker image settings.
 image:
@@ -483,6 +479,7 @@ post_install_job:
   #     memory: 1024Mi
   # labels: {}
   # annotations: {}
+  affinity: {}
 
 post_upgrade_job:
   enabled: true
@@ -507,6 +504,7 @@ post_upgrade_job:
   # extraEnvFrom:
   #   - secretRef:
   #       name: redpanda-aws-secrets
+  affinity: {}
 
 statefulset:
   # -- Number of Redpanda brokers (Redpanda Data recommends setting this to the number of worker nodes in the cluster)


### PR DESCRIPTION
Hi there, there is no way to set `affinity` for redpanda-post-upgrade and redpanda-configuration Jobs. Allow affinity to be set as well as nodeSelector. statefulset is not changed in PR.

refs #305