### PR TITLE
redpanda/feat: Allow jobs and sts to have the same affinity

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.12
+version: 5.6.13
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_job.tpl
+++ b/charts/redpanda/templates/_job.tpl
@@ -1,0 +1,38 @@
+{{/*
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Set affinity for post_install_job, defaults to global affinity if not defined in post_install_job
+*/}}
+{{- define "post-install-job-affinity" -}}
+{{- $affinity := .Values.affinity -}}
+{{- if not ( empty .Values.post_install_job.affinity ) -}}
+  {{- $affinity = .Values.post_install_job.affinity -}}
+{{- end -}}
+{{- toYaml $affinity -}}
+{{- end -}}
+
+{{/*
+Set affinity for post_upgrade_job, defaults to global affinity if not defined in post_upgrade_job
+*/}}
+{{- define "post-upgrade-job-affinity" -}}
+{{- $affinity := .Values.affinity -}}
+{{- if not ( empty .Values.post_upgrade_job.affinity ) -}}
+  {{- $affinity = .Values.post_upgrade_job.affinity -}}
+{{- end -}}
+{{- toYaml $affinity -}}
+{{- end -}}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -56,11 +56,11 @@ spec:
     {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with ( include "post-install-job-affinity" . ) }}
+      affinity: {{- . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.post_install_job.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -50,11 +50,11 @@ spec:
     {{- with .Values.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with ( include "post-upgrade-job-affinity" . ) }}
+      affinity: {{- . | nindent 8 }}
+    {{- end }}
     {{- with .Values.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
-    {{- end }}
-    {{- with .Values.post_upgrade_job.affinity }}
-      affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
       restartPolicy: Never
       securityContext: {{ include "pod-security-context" . | nindent 8 }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -363,33 +363,6 @@ spec:
           secret:
             secretName: {{ template "redpanda.fullname" . }}-config-watcher
             defaultMode: 0o775
-{{- if or .Values.statefulset.nodeAffinity .Values.statefulset.podAffinity .Values.statefulset.podAntiAffinity }}
-      affinity:
-  {{- with .Values.statefulset.nodeAffinity }}
-        nodeAffinity: {{- toYaml . | nindent 10 }}
-  {{- end }}
-  {{- with .Values.statefulset.podAffinity }}
-        podAffinity: {{- toYaml . | nindent 10 }}
-  {{- end }}
-  {{- if .Values.statefulset.podAntiAffinity }}
-        podAntiAffinity:
-      {{- if eq .Values.statefulset.podAntiAffinity.type "hard" }}
-          requiredDuringSchedulingIgnoredDuringExecution:
-            - topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
-              labelSelector:
-                matchLabels: {{ include "statefulset-pod-labels" . | nindent 18 }}
-      {{- else if eq .Values.statefulset.podAntiAffinity.type "soft" }}
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: {{ .Values.statefulset.podAntiAffinity.weight | int64 }}
-              podAffinityTerm:
-                topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
-                labelSelector:
-                  matchLabels: {{ include "statefulset-pod-labels" . | nindent 20 }}
-      {{- else if eq .Values.statefulset.podAntiAffinity.type "custom" }}
-          {{- toYaml .Values.statefulset.podAntiAffinity.custom | nindent 10 }}
-      {{- end }}
-  {{- end }}
-{{- end }}
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
       topologySpreadConstraints:
     {{- range $v := .Values.statefulset.topologySpreadConstraints }}
@@ -402,6 +375,9 @@ spec:
 {{- end }}
 {{- with ( include "statefulset-nodeSelectors" . ) }}
       nodeSelector: {{- . | nindent 8 }}
+{{- end }}
+{{- with ( include "statefulset-affinity" . ) }}
+      affinity: {{- . | nindent 8 }}
 {{- end }}
 {{- if .Values.statefulset.priorityClassName }}
       priorityClassName: {{ .Values.statefulset.priorityClassName }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -20,6 +20,20 @@
     "nodeSelector": {
       "type": "object"
     },
+    "affinity": {
+      "type": "object",
+      "properties": {
+        "nodeAffinity": {
+          "type": "object"
+        },
+        "podAffinity": {
+          "type": "object"
+        },
+        "podAntiAffinity": {
+          "type": "object"
+        }
+      }
+    },
     "tolerations": {
       "type": "array"
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -37,6 +37,10 @@ commonLabels: {}
 # For details,
 # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector).
 nodeSelector: {}
+# -- Affinity constraints for scheduling Pods, can override this for StatefulSets and Jobs.
+# For details,
+# see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).
+affinity: {}
 # -- Taints to be tolerated by Pods, can override this for StatefulSets.
 # For details,
 # see the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/).


### PR DESCRIPTION
Hi there, this is the proposal for jobs to have the same affinity with sts.  This is for `affinity` almost similar to #306.

For the backward compatibility of statefulset.podAntiAffinity, `{}` needs to be set.

```yaml
affinity:
  podAntiAffinity: <some podAntiAffinity> 
statefulset:
  podAntiAffinity: {} # Use affinity.podAntiAffinity
```

refs: #306 #715