### PR TITLE
feat: pass license to console subchart

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.2
+version: 5.4.3
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl
@@ -22,4 +22,5 @@ storage:
     cloud_storage_region: "${AWS_REGION}"
     cloud_storage_bucket: "${TEST_BUCKET}"
     cloud_storage_segment_max_upload_interval_sec: 1
-license_key: "${REDPANDA_SAMPLE_LICENSE}"
+enterprise:
+  license: "${REDPANDA_SAMPLE_LICENSE}"

--- a/charts/redpanda/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl
@@ -23,7 +23,8 @@ storage:
     cloud_storage_segment_max_upload_interval_sec: 1
     cloud_storage_access_key: "${GCP_ACCESS_KEY_ID}"
     cloud_storage_secret_key: "${GCP_SECRET_ACCESS_KEY}"
-license_key: "${REDPANDA_SAMPLE_LICENSE}"
+enterprise:
+  license: "${REDPANDA_SAMPLE_LICENSE}"
 
 
 resources:

--- a/charts/redpanda/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl
@@ -23,7 +23,8 @@ storage:
     cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
-license_key: "${REDPANDA_SAMPLE_LICENSE}"
+enterprise:
+    license: "${REDPANDA_SAMPLE_LICENSE}"
 
 resources:
   cpu:

--- a/charts/redpanda/ci/99-none-existent-config-options-with-empty-values.yaml
+++ b/charts/redpanda/ci/99-none-existent-config-options-with-empty-values.yaml
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-license_secret_ref:
-  secret_name: redpanda-license
-  secret_key: license-key
+enterprise:
+  licenseSecretRef:
+    name: redpanda-license
+    key: license-key
 
 storage:
   tieredConfig:

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -625,7 +625,7 @@ advertised-host returns a json string with the data needed for configuring the a
 {{- end -}}
 
 {{- define "is-licensed" -}}
-{{- toJson (dict "bool" (or (not (empty .Values.license_key)) (not (empty .Values.license_secret_ref)))) -}}
+{{- toJson (dict "bool" (or (not (empty (include "enterprise-license" . ))) (not (empty (include "enterprise-secret" . ))))) -}}
 {{- end -}}
 
 {{/*
@@ -682,7 +682,51 @@ return correct secretName to use based if secretRef exists
 {{- define "cert-secret-name" -}}
   {{- if .tempCert.cert.secretRef -}}
     {{- .tempCert.cert.secretRef.name -}}
-  {{- else }}
+  {{- else -}}
     {{- include "redpanda.fullname" . }}-{{ .tempCert.name }}-cert
-  {{- end }}
+  {{- end -}}
+{{- end -}}
+
+{{/*
+return license checks deprecated values if current values is empty
+*/}}
+{{- define "enterprise-license" -}}
+{{- if dig "license" dict .Values.enterprise -}}
+  {{- .Values.enterprise.license -}}
+{{- else -}}
+  {{- .Values.license_key -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+return licenseSecretRef checks deprecated values entry if current values empty
+*/}}
+{{- define "enterprise-secret" -}}
+{{- if ( dig "licenseSecretRef" dict .Values.enterprise ) -}}
+  {{- .Values.enterprise.licenseSecretRef -}}
+{{- else if not (empty .Values.license_secret_ref ) -}}
+  {{- .Values.license_secret_ref -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+return licenseSecretRef.name checks deprecated values entry if current values empty
+*/}}
+{{- define "enterprise-secret-name" -}}
+{{- if ( dig "licenseSecretRef" dict .Values.enterprise ) -}}
+  {{- dig "name" "" .Values.enterprise.licenseSecretRef -}}
+{{- else if not (empty .Values.license_secret_ref ) -}}
+  {{- dig "secret_name" "" .Values.license_secret_ref -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+return licenseSecretRef.key checks deprecated values entry if current values empty
+*/}}
+{{- define "enterprise-secret-key" -}}
+{{- if ( dig "licenseSecretRef" dict .Values.enterprise ) -}}
+  {{- dig "key" "" .Values.enterprise.licenseSecretRef -}}
+{{- else if not (empty .Values.license_secret_ref ) -}}
+  {{- dig "secret_key" "" .Values.license_secret_ref -}}
+{{- end -}}
 {{- end -}}

