### PR TITLE
use redpanda.yaml for rpk commands instead of flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,12 @@ charts/kminion/templates/redpanda-tls.yaml
 charts/connectors/templates/hidden-only-for-ci/
 
 ct_previous_*
+
+tls.crt
+tls.csr
+tls.key
+ca.crt
+ca.key
+cert.conf
+csr.conf
+ca.srl

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.5.3
+version: 5.6.0
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/NOTES.txt
+++ b/charts/redpanda/templates/NOTES.txt
@@ -37,11 +37,7 @@ Any rpk command that's given to the user in in this file must be defined in _exa
 {{- $anySASL := (include "sasl-enabled" . | fromJson).bool }}
 {{- $rpk := deepCopy . }}
 
-{{- $_ := set $rpk "rpk" (
-  printf "kubectl -n %s exec -ti %s-0 -c redpanda -- rpk"
-    .Release.Namespace
-    (include "redpanda.fullname" .))
-}}
+{{- $_ := set $rpk "rpk" "rpk" }}
 
 Congratulations on installing {{ .Chart.Name }}!
 
@@ -56,18 +52,42 @@ If you are using the load balancer service with a cloud provider, the services w
   {{ printf "helm upgrade %s redpanda/redpanda -n %s --set $(kubectl get svc -n %s -o jsonpath='{\"external.addresses={\"}{ range .items[*]}{.status.loadBalancer.ingress[0].ip }{.status.loadBalancer.ingress[0].hostname}{\",\"}{ end }{\"}\\n\"}')" (include "redpanda.name" .) .Release.Namespace .Release.Namespace }}
 {{- end }}
 
