### PR TITLE
Fix operator chart release

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.16
+version: 0.3.17
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging


### PR DESCRIPTION
After rebase https://github.com/redpanda-data/helm-charts/pull/720 I made mistake by not including chart version bump.

It would be good to address https://github.com/helm/chart-testing/pull/594 as this would fail differently in Github actions and maybe I would catch this.

I need to admit that I merged PR that failed the tests, but I mentioned operator test is flaky 
https://github.com/redpanda-data/helm-charts/pull/708#issuecomment-1712477889

Previous PR github action failure:
```
unable to create topics [test]: unable to dial: dial tcp: lookup cluster-tls-0.cluster-tls.operator-3nzsgrw4nc.svc.cluster.local. on 10.96.0.10:53: no such host
```

https://github.com/redpanda-data/helm-charts/actions/runs/6175053133/job/16761083500#step:12:14851


```
helm test operator-3nzsgrw4nc --namespace operator-3nzsgrw4nc --timeout 900s
NAME: operator-3nzsgrw4nc
LAST DEPLOYED: Wed Sep 13 16:21:13 2023
NAMESPACE: operator-3nzsgrw4nc
STATUS: deployed
REVISION: 1
TEST SUITE:     create-test-topic-tls
Last Started:   Wed Sep 13 16:21:26 2023
Last Completed: Wed Sep 13 16:22:16 2023
Phase:          Failed
NOTES:
Congratulations on installing operator!

The pods will rollout in a few seconds. To check the status:

  kubectl -n operator-3nzsgrw4nc rollout status -w deployment/operator-3nzsgrw4nc

Now you can install a Redpanda resource!
Error: pod create-test-topic-tls failed
```
https://github.com/redpanda-data/helm-charts/actions/runs/6175053133/job/16761083500#step:12:2492