### PR TITLE
chore: fail fast if we do not have ability to create servicemonitors

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.9
+version: 5.4.10
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/servicemonitor.yaml
+++ b/charts/redpanda/templates/servicemonitor.yaml
@@ -14,7 +14,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.monitoring.enabled }}
+{{- if .Values.monitoring.enabled }}
 ---
 # This servicemonitor is used by Prometheus Operator to scrape the metrics
 apiVersion: monitoring.coreos.com/v1


### PR DESCRIPTION
ServiceMonitor could be created or not depending if you have the right CRDs installed or not. That would mean that if you enabled this resource in a cluster without prometheus you would have the impression that your servicemonitor object installed, only to find out later that is not the case. This should avoid bugs being filed to us. 