### PR TITLE
[redpanda] Allow set memory without SI suffix and Redpanda reserve memory can be 0 

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -56,6 +56,7 @@ jobs:
           - '0[7-9]*'
           - '1[0-2]*'
           - '1[3-5]*'
+          - '1[6-7]*'
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -31,6 +31,7 @@ jobs:
           - '0[7-9]*'
           - '1[0-2]*'
           - '1[3-5]*'
+          - '1[6-7]*'
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pull_requests_redpanda.yaml
+++ b/.github/workflows/pull_requests_redpanda.yaml
@@ -87,6 +87,7 @@ jobs:
           - '0[7-9]*'
           - '1[0-2]*'
           - '1[3-5]*'
+          - '1[6-7]*'
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.7
+version: 5.4.8
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/17-resources-without-unit-values.yaml
+++ b/charts/redpanda/ci/17-resources-without-unit-values.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+resources:
+  cpu:
+    cores: "1"
+  memory:
+    container:
+      max: 2500Mi
+      min: 2500Mi
+    redpanda:
+      memory: "2097152000"
+      reserveMemory: "0"

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -306,9 +306,6 @@ Generate configuration needed for rpk
       {{- $result = 1000 -}}
     {{- end -}}
   {{- end -}}
-  {{- if eq $result 0 -}}
-    {{- "unable to get memory value" | fail -}}
-  {{- end -}}
   {{- $result -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -203,6 +203,7 @@ Generate configuration needed for rpk
   {{/*
   This template converts the incoming SI value to whole number bytes.
   Input can be: b | B | k | K | m | M | g | G | Ki | Mi | Gi
+  Or number without suffix
   */}}
   {{- $si := . -}}
   {{- $bytes := 0 -}}
@@ -226,8 +227,10 @@ Generate configuration needed for rpk
   {{- else if hasSuffix "Gi" $si -}}
     {{- $raw := $si | trimSuffix "Gi" | float64 -}}
     {{- $bytes = mulf $raw (mul 1024 1024 1024) | floor -}}
+  {{- else if (mustRegexMatch "^[0-9]+$" $si) -}}
+    {{- $bytes = $si -}}
   {{- else -}}
-    {{- printf "\n%s is invalid SI quantity\nSuffixes can be: b | B | k | K | m | M | g | G | Ki | Mi | Gi" $si | fail -}}
+    {{- printf "\n%s is invalid SI quantity\nSuffixes can be: b | B | k | K | m | M | g | G | Ki | Mi | Gi or without any Suffixes" $si | fail -}}
   {{- end -}}
   {{- $bytes | int64 -}}
 {{- end -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -251,7 +251,7 @@ Generate configuration needed for rpk
     {{- $result = .Values.resources.memory.container.max | include "redpanda-memoryToMi" -}}
   {{- end -}}
   {{- if eq $result "" -}}
-    {{- "unable to get memory value" | fail -}}
+    {{- "unable to get memory value from container" | fail -}}
   {{- end -}}
   {{- $result -}}
 {{- end -}}
@@ -329,7 +329,7 @@ Generate configuration needed for rpk
     {{- $result = mulf (include "container-memory" .) 0.8 | int64 -}}
   {{- end -}}
   {{- if eq $result 0 -}}
-    {{- "unable to get memory value" | fail -}}
+    {{- "unable to get memory value redpanda-memory" | fail -}}
   {{- end -}}
   {{- if lt $result 256 -}}
     {{- printf "\n%d is below the minimum value for Redpanda" $result | fail -}}


### PR DESCRIPTION
In Redpanda operator project the following comment was made:

Setting both `--memory` and `--reserve-memory` is undocumented, and
shouldn't be used. However, there is insufficient information to
correctly calculate what `--reserve-memory` should be. By setting
just `--memory`, seastar will reserve at least 1.5Gi for the OS,
which doesn't make sense in a container.

REF
https://github.com/redpanda-data/redpanda/commit/25f1055573c34320873c4296c48933db4796b99d
https://github.com/redpanda-data/redpanda/pull/3831

Test is added to Github Action Workflow definition.

P.S. Differentiate similar failures when memory is used.

Fixes https://github.com/redpanda-data/redpanda/issues/13346