### PR TITLE
operator: prometheus stack deployed if deployPrometheusKubeStack=true

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.20
+version: 0.3.21
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
@@ -21,8 +21,8 @@ maintainers:
 
 dependencies:
 - name: kube-prometheus-stack
-  condition: monitoring.enabled
-  version: 13.13.1
+  condition: monitoring.deployPrometheusKubeStack
+  version: 51.2.0
   repository: https://prometheus-community.github.io/helm-charts
 
 annotations:

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -101,6 +101,7 @@ labels:
 # monitoring -- Add service monitor to the deployment
 monitoring:
   enabled: false
+  deployPrometheusKubeStack: false
 
 webhookSecretName: webhook-server-cert
 


### PR DESCRIPTION
Found that the subchart prometheus stack was deployed if monitoring enabled=true, which is too broad. For now we add another field monitoring.deployPrometheusKubeStack=true to make the stack to deploy, thought this is not ideal.

Previously installing with monitoring.enabled=true would cause: (on 1.25+ k8s clusters)
```
Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: [resource mapping not found for name: "redpanda-operator-grafana" namespace: "default" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "redpanda-operator-grafana-test" namespace: "default" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "redpanda-operator-kube-state-metrics" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "redpanda-operator-prometheus-node-exporter" namespace: "default" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "redpanda-operator-kube-pro-alertmanager" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "redpanda-operator-kube-pro-operator" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first, resource mapping not found for name: "redpanda-operator-kube-pro-prometheus" namespace: "" from "": no matches for kind "PodSecurityPolicy" in version "policy/v1beta1"
ensure CRDs are installed first]

We updated the subchart to avoid this, BUT, we do not recommend using this chart to deploy prometheus, we leave that as optional so we do not deploy this when you are creating your monitoring resource.


