### PR TITLE
Chart version bump fix

### DIFF
--- a/.github/bump_chart_versions.sh
+++ b/.github/bump_chart_versions.sh
@@ -41,3 +41,4 @@ echo "update ${CHART} appVersion from ${APPVERSION} to ${LATEST}"
 bump_patch_version
 sed -i "s/^version: .*$/version: ${NEW_VERSION}/" "${CHARTFILE}"
 sed -i "s/^appVersion: .*$/appVersion: ${LATEST}/" "${CHARTFILE}"
+sed -i "s/${APPVERSION}/${LATEST}/" "${CHARTFILE}"

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.7.2
+version: 0.7.3
 
 # The app version is the version of the Chart application
 appVersion: v2.3.2
@@ -44,4 +44,4 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/console:v2.2.5
+      image: docker.redpanda.com/redpandadata/console:v2.3.2

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -34,9 +34,9 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.5
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.7
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.2.5
+      image: docker.redpanda.com/redpandadata/redpanda:v23.2.7
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
   artifacthub.io/crds: |

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
         - --metrics-bind-address=127.0.0.1:8080
         - --leader-elect
         - --configurator-tag={{ include "configurator.tag" . }}
-        - --configurator-base-image={{ .Values.configurator.repository }}
+        - --configurator-base-image={{ .Values.configurator.containerRegistry }}
         {{- if and .Values.webhook.enabled (eq .Values.scope "Cluster" ) }}
         - --webhook-enabled=true
         {{- else }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -24,7 +24,7 @@ image:
 
 configurator:
   # configurator.repository -- Repository that Redpanda configurator image is available
-  repository: docker.redpanda.com/redpandadata/configurator
+  containerRegistry: docker.redpanda.com/redpandadata/configurator
   # configurator.tag -- Define the Redpanda configurator container tag
   # tag:
   # configurator.pullPolicy -- Define the pullPolicy for Redpanda configurator image

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.2
+version: 5.4.3
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
@@ -56,7 +56,7 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.2.7
+      image: docker.redpanda.com/redpandadata/redpanda:v23.2.8
     - name: busybox
       image: busybox:latest
     - name: mintel/docker-alpine-bash-curl-jq


### PR DESCRIPTION
Align all appVersion string with artifacthub.io/images annotation.

Fix operator values.yaml to work with `bump_chart_version.sh` script.
Currently nightly build is failing with the following error:
```
2023/09/15 01:26:17 Error querying repository tags: unable to open repository 'docker.redpanda.com/redpandadata/redpanda-operator
docker.redpanda.com/redpandadata/configurator': invalid reference: invalid repository
```

The values.yaml file for operator has 2 repository values which confuses `bump_chart_version.sh` script.

The `docker-tag-list` program receives in the REPO variable the following content:
```
docker.redpanda.com/redpandadata/redpanda-operator
docker.redpanda.com/redpandadata/configurator
```

This change overcome this issue.

P.S. New version of the Operator will not use configurator container.

REF
https://github.com/redpanda-data/helm-charts/actions/runs/6192749166/job/16813278284#step:6:7

Make new replacement of any occurrence of old version into new version in `Chart.yaml` file. 