### PR TITLE
Fix topic controller permisions

### DIFF
--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -393,17 +393,21 @@ rules:
     - patch
     - update
 - apiGroups:
-    - cluster.redpanda.com
-  resources:
-    - topics
-  verbs:
-    - create
-- apiGroups:
     - ""
   resources:
     - persistentvolumeclaims
   verbs:
     - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - cluster.redpanda.com
+  resources:
+    - topics
+  verbs:
     - get
     - list
     - patch


### PR DESCRIPTION
The PR https://github.com/redpanda-data/helm-charts/pull/713 broke permissions for topic controller as controller runtime can not list nor watch for topic resource. The create and delete verb for topic resource was removed as topic controller does not create nor delete this resource.

REF:
https://github.com/redpanda-data/helm-charts/pull/713/files#diff-250227697f8776465869fa07da13df0e7ccce78bb414e3a13505b9dfba1773faR388-R404
https://github.com/redpanda-data/helm-charts/pull/708