### PR TITLE
[redpanda] Add tlsConfig for ServiceMonitor

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.13
+version: 5.6.14
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/servicemonitor.yaml
+++ b/charts/redpanda/templates/servicemonitor.yaml
@@ -34,10 +34,17 @@ spec:
   - interval: {{ .Values.monitoring.scrapeInterval }}
     path: /public_metrics
     targetPort: admin
-  {{- if .Values.tls.enabled }}
+    {{- if dig "enableHttp2" "" .Values.monitoring }}
+    enableHttp2: .Values.monitoring.enableHttp2
+    {{- end }}
+  {{- if or .Values.tls.enabled .Values.monitoring.tlsConfig }}
     scheme: https
     tlsConfig:
+      {{- if  dig "tlsConfig" dict .Values.monitoring }}
+      {{- .Values.monitoring.tlsConfig | toYaml | nindent 6 }}
+      {{- else }}
       insecureSkipVerify: true
+      {{- end}}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -306,6 +306,9 @@
         },
         "labels": {
           "type": "object"
+        },
+        "tlsConfig": {
+          "type": "object"
         }
       }
     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -275,6 +275,13 @@ monitoring:
   enabled: false
   scrapeInterval: 30s
   labels: {}
+  # Enables http2 for scraping metrics for prometheus. Used when Istio's mTLS is enabled and using tlsConfig.
+  # enableHttp2: true
+  tlsConfig: {}
+    # caFile: /etc/prom-certs/root-cert.pem
+    # certFile: /etc/prom-certs/cert-chain.pem
+    # insecureSkipVerify: true
+    # keyFile: /etc/prom-certs/key.pem
 
 # -- Pod resource management.
 # This section simplifies resource allocation


### PR DESCRIPTION
## Motivation

ServiceMonitor does not have configuration to set TLS for scraping with Prometheus.

## Approach
Enable tlsConfig in ServiceMonitor as-well keep default configuration if the cluster uses TLS. Also adds `enableHttp2` which by default is `true`.