### PR TITLE
redpanda: Revert security context helper method

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.5
+version: 5.4.6
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -564,10 +564,10 @@ fsGroupChangePolicy: {{ dig "securityContext" "fsGroupChangePolicy" "OnRootMisma
 {{- end -}}
 
 # for backward compatibility, force a default on releases that didn't
-
+# set the podSecurityContext.runAsUser before
 {{- define "container-security-context" -}}
-
-
+runAsUser: {{ dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset }}
+runAsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
 {{- end -}}
 
 {{- define "admin-tls-curl-flags" -}}

--- a/charts/redpanda/templates/tests/test-api-status.yaml
+++ b/charts/redpanda/templates/tests/test-api-status.yaml
@@ -47,6 +47,6 @@ spec:
           do sleep 2
         done
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -178,6 +178,6 @@ spec:
           rpk topic list {{ include "rpk-topic-flags" . }}
           rpk topic delete {{ $testTopic }} source.{{ $testTopic }} mm2-offset-syncs.test-only-redpanda.internal {{ include "rpk-topic-flags" . }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-console.yaml
+++ b/charts/redpanda/templates/tests/test-console.yaml
@@ -44,6 +44,6 @@ spec:
       - |
         curl -svm3 --fail --retry 120 --retry-max-time 120 --retry-all-errors http://{{ include "redpanda.fullname" . }}-console.{{ .Release.Namespace }}.svc:{{ include "console.containerPort" (dict "Values" .Values.console) }}/api/cluster
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
+++ b/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
@@ -118,6 +118,6 @@ spec:
       {{- end }}
     {{- end }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
@@ -59,6 +59,6 @@ spec:
         done
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -69,5 +69,5 @@ spec:
 {{- end }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -65,6 +65,6 @@ spec:
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources:
 {{- toYaml .Values.statefulset.resources | nindent 12 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-lifecycle-scripts.yaml
+++ b/charts/redpanda/templates/tests/test-lifecycle-scripts.yaml
@@ -56,7 +56,7 @@ spec:
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
         - name: lifecycle-scripts
           mountPath: /var/lifecycle
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
     - name: lifecycle-scripts
       secret:

--- a/charts/redpanda/templates/tests/test-loadbalancer-tls.yaml
+++ b/charts/redpanda/templates/tests/test-loadbalancer-tls.yaml
@@ -125,7 +125,7 @@ spec:
   {{- end }}
   {{- end }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 ---
 apiVersion: v1

--- a/charts/redpanda/templates/tests/test-nodeport-tls.yaml
+++ b/charts/redpanda/templates/tests/test-nodeport-tls.yaml
@@ -126,7 +126,7 @@ spec:
     {{- end }}
   {{- end }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 ---
 apiVersion: v1

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -67,6 +67,6 @@ spec:
           https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.http.port }}/topics
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -57,6 +57,6 @@ spec:
           {{- end }}
           http://{{ include "redpanda.servicename" . }}:{{ .Values.listeners.http.port }}/topics
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -69,5 +69,5 @@ spec:
 
         rpk cluster config get enable_rack_awareness {{ template "rpk-acl-user-flags" $ }} | grep '{{ .Values.rackAwareness.enabled }}'
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}

--- a/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
+++ b/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
@@ -87,7 +87,7 @@ spec:
 
         test -f /tmp/bundle/k8s/pods.json
         test -f /tmp/bundle/k8s/configmaps.json
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end -}}
 */}}

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -60,6 +60,6 @@ spec:
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources:
 {{- toYaml .Values.statefulset.resources | nindent 12 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -132,6 +132,6 @@ spec:
           fi
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end -}}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -116,6 +116,6 @@ spec:
             exit 1
           fi
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
-      securityContext: {{ include "container-security-context" . }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
In previous PR #733 the commit https://github.com/redpanda-data/helm-charts/pull/733/commits/9af15ba8c12a6d7bc2258b2f67d8c056164e7c71 removed security context helper function.

This PR reverts that.

https://github.com/redpanda-data/helm-charts/commit/9af15ba8c12a6d7bc2258b2f67d8c056164e7c71#diff-8407f32f870c88088a3041f8a5a8394806973dabdef154b7fde83d5e77f70ed8R567-R570