### PR TITLE
Enable new topic custom resource RBAC rules

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.17
+version: 0.3.18
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/operator/templates/clusterrole.yaml
+++ b/charts/operator/templates/clusterrole.yaml
@@ -261,6 +261,30 @@ rules:
     - get
     - patch
     - update
+- apiGroups:
+    - cluster.redpanda.com
+  resources:
+    - topics
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - cluster.redpanda.com
+  resources:
+    - topics/finalizers
+  verbs:
+    - update
+- apiGroups:
+    - cluster.redpanda.com
+  resources:
+    - topics/status
+  verbs:
+    - get
+    - patch
+    - update
 {{- end -}}
 {{- if and .Values.rbac.create (and ( eq .Values.scope "Namespace" ) .Values.rbac.createAdditionalControllerCRs ) -}}
 ---


### PR DESCRIPTION
As the topic controller will be enabled by default the RBAC rules for new topic custom resource needs to be added to cluster scoped type of deployment. The Kubernetes controller runtime would shutdown whole operator Pod due to missing RBAC permissions.

REF:
https://github.com/redpanda-data/redpanda/pull/11208