+Set up rpk for access to your external listeners:
+{{- $profile := keys .Values.listeners.kafka.external | first -}}
+{{ if (include "tls-enabled" . | fromJson).bool }}
+  {{- $external := dig "tls" "cert" .Values.listeners.kafka.tls.cert (get .Values.listeners.kafka.external $profile )}}
+  kubectl get secret -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-{{ $external }}-cert -o go-template='{{ "{{" }} index .data "ca.crt" | base64decode }}' > ca.crt
+  {{- if or .Values.listeners.kafka.tls.requireClientAuth .Values.listeners.admin.tls.requireClientAuth }}
+  kubectl get secret -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-client -o go-template='{{ "{{" }} index .data "tls.crt" | base64decode }}' > tls.crt
+  kubectl get secret -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-client -o go-template='{{ "{{" }} index .data "tls.key" | base64decode }}' > tls.key
+  {{- end }}
+{{- end }}
+  rpk profile create --from-profile <(kubectl get configmap -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-rpk -o go-template='{{ "{{" }} .data.profile }}') {{ $profile }}
+
+Set up dns to look up the pods on their Kubernetes Nodes. You can use this query to get the list of short-names to IP addresses. Add your external domain to the hostnames and you could test by adding these to your /etc/hosts:
+
+  kubectl get pod -n {{ .Release.Namespace }} -o custom-columns=node:.status.hostIP,name:.metadata.name --no-headers -l app.kubernetes.io/name=redpanda,app.kubernetes.io/component=redpanda-statefulset
+
+{{- if and $anySASL }}
+
+Set the credentials in the environment:
+
+  kubectl -n {{ .Release.Namespace }} get secret {{ .Values.auth.sasl.secretRef }} -o go-template="{{ "{{" }} range .data }}{{ "{{" }} . | base64decode }}{{ "{{" }} end }}" | IFS=: read -r {{ include "rpk-sasl-environment-variables" . }}
+  export {{ include "rpk-sasl-environment-variables" . }}
+
+{{- end }}
+
 Try some sample commands:
 
 {{- if and $anySASL }}
-{{- $_ := set $rpk "dummySasl" true }}
-
 Create a user:
 
   {{ include "rpk-acl-user-create" $rpk }}
 
 Give the user permissions:
 
-    {{ include "rpk-acl-create" $rpk }}
+  {{ include "rpk-acl-create" $rpk }}
+
 {{- end }}
 
 Get the api status:

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,58 +23,30 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }} {{ include "rpk-acl-user-flags" . }}
+{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-create" -}}
-{{- $dummySasl := .dummySasl -}}
-{{- if $dummySasl -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
-{{- else -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic' {{ include "rpk-flags-no-admin" . }}
-{{- end -}}
+{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic'
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-cluster-info" -}}
-{{- $dummySasl := .dummySasl -}}
-{{- if $dummySasl -}}
-{{ .rpk }} cluster info {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
-{{- else -}}
-{{ .rpk }} cluster info {{ include "rpk-flags-no-admin" . }}
-{{- end -}}
+{{ .rpk }} cluster info
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-create" -}}
-{{- $flags := fromJson (include "rpk-flags" .) -}}
-{{- $dummySasl := .dummySasl -}}
-{{- if $dummySasl -}}
-{{ .rpk }} topic create test-topic -p 3 -r {{ .Values.statefulset.replicas | int64 }} {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
-{{- else -}}
-{{ .rpk }} topic create test-topic -p 3 -r {{ .Values.statefulset.replicas | int64 }} {{ include "rpk-flags-no-admin" . }}
-{{- end -}}
+{{ .rpk }} topic create test-topic -p 3 -r {{ min (int64 .Values.statefulset.replicas) 3 }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-describe" -}}
-{{- $flags := fromJson (include "rpk-flags" .) -}}
-{{- $dummySasl := .dummySasl -}}
-{{- if $dummySasl -}}
-{{ .rpk }} topic describe test-topic {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
-{{- else -}}
-{{ .rpk }} topic describe test-topic {{ include "rpk-flags-no-admin" . }}
-{{- end -}}
+{{ .rpk }} topic describe test-topic
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-delete" -}}
-{{- $flags := fromJson (include "rpk-flags" .) -}}
-{{- $dummySasl := $.dummySasl -}}
-{{- if $dummySasl -}}
-{{ .rpk }} topic delete test-topic {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
-{{- else -}}
-{{ .rpk }} topic delete test-topic {{ include "rpk-flags-no-admin" . }}
-{{- end -}}
+{{ .rpk }} topic delete test-topic
 {{- end -}}

--- a/charts/redpanda/templates/certs.yaml
+++ b/charts/redpanda/templates/certs.yaml
@@ -73,4 +73,32 @@ spec:
       {{- end }}
     {{- end }}
   {{- end }}
+---
+  {{- $name := .Values.listeners.kafka.tls.cert }}
+  {{- $data := get .Values.tls.certs $name }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ template "redpanda.fullname" $ }}-client
+  namespace: {{ $ns | quote }}
+  {{- with include "full.labels" $root }}
+  labels: {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  commonName: {{ template "redpanda.fullname" $ }}-client
+  duration: {{ $data.duration | default "43800h" }}
+  isCA: false
+  secretName: {{ template "redpanda.fullname" $ }}-client
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  {{- if not (empty $data.issuerRef) }}
+  issuerRef: {{- toYaml $data.issuerRef | nindent 4 }}
+    group: cert-manager.io
+  {{- else }}
+  issuerRef:
+    name: {{ template "redpanda.fullname" $ }}-{{ $name }}-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+  {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -24,5 +24,19 @@ metadata:
 {{- with include "full.labels" . }}
   {{- . | nindent 4 }}
 {{- end }}
+data: {{ include "full-configmap" . | nindent 2 }}
+
+{{- if .Values.external.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "redpanda.fullname" . }}-rpk
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+{{- with include "full.labels" . }}
+  {{- . | nindent 4 }}
+{{- end }}
 data:
-  {{ include "configmap-with-server-list" . | trim }}
+  profile: | {{ include "rpk-config-external" . | nindent 4 }}
+{{- end }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -83,10 +83,10 @@ spec:
           - |
             set -e
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
-          {{- if not (empty (include "enterprise-secret" . ) ) }}
-            rpk cluster license set "$REDPANDA_LICENSE" {{ template "rpk-acl-user-flags" $ }}
-          {{- else if not ( empty (include "enterprise-license" . ) ) }}
-            rpk cluster license set {{ include "enterprise-license" .  | quote }} {{ template "rpk-acl-user-flags" $ }}
+          {{- if not (empty (include "enterprise-secret" . )) }}
+            rpk cluster license set "$REDPANDA_LICENSE"
+          {{- else if not (empty (include "enterprise-license" . )) }}
+            rpk cluster license set {{ .Values.license_key | quote }}
           {{- end }}
         {{- end }}
         {{- with .Values.post_install_job.resources }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.post_upgrade_job.enabled }}
-{{- $rpkFlags := include "rpk-acl-user-flags" . }}
 {{- $sasl := .Values.auth.sasl }}
 {{- $root := deepCopy . }}
 apiVersion: batch/v1
@@ -70,14 +69,14 @@ spec:
         args:
           - |
             set -e
-            rpk cluster config import -f /etc/redpanda/bootstrap.yaml {{ $rpkFlags }}
+            rpk cluster config import -f /etc/redpanda/bootstrap.yaml
 {{- range $key, $value := .Values.config.cluster }}
   {{- if $value }}
-            rpk cluster config set {{ $key }} {{ $value }} {{ $rpkFlags }}
+            rpk cluster config set {{ $key }} {{ $value }}
   {{- end }}
 {{- end }}
 {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
-            rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }} {{ $rpkFlags }}
+            rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }}
 {{- end }}
         {{- with .Values.post_upgrade_job.resources }}
         resources:

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -74,7 +74,7 @@ stringData:
       # Setup and export SASL bootstrap-user
       IFS=":" read -r USER_NAME PASSWORD MECHANISM < $(find /etc/secrets/users/* -print)
       MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
-      rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ template "rpk-flags-no-brokers-no-sasl" $ }} || true
+      rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
 {{- end }}
 
       touch /tmp/postStartHookFinished
@@ -166,10 +166,17 @@ type: Opaque
 stringData:
   sasl-user.sh: |-
     #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
     set -e
 
     echo "Waiting for cluster to be ready"
-    rpk cluster health {{ include "rpk-acl-user-flags" . }} --watch --exit-when-healthy
+    rpk cluster health --watch --exit-when-healthy
 
   {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
     while true; do
@@ -201,21 +208,21 @@ stringData:
           fi
           echo "Creating user ${USER_NAME}..."
           MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
-          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} {{ include "rpk-acl-user-flags" $ }} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
           if [[ $creation_result_exit_code -ne 0 ]]; then
             # Check if the stderr contains "User already exists"
             # this error occurs when password has changed
             if [[ $creation_result == *"User already exists"* ]]; then
               echo "Update user ${USER_NAME}"
               # we will try to update by first deleting
-              deletion_result=$(rpk acl user delete ${USER_NAME}  {{ include "rpk-acl-user-flags" $ }} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
               if [[ $deletion_result_exit_code -ne 0 ]]; then
                 echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
                 READ_LIST_SUCCESS=1
                 break
               fi
               # Now we update the user
-              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM}  {{ include "rpk-acl-user-flags" $ }} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
               if [[ $update_result_exit_code -ne 0 ]]; then
                 echo "updating user ${USER_NAME} failed: ${update_result}"
                 READ_LIST_SUCCESS=1
@@ -239,7 +246,7 @@ stringData:
 
         if [[ -n "${USERS_LIST}" && ${READ_LIST_SUCCESS} ]]; then
           echo "Setting superusers configurations with users [${USERS_LIST}]"
-          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] {{ template "rpk-acl-user-flags" $ }} 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
+          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
           if [[ $superuser_result_exit_code -ne 0 ]]; then
               echo "Setting superusers configurations failed: ${superuser_result}"
           else

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -41,7 +41,7 @@ spec:
   {{- if $enabled }}
     - name: admin-{{ $name }}
       protocol: TCP
-      port: {{ $values.listeners.admin.port }}
+      port: {{ $listener.port }}
       nodePort: {{ first (dig "advertisedPorts" (list $listener.port) $listener) }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -224,8 +224,8 @@ spec:
                 - -c
                 - |
                   set -x
-                  rpk cluster health {{ (include "rpk-flags" . | fromJson).admin }}
-                  rpk cluster health {{ (include "rpk-flags" . | fromJson).admin }} | grep 'Healthy:.*true'
+                  rpk cluster health
+                  rpk cluster health | grep 'Healthy:.*true'
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}
@@ -234,14 +234,7 @@ spec:
             - rpk
             - redpanda
             - start
-            - --smp={{ include "redpanda-smp" . }}
-            - --memory={{ template "redpanda-memory" . }}M
-            - --reserve-memory={{ template "redpanda-reserve-memory" . }}M
-            - --default-log-level={{ .Values.logging.logLevel }}
-            - --advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}
-            {{- with .Values.statefulset.additionalRedpandaCmdFlags }}
-              {{- toYaml . | nindent 12 }}
-            {{- end }}
+            - "--advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}"
           ports:
 {{- range $name, $listener := .Values.listeners }}
             - name: {{ lower $name }}
@@ -294,12 +287,13 @@ spec:
           securityContext: {{- toYaml .Values.statefulset.sideCars.configWatcher.securityContext | nindent 12 }}
   {{- end }}
           volumeMounts: {{ include "common-mounts" . | nindent 12 }}
+            - name: config
+              mountPath: /etc/redpanda
+            - name: {{ template "redpanda.fullname" . }}-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
   {{- if dig "sideCars" "configWatcher" "extraVolumeMounts" false .Values.statefulset -}}
     {{ tpl .Values.statefulset.sideCars.configWatcher.extraVolumeMounts . | nindent 12 }}
   {{- end }}
-            - name: {{ template "redpanda.fullname" . }}-config-watcher
-              mountPath: /etc/secrets/config-watcher/scripts
-              readOnly: true
 {{- end }}
       {{- if and .Values.rbac.enabled .Values.statefulset.sideCars.controllers.enabled }}
         - name: redpanda-controllers
@@ -364,12 +358,10 @@ spec:
         - name: {{ (include "redpanda.name" .) | trunc 51 }}-configurator
           secret:
             secretName: {{ (include "redpanda.name" .) | trunc 51 }}-configurator
-            optional: false
             defaultMode: 0o775
         - name: {{ template "redpanda.fullname" . }}-config-watcher
           secret:
             secretName: {{ template "redpanda.fullname" . }}-config-watcher
-            optional: false
             defaultMode: 0o775
 {{- if or .Values.statefulset.nodeAffinity .Values.statefulset.podAffinity .Values.statefulset.podAntiAffinity }}
       affinity:

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -57,32 +57,38 @@ spec:
         - bash
         - -c
         - |
-          {{- $testTopic := printf "test-topic-%s" (randNumeric 3) }}
-          rpk topic create {{ $testTopic }} {{ include "rpk-topic-flags" . }}
-          rpk topic list {{ include "rpk-topic-flags" . }}
-          echo "Test message!" | rpk topic produce {{ $testTopic }} {{ include "rpk-topic-flags" . }}
-
-          SASL_MECHANISM="PLAIN"
           {{- if .Values.auth.sasl.enabled }}
           set -e
           set +x
 
-          IFS=: read -r CONNECT_SASL_USERNAME KAFKA_SASL_PASSWORD CONNECT_SASL_MECHANISM < $(find /etc/secrets/users/* -print)
-          CONNECT_SASL_MECHANISM=${CONNECT_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
-          if [[ -n "$CONNECT_SASL_USERNAME" && -n "$KAFKA_SASL_PASSWORD" && -n "$CONNECT_SASL_MECHANISM" ]]; then
-            SASL_MECHANISM=$CONNECT_SASL_MECHANISM
-            JAAS_CONFIG_SOURCE="\"source.cluster.sasl.jaas.config\": \"org.apache.kafka.common.security.scram.ScramLoginModule required username=\\\\"\"${CONNECT_SASL_USERNAME}\\\\"\" password=\\\\"\"${KAFKA_SASL_PASSWORD}\\\\"\";\","
-            JAAS_CONFIG_TARGET="\"target.cluster.sasl.jaas.config\": \"org.apache.kafka.common.security.scram.ScramLoginModule required username=\\\\"\"${CONNECT_SASL_USERNAME}\\\\"\" password=\\\\"\"${KAFKA_SASL_PASSWORD}\\\\"\";\","
-          fi
+          echo "SASL enabled: reading credentials from $(find /etc/secrets/users/* -print)"
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          RPK_USER="${REDPANDA_SASL_USERNAME}"
+          RPK_PASS="${REDPANDA_SASL_PASSWORD}"
+          RPK_SASL_MECHANISM="${REDPANDA_SASL_MECHANISM}"
+          {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+
+          JAAS_CONFIG_SOURCE="\"source.cluster.sasl.jaas.config\": \"org.apache.kafka.common.security.scram.ScramLoginModule required username=\\\\"\"${RPK_USER}\\\\"\" password=\\\\"\"${RPK_PASS}\\\\"\";\","
+          JAAS_CONFIG_TARGET="\"target.cluster.sasl.jaas.config\": \"org.apache.kafka.common.security.scram.ScramLoginModule required username=\\\\"\"${RPK_USER}\\\\"\" password=\\\\"\"${RPK_PASS}\\\\"\";\","
+          {{- end }}
+
+          {{- $testTopic := printf "test-topic-%s" (randNumeric 3) }}
+          rpk topic create {{ $testTopic }}
+          rpk topic list
+          echo "Test message!" | rpk topic produce {{ $testTopic }}
 
           set -x
           set +e
-          {{- end }}
 
           SECURITY_PROTOCOL=PLAINTEXT
-          if [[ -n "$CONNECT_SASL_MECHANISM" && $TLS_ENABLED == "true" ]]; then
+          if [[ -n "$RPK_SASL_MECHANISM" && $TLS_ENABLED == "true" ]]; then
             SECURITY_PROTOCOL="SASL_SSL"
-          elif [[ -n "$CONNECT_SASL_MECHANISM" ]]; then
+          elif [[ -n "$RPK_SASL_MECHANISM" ]]; then
             SECURITY_PROTOCOL="SASL_PLAINTEXT"
           elif [[ $TLS_ENABLED == "true" ]]; then
             SECURITY_PROTOCOL="SSL"
@@ -122,61 +128,37 @@ spec:
           EOF
 
           sed -i "s/CONNECTOR_NAME/$CONNECTOR_NAME/g" /tmp/mm2-conf.json
-          sed -i "s/SASL_MECHANISM/$SASL_MECHANISM/g" /tmp/mm2-conf.json
+          sed -i "s/SASL_MECHANISM/$RPK_SASL_MECHANISM/g" /tmp/mm2-conf.json
           sed -i "s/SECURITY_PROTOCOL/$SECURITY_PROTOCOL/g" /tmp/mm2-conf.json
           set +x
           sed -i "s/JAAS_CONFIG_SOURCE/$JAAS_CONFIG_SOURCE/g" /tmp/mm2-conf.json
           sed -i "s/JAAS_CONFIG_TARGET/$JAAS_CONFIG_TARGET/g" /tmp/mm2-conf.json
           set -x
 
-          max_iteration=10
-          for i in $(seq 1 $max_iteration)
-          do
-            curl -v -H 'Content-Type: application/json' http://{{ include "console.fullname" $consoleValues }}:{{ include "console.containerPort" $consoleValues }}/api/kafka-connect/clusters/connectors/connectors \
-            -d @/tmp/mm2-conf.json && echo
-
-            result=$?
-            if [[ $result -eq 0 ]]
-            then
-              echo "Result successful"
-              break
-            else
-              echo "Result unsuccessful"
-              sleep 1
-            fi
-          done
-
-          if [[ $result -ne 0 ]]
+          URL=http://{{ include "console.fullname" $consoleValues }}:{{ include "console.containerPort" $consoleValues }}/api/kafka-connect/clusters/connectors/connectors
+          {{/* outputting to /dev/null because the output contains the user password */}}
+          echo "Creating mm2 connector"
+          if curl -svm3 --fail --retry 120 --retry-max-time 120 --retry-all-errors -H 'Content-Type: application/json' -o /dev/null "${URL}" -d @/tmp/mm2-conf.json
           then
+            echo "Result successful"
+          else
             echo "mm2 connector can not be created!!!"
             exit 1
           fi
 
-          rpk topic consume source.{{ $testTopic }} -n 1 {{ include "rpk-topic-flags" . }}
+          rpk topic consume source.{{ $testTopic }} -n 1
 
-          for i in $(seq 1 $max_iteration)
-          do
-            curl -v -X DELETE http://{{ include "console.fullname" $consoleValues }}:{{ include "console.containerPort" $consoleValues }}/api/kafka-connect/clusters/connectors/connectors/$CONNECTOR_NAME && echo
-
-            result=$?
-            if [[ $result -eq 0 ]]
-            then
-              echo "Result successful"
-              break
-            else
-              echo "Result unsuccessful"
-              sleep 1
-            fi
-          done
-
-          if [[ $result -ne 0 ]]
+          echo "Destroying mm2 connector"
+          if curl -svm3 --fail --retry 120 --retry-max-time 120 --retry-all-errors -o /dev/null -X DELETE "${URL}/${CONNECTOR_NAME}"
           then
+            echo "Result successful"
+          else
             echo "mm2 connector can not be destroyed!!!"
             exit 1
           fi
 
-          rpk topic list {{ include "rpk-topic-flags" . }}
-          rpk topic delete {{ $testTopic }} source.{{ $testTopic }} mm2-offset-syncs.test-only-redpanda.internal {{ include "rpk-topic-flags" . }}
+          rpk topic list
+          rpk topic delete {{ $testTopic }} source.{{ $testTopic }} mm2-offset-syncs.test-only-redpanda.internal
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -34,7 +34,7 @@ spec:
   securityContext: {{ include "pod-security-context" . | nindent 4 }}
   {{- with .Values.imagePullSecrets }}
   imagePullSecrets: {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{- end }}
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
@@ -56,17 +56,27 @@ spec:
 {{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
   {{- $cloudStorageFlags = "-c retention.bytes=80 -c segment.bytes=40 -c redpanda.remote.read=true -c redpanda.remote.write=true"}}
 {{- end }}
-{{- if $sasl.enabled }}
-          until rpk topic create produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }} {{ $cloudStorageFlags }}
+{{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          if [[ -n "$old_setting" ]]; then set -x; fi
+{{- end }}
+          until rpk topic create produce.consume.test.$POD_NAME {{ $cloudStorageFlags }}
             do sleep 2
           done
           {{- range $i := until 100 }}
-          echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" $ }}
+          echo "Pandas are awesome!" | rpk topic produce produce.consume.test.$POD_NAME
           {{- end }}
           sleep 2
-          rpk topic consume produce.consume.test.$POD_NAME -n 1 {{ include "rpk-topic-flags" . }} | grep "Pandas are awesome!"
-          rpk topic delete produce.consume.test.$POD_NAME {{ include "rpk-topic-flags" . }}
-{{- end }}
+          rpk topic consume produce.consume.test.$POD_NAME -n 1 | grep "Pandas are awesome!"
+          rpk topic delete produce.consume.test.$POD_NAME
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
       securityContext: {{ include "container-security-context" . | nindent 8 }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -15,8 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if (include "sasl-enabled" . | fromJson).bool }}
-{{- $testTopicFlags := mustRegexReplaceAll "--user \\S+ " (include "rpk-topic-flags" . ) "--user myuser" }}
-{{- $testTopicFlags := mustRegexReplaceAll "--password \\S+ " $testTopicFlags "--password changeme" }}
 {{- $rpk := deepCopy . }}
 {{- $sasl := .Values.auth.sasl }}
 {{- $_ := set $rpk "rpk" "rpk" }}
@@ -49,7 +47,21 @@ spec:
         - -c
         - |
           set -xe
-          until rpk acl user delete myuser {{ include "rpk-acl-user-flags" . }}
+
+{{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          if [[ -n "$old_setting" ]]; then set -x; fi
+{{- end }}
+
+          until rpk acl user delete myuser
             do sleep 2
           done
           sleep 3
@@ -61,7 +73,7 @@ spec:
           {{ include "rpk-topic-create" $rpk }}
           {{ include "rpk-topic-describe" $rpk }}
           {{ include "rpk-topic-delete" $rpk }}
-          rpk acl user delete myuser {{ include "rpk-acl-user-flags" . }}
+          rpk acl user delete myuser
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources:
 {{- toYaml .Values.statefulset.resources | nindent 12 }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -43,14 +43,24 @@ spec:
       command: [ "/bin/bash", "-c" ]
       args:
         - |
-          {{- if $sasl.enabled }}
-          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
-          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+  {{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          RPK_USER="${RPK_USER:-${REDPANDA_SASL_USERNAME}}"
+          RPK_PASS="${RPK_PASS:-${REDPANDA_SASL_PASSWORD}}"
+          if [[ -n "$old_setting" ]]; then set -x; fi
+  {{- end }}
 
           curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
-          -u $USERNAME:$PASSWORD \
+          -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
           {{- if $cert.caEnabled }}
           --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
@@ -59,7 +69,7 @@ spec:
 
           curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
-          -u $USERNAME:$PASSWORD \
+          -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
           {{- if $cert.caEnabled }}
           --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -40,20 +40,30 @@ spec:
       command: [ "/bin/bash", "-c" ]
       args:
         - |
-          {{- if $sasl.enabled }}
-          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
-          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+  {{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          RPK_USER="${RPK_USER:-${REDPANDA_SASL_USERNAME}}"
+          RPK_PASS="${RPK_PASS:-${REDPANDA_SASL_PASSWORD}}"
+          if [[ -n "$old_setting" ]]; then set -x; fi
+  {{- end }}
 
           curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
-          -u $USERNAME:$PASSWORD \
+          -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
           http://{{ include "redpanda.servicename" . }}:{{ .Values.listeners.http.port }}/brokers
 
           curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
-          -u $USERNAME:$PASSWORD \
+          -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
           http://{{ include "redpanda.servicename" . }}:{{ .Values.listeners.http.port }}/topics
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -14,25 +14,23 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
   name: {{ include "redpanda.fullname" . }}-test-rack-awareness
   namespace: {{ .Release.Namespace | quote }}
-  labels:
-    {{- with include "full.labels" . }}
-        {{- . | nindent 4 }}
-    {{- end }}
+{{- with include "full.labels" . }}
+  labels: {{- . | nindent 4 }}
+{{- end }}
   annotations:
     "helm.sh/hook": test
     "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   restartPolicy: Never
   securityContext: {{ include "pod-security-context" . | nindent 4 }}
-  {{- with .Values.imagePullSecrets }}
+{{- with .Values.imagePullSecrets }}
   imagePullSecrets: {{- toYaml . | nindent 4 }}
-  {{- end }}
+{{- end }}
   containers:
     - name: {{ template "redpanda.name" . }}
       image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
@@ -41,33 +39,22 @@ spec:
       - -c
       - |
         set -e
-    {{- if and .Values.rackAwareness.enabled (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
+{{- if and .Values.rackAwareness.enabled (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
         curl --silent --fail --retry 120 \
           --retry-max-time 120 --retry-all-errors \
-      {{- if (include "tls-enabled" . | fromJson).bool }}
-        {{- range $name, $cert := .Values.tls.certs }}
-          {{- if and $cert.caEnabled (eq $name "default") }}
-          --cacert {{ printf "/etc/tls/certs/%s/ca.crt" $name }} \
-          {{- end }}
-        {{- end }}
-        https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
-      {{- else }}
-        http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
-      {{- end }}
+  {{- if (include "tls-enabled" . | fromJson).bool }}
+    {{- if (dig "default" "caEnabled" false .Values.tls.certs) }}
+          --cacert "/etc/tls/certs/default/ca.crt" \
     {{- end }}
+        https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
+  {{- else }}
+        http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }}/v1/node_config | grep '"rack":"rack[1-4]"'
+  {{- end }}
+{{- end }}
 
-        rpk redpanda admin config print \
-      {{- if (include "tls-enabled" . | fromJson).bool }}
-        {{- range $name, $cert := .Values.tls.certs }}
-          {{- if and $cert.caEnabled (eq $name "default") }}
-          --admin-api-tls-enabled \
-          --admin-api-tls-truststore {{ printf "/etc/tls/certs/%s/ca.crt" $name }} \
-          {{- end }}
-        {{- end }}
-      {{- end }}
-          --host {{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} | grep '"enable_rack_awareness": {{ .Values.rackAwareness.enabled }}'
+        rpk redpanda admin config print --host {{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.admin.port }} | grep '"enable_rack_awareness": {{ .Values.rackAwareness.enabled }}'
 
-        rpk cluster config get enable_rack_awareness {{ template "rpk-acl-user-flags" $ }} | grep '{{ .Values.rackAwareness.enabled }}'
+        rpk cluster config get enable_rack_awareness
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}

--- a/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
+++ b/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
@@ -65,7 +65,19 @@ spec:
       - -c
       - |
         set -e
-        rpk debug bundle -o /usr/share/redpanda/test/debug-test.zip -n {{ .Release.Namespace }} {{ include "rpk-common-flags" . }}
+  {{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          if [[ -n "$old_setting" ]]; then set -x; fi
+  {{- end }}
+        rpk debug bundle -o /usr/share/redpanda/test/debug-test.zip -n {{ .Release.Namespace }}
   containers:
     - name: {{ template "redpanda.name" . }}-tester
       image: busybox:latest

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -47,11 +47,21 @@ spec:
         - bash
         - -c
         - |
-          set -xe
+          set -e
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+
+          set -x
+
           # check that the users list did update
           ready_result_exit_code=1
           while [[ ${ready_result_exit_code} -ne 0 ]]; do
-            ready_result=$(rpk acl user list {{ include "rpk-acl-user-flags" . }} | grep anotheranotherme 2>&1) && ready_result_exit_code=$?
+            ready_result=$(rpk acl user list | grep anotheranotherme 2>&1) && ready_result_exit_code=$?
             sleep 2
           done
 

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -43,93 +43,75 @@ spec:
       command: ["/bin/bash", "-c"]
       args:
         - |
-          {{- if $sasl.enabled }}
-          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
-          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+  {{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          RPK_USER="${RPK_USER:-${REDPANDA_SASL_USERNAME}}"
+          RPK_PASS="${RPK_PASS:-${REDPANDA_SASL_PASSWORD}}"
+          if [[ -n "$old_setting" ]]; then set -x; fi
+  {{- end }}
+
+          set -ex
 
           schemaCurl () {
-            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
-            {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-            -u $USERNAME:$PASSWORD \
-            {{- end }}
-            {{- if $cert.caEnabled }}
-            --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
-            {{- end }}
-            $*
+            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u "${RPK_USER}:${RPK_PASS}" \
+              {{- end }}
+              {{- if $cert.caEnabled }}
+              --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+              {{- end }}
+              $*
           }
 
+          echo "Get existng schemas"
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
-          -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
-          -d '{"schema": "{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
-          {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-          -u $USERNAME:$PASSWORD \
-          {{- end }}
-          {{- if $cert.caEnabled }}
-          --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
-          {{- end }}
-          https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+          echo "Create schema"
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
+            -d '{"schema": "{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
+            {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u ${RPK_USER}:${RPK_PASS} \
+            {{- end }}
+            {{- if $cert.caEnabled }}
+              --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+            {{- end }}
+            https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
 
+          echo "Get schema 1"
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
 
+          echo "Get existng schemas"
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
-          max_iteration=10
-
-          for i in $(seq 1 $max_iteration)
-          do
-            curl -vv -X DELETE \
-              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-              -u $USERNAME:$PASSWORD \
-              {{- end }}
-              {{- if $cert.caEnabled }}
+          echo "Delete schema 1"
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
+            {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u ${RPK_USER}:${RPK_PASS} \
+            {{- end }}
+            {{- if $cert.caEnabled }}
               --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
-              {{- end }}
+            {{- end }}
               https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
-            result=$?
-            if [[ $result -eq 0 ]]
-            then
-              echo "Result successful"
-              break
-            else
-              echo "Result unsuccessful"
-              sleep 1
-            fi
-          done
 
-          if [[ $result -ne 0 ]]
-          then
-            echo "All of the trials failed to delete schema!!!"
-          fi
-
-          for i in $(seq 1 $max_iteration)
-          do
-            curl -vv -X DELETE \
-              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-              -u $USERNAME:$PASSWORD \
-              {{- end }}
-              {{- if $cert.caEnabled }}
+          echo "Delete schema 1 permanently"
+          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
+            {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u ${RPK_USER}:${RPK_PASS} \
+            {{- end }}
+            {{- if $cert.caEnabled }}
               --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
-              {{- end }}
+            {{- end }}
               https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
-            result=$?
-            if [[ $result -eq 0 ]]
-            then
-              echo "Result successful"
-              break
-            else
-              echo "Result unsuccessful"
-              sleep 1
-            fi
-          done
 
-          if [[ $result -ne 0 ]]
-          then
-            echo "All of the trials failed to permanently delete schema!!!"
-            exit 1
-          fi
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}
       securityContext: {{ include "container-security-context" . | nindent 8 }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -40,15 +40,25 @@ spec:
       command: [ "/bin/bash", "-c" ]
       args:
         - |
-          {{- if $sasl.enabled }}
-          USERNAME=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 1p )
-          PASSWORD=$(find /etc/secrets/users/* -print | sed -n 1p | xargs cat | sed -n 1p | tr ':' '\n' | sed -n 2p )
+  {{- if .Values.auth.sasl.enabled }}
+          old_setting=${-//[^x]/}
+          set +x
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          RPK_USER="${RPK_USER:-${REDPANDA_SASL_USERNAME}}"
+          RPK_PASS="${RPK_PASS:-${REDPANDA_SASL_PASSWORD}}"
+          if [[ -n "$old_setting" ]]; then set -x; fi
+  {{- end }}
 
           schemaCurl () {
             curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-            -u $USERNAME:$PASSWORD \
+            -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}
             $*
           }
@@ -59,7 +69,7 @@ spec:
           -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
           -d '{"schema":"{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-          -u $USERNAME:$PASSWORD \
+          -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
           http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
 
@@ -73,7 +83,7 @@ spec:
           do
             curl -vv -X DELETE \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-              -u $USERNAME:$PASSWORD \
+              -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}
               http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
             result=$?
@@ -96,7 +106,7 @@ spec:
           do
             curl -vv -X DELETE \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
-              -u $USERNAME:$PASSWORD \
+              -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}
               http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
             result=$?


### PR DESCRIPTION
configure the rpk section of redpanda.yaml to satisfy the configuration
needs of rpk to avoid using flags everywhere.

Add instructions for creating an rpk profile so external rpk users can
also run commands without having to set flags.