### PR TITLE
redpanda: Give tuners init container root user

### DIFF
--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -76,6 +76,8 @@ spec:
             capabilities:
               add: ["SYS_RESOURCE"]
             privileged: true
+            runAsUser: 0
+            runAsGroup: 0
           volumeMounts: {{ include "common-mounts" . | nindent 12 }}
   {{- if dig "initContainers" "tuning" "extraVolumeMounts" false .Values.statefulset -}}
     {{ tpl .Values.statefulset.initContainers.tuning.extraVolumeMounts . | nindent 12 }}


### PR DESCRIPTION
In previous PR #733 the commit https://github.com/redpanda-data/helm-charts/pull/733/commits/9af15ba8c12a6d7bc2258b2f67d8c056164e7c71 reverted root user and group for tuners init container. This PR reverts that.