### PR TITLE
chore: change service's selectors to avoid targeting hook pods. 

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.12
+version: 5.4.13
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/service.internal.yaml
+++ b/charts/redpanda/templates/service.internal.yaml
@@ -35,9 +35,7 @@ spec:
   type: ClusterIP
   publishNotReadyAddresses: true
   clusterIP: None
-  selector:
-    app.kubernetes.io/name: {{ template "redpanda.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  selector: {{ (include "statefulset-pod-labels" .) | nindent 4 }}
   ports:
     - name: admin
       protocol: TCP

--- a/charts/redpanda/templates/service.loadbalancer.yaml
+++ b/charts/redpanda/templates/service.loadbalancer.yaml
@@ -90,9 +90,7 @@ spec:
       port: {{ dig "nodePort" (first (dig "advertisedPorts" (list $listener.port) $listener)) $listener }}
       {{- end }}
     {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "redpanda.name" $root }}
-    app.kubernetes.io/instance: {{ $root.Release.Name }}
+  selector: {{ (include "statefulset-pod-labels" $root ) | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $podName }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/services.nodeport.yaml
+++ b/charts/redpanda/templates/services.nodeport.yaml
@@ -72,7 +72,5 @@ spec:
       nodePort: {{ first (dig "advertisedPorts" (list $listener.port) $listener) }}
   {{- end }}
 {{- end }}
-  selector:
-    app.kubernetes.io/name: {{ template "redpanda.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+  selector: {{ (include "statefulset-pod-labels" .) | nindent 4 }}
 {{- end }}


### PR DESCRIPTION
Fixes #749 
Remove full set of labels found in the service selector 

```
  selector:
    app.kubernetes.io/name: {{ template "redpanda.name" . }}
    app.kubernetes.io/instance: {{ .Release.Name | quote }}
```

Changed to:

```
spec:
...
  selector: {{ (include "statefulset-pod-labels" .) | nindent 4 }}
```

It was agreed that we will change selectors for the services.  