--- a/charts/redpanda/templates/console/configmap-and-deployment.yaml
+++ b/charts/redpanda/templates/console/configmap-and-deployment.yaml
@@ -15,6 +15,28 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{ $values := .Values }}
+
+{{/* Secret */}}
+{{ $secretConfig := dict }}
+{{ if and .Values.console.enabled (not .Values.console.secret.create) }}
+{{ $licenseKey := ( include "enterprise-license" .  ) }}
+{{ $secretConfig = ( dict
+  "create" true
+  "enterprise" ( dict "license" $licenseKey)
+  )
+}}
+
+{{ $config := dict
+  "Values" (dict
+  "secret" $secretConfig
+  )}}
+
+{{ $console := deepCopy .Subcharts.console }}
+{{ $console = merge $config $console }}
+---
+{{ include (print .Subcharts.console.Template.BasePath "/secret.yaml") $console }}
+{{ end }}
+
 {{ $configmap := dict }}
 {{/* if the console chart has the creation of the configmap disabled, create it here instead */}}
 {{ if and .Values.console.enabled (not .Values.console.configmap.create) }}
@@ -93,19 +115,22 @@ limitations under the License.
       "kafka" $consoleConfigKafka
       "connect" $connectConfig
 }}
+
 {{ $config := dict
     "Values" (dict
       "console" (dict "config" $consoleConfig)
       "configmap" $consoleConfigmap
+      "secret" $secretConfig
     )
 }}
 
 {{ $console := deepCopy .Subcharts.console }}
 {{ $console = merge $config $console }}
-
+---
 {{ include (print .Subcharts.console.Template.BasePath "/configmap.yaml") $console }}
 {{ $configmap = include (print .Subcharts.console.Template.BasePath "/configmap.yaml") $console }}
 {{ end }}
+
 {{/* Deployment */}}
 {{ if and .Values.console.enabled (not .Values.console.deployment.create) }}
 
@@ -229,12 +254,26 @@ limitations under the License.
   "value" (print (include "admin-http-protocol" .) "://" (include "admin-api-service-url" .))
 )}}
 
+{{ $enterprise := dict }}
+{{ if ( include "enterprise-secret" .) }}
+  {{ $enterprise = dict
+    "licenseSecretRef" ( dict
+       "name" ( include "enterprise-secret-name" . )
+       "key" ( include "enterprise-secret-key" . )
+     )
+  }}
+{{ end }}
+
 {{ $extraEnv := concat $kafkaTLS $schemaRegistryTLS $adminAPI}}
