### PR TITLE
Add default crash loop limit node property

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.0
+version: 5.4.1
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -129,7 +129,7 @@ limitations under the License.
   {{- end }}
       {{- with dig "node" dict .Values.config }}
       {{- range $key, $element := .}}
-        {{- if or (eq (typeOf $element) "bool") $element }}
+        {{- if and (or (eq (typeOf $element) "bool") $element) (and (eq $key "crash_loop_limit") (include "redpanda-atleast-23-1-1" $root | fromJson).bool) }}
       {{ $key }}: {{ $element | toYaml }}
         {{- end }}
       {{- end }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -940,7 +940,19 @@ config:
     # wait_for_leader_timeout_ms: 5000ms                           # Timeout (ms) to wait for leadership in metadata cache
   # -- Node (broker) properties.
   # See the [property reference documentation](https://docs.redpanda.com/docs/reference/node-properties/).
-  node: {}
+  node:
+    # -- Crash loop limit
+    # A limit on the number of consecutive times a broker can crash within one hour before its crash-tracking logic is reset.
+    # This limit prevents a broker from getting stuck in an infinite cycle of crashes.
+    # User can disable this crash loop limit check by the following action:
+    #
+    # * One hour elapses since the last crash
+    # * The node configuration file, redpanda.yaml, is updated via config.cluster or config.node or config.tunable objects
+    # * The startup_log file in the node’s data_directory is manually deleted
+    #
+    # Default to 5
+    # REF: https://docs.redpanda.com/current/reference/node-properties/#crash_loop_limit
+    crash_loop_limit: 5
     # node_id:                                                     # Unique ID identifying a node in the cluster
     # data_directory:                                              # Place where redpanda will keep the data
     # admin_api_doc_dir: /usr/share/redpanda/admin-api-doc         # Admin API doc directory


### PR DESCRIPTION
When cluster is experiencing allocation failures then it can start to accumulate very small segments that makes bootstraping of a particular node harder. The amount of memory that is requiured due to high amount of small segments on disk with possibility of managing tiered storage cache in paraller is greater every time Redpanda stops/crash. This crash loop limit prevents from accumulating those small segments.

User can disable this crash loop limit check by the following action:
* One hour elapses since the last crash
* The node configuration file, redpanda.yaml, is updated via config.cluster or config.node or config.tunable objects
* The startup_log file in the node’s data_directory is manually deleted

REF:
https://github.com/redpanda-data/redpanda/pull/8122
https://docs.redpanda.com/current/reference/node-properties/#crash_loop_limit

Fixes https://github.com/redpanda-data/helm-charts/issues/717