### PR TITLE
Operator: use helper sa value instead of full name for leader election

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.19
+version: 0.3.20
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/operator/templates/role_binding.yaml
+++ b/charts/operator/templates/role_binding.yaml
@@ -18,7 +18,7 @@ metadata:
 {{ include "redpanda-operator.labels" . | indent 4 }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "redpanda-operator.fullname" . }}
+  name: {{ include "redpanda-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role


### PR DESCRIPTION
Use the same helper reference to assign the service account to the leader-election-role. This will allow consistent use of your own sa or the sa we generate. 