-{{ $consoleValues := dict "Values" (dict
+{{ $consoleValues := dict
+  "Values" (dict
   "extraVolumes" $extraVolumes
   "extraVolumeMounts" $extraVolumeMounts
   "extraEnv" $extraEnv
+  "secret" $secretConfig
+  "enterprise" $enterprise
 )}}
+
 {{ if not (empty $command) }}
   {{ $consoleValues := merge $consoleValues (dict "Values" (dict "deployment" (dict "command" $command))) }}
 {{ end }}
@@ -246,6 +285,7 @@ limitations under the License.
 
 {{ $helmVars := deepCopy .Subcharts.console }}
 {{ $helmVars := merge $consoleValues $helmVars }}
+
 ---
 {{ include (print .Subcharts.console.Template.BasePath "/deployment.yaml") $helmVars }}
 {{ end }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -70,23 +70,23 @@ spec:
       containers:
       - name: {{ template "redpanda.name" . }}-post-install
         image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-        {{- if not (empty .Values.license_secret_ref) }}
+        {{- if not ( empty (include "enterprise-secret" . ) ) }}
         env:
           - name: REDPANDA_LICENSE
             valueFrom:
               secretKeyRef:
-                name: {{ .Values.license_secret_ref.secret_name }}
-                key: {{ .Values.license_secret_ref.secret_key }}
+                name: {{ include "enterprise-secret-name" . }}
+                key: {{ include "enterprise-secret-key" . }}
         {{- end }}
         command: ["bash","-c"]
         args:
           - |
             set -e
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
-          {{- if not (empty .Values.license_secret_ref) }}
+          {{- if not (empty (include "enterprise-secret" . ) ) }}
             rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-acl-user-flags" $ }}
-          {{- else if not (empty .Values.license_key) }}
-            rpk cluster license set {{ .Values.license_key | quote }} {{ template "rpk-acl-user-flags" $ }}
+          {{- else if not ( empty (include "enterprise-license" . ) ) }}
+            rpk cluster license set {{ include "enterprise-license" .  | quote }} {{ template "rpk-acl-user-flags" $ }}
           {{- end }}
         {{- end }}
         {{- with .Values.post_install_job.resources }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -73,12 +73,32 @@
     },
     "license_secret_ref": {
       "type": "object",
+      "deprecated": true,
       "properties": {
         "secret_name": {
           "type": "string"
         },
         "secret_key": {
           "type": "string"
+        }
+      }
+    },
+    "enterprise": {
+      "type": "object",
+      "properties": {
+        "license": {
+          "type": "string"
+        },
+        "licenseSecretRef": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "key": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -74,14 +74,25 @@ image:
 # See https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
 imagePullSecrets: []
 
-# -- Enterprise license key (optional).
+# -- DEPRECATED Enterprise license key (optional).
 # For details,
 # see the [License documentation](https://docs.redpanda.com/docs/get-started/licenses/?platform=kubernetes#redpanda-enterprise-edition).
 license_key: ""
-# -- Secret name and secret key where the license key is stored.
+# -- DEPRECATED Secret name and secret key where the license key is stored.
 license_secret_ref: {}
   # secret_name: my-secret
   # secret_key: key-where-license-is-stored
+
+# -- Enterprise (optional)
+# For details,
+# see the [License documentation](https://docs.redpanda.com/docs/get-started/licenses/?platform=kubernetes#redpanda-enterprise-edition).
+enterprise:
+  # -- license (optional).
+  license: ""
+  # -- Secret name and key where the license key is stored.
+  licenseSecretRef: {}
+    # name: my-secret
+    # key: key-where-license-is-stored
 
 # -- Rack Awareness settings.
 # For details,
@@ -400,7 +411,7 @@ storage:
     annotations: {}
   #
   # -- Tiered Storage settings
-  # Requires `license_key` or `license_secret_ref`
+  # Requires `enterprise.licenseKey` or `enterprised.licenseSecretRef`
   # For details,
   # see the [Tiered Storage documentation](https://docs.redpanda.com/docs/manage/kubernetes/tiered-storage/).
   tieredConfig:


### PR DESCRIPTION
Fixes #703 
Passing license information to console chart, there are now two mechanisms for doing this:

First passing through license key direction, which I would not recommend but its possible
```
helm template redpanda charts/redpanda --set license_key="<redacted>"
```

which results in 2 resources being created, one a secret:

```
# Source: redpanda/templates/console/configmap-and-deployment.yaml
apiVersion: v1
kind: Secret
metadata:
  name: redpanda-console
  labels:
    helm.sh/chart: console-0.7.2
    app.kubernetes.io/name: console
    app.kubernetes.io/instance: redpanda
    app.kubernetes.io/version: "v2.3.2"
    app.kubernetes.io/managed-by: Helm
type: Opaque
data:
  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
  # For this reason we can't use `with` to change the scope.
  # Kafka
  kafka-sasl-password: ""
  kafka-protobuf-git-basicauth-password: ""
  kafka-sasl-aws-msk-iam-secret-key: ""

...

  # Enterprise
  enterprise-license: "<redacted>"

...

```

and the deployment now looks like 

```
# Source: redpanda/templates/console/configmap-and-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redpanda-console
  labels:
    helm.sh/chart: console-0.7.2
    app.kubernetes.io/name: console
    app.kubernetes.io/instance: redpanda
    app.kubernetes.io/version: "v2.3.2"
    app.kubernetes.io/managed-by: Helm

...

            - name: LICENSE
              valueFrom:
                secretKeyRef:
                  name: redpanda-console
                  key: enterprise-license

...


```

Second is passing license key through a secret:

```
helm template redpanda charts/redpanda --set license_secret_ref.secret_name="blah" --set license_secret_ref.secret_key="my-awsome-key"
```

which results in 

```
---
# Source: redpanda/templates/console/configmap-and-deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redpanda-console
  labels:
    helm.sh/chart: console-0.7.2
    app.kubernetes.io/name: console
    app.kubernetes.io/instance: redpanda
    app.kubernetes.io/version: "v2.3.2"
    app.kubernetes.io/managed-by: Helm

...

       - name: LICENSE
         valueFrom:
                secretKeyRef:
                  name: blah
                  key: my-awsome-key

...
```