### PR TITLE
refactor tiered storage configuration values

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -48,8 +48,8 @@ jobs:
       matrix:
         version:
           - ""
-          - v22.3.17
-          - v22.2.11
+          - v23.1.18
+          - v22.3.23
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'
@@ -57,7 +57,7 @@ jobs:
           - '1[0-2]*'
           - '1[3-5]*'
           - '1[6-7]*'
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -32,7 +32,7 @@ jobs:
           - '1[0-2]*'
           - '1[3-5]*'
           - '1[6-7]*'
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -35,11 +35,12 @@ jobs:
       matrix:
         version:
           - ""
-          - v22.3.17
-          # - v22.2.x takes too long. Only run nightly.
+          - v23.1.18
+          - v22.3.23
         testvaluespattern:
+          - '1[8-9]*' # tests 18 and 19 depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
           - '99*'
-      fail-fast: true
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -96,15 +97,15 @@ jobs:
           kubectl create secret generic redpanda-license \
           --from-literal=license-key="$REDPANDA_LICENSE" \
           --dry-run=client -o yaml > redpanda-license.yaml.tmp
-          
+
           kubectl annotate -f redpanda-license.yaml.tmp \
           helm.sh/hook-delete-policy="before-hook-creation" \
           helm.sh/hook="pre-install" \
           helm.sh/hook-weight="-100" \
           --local --dry-run=none -o yaml > redpanda-license.yaml
-          
+
           rm redpanda-license.yaml.tmp
-          
+
           mv redpanda-license.yaml ./charts/redpanda/templates/
 
       - name: install cert-manager

--- a/.github/workflows/pull_requests_redpanda.yaml
+++ b/.github/workflows/pull_requests_redpanda.yaml
@@ -72,14 +72,13 @@ jobs:
       - name: compare console values with main
         run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/console/values.yaml') charts/console/values.yaml
   test:
-    needs: lint
     name: "${{ matrix.version }}/${{ matrix.testvaluespattern }}: Run ct tests"
     strategy:
       matrix:
         version:
           - ""
-          - v22.3.17
-          # - v22.2.x takes too long. Only run nightly.
+          - v23.1.18
+          - v22.3.23
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'
@@ -87,8 +86,8 @@ jobs:
           - '1[0-2]*'
           - '1[3-5]*'
           - '1[6-7]*'
-          - '1[8-9]*'
-      fail-fast: true
+          # - '1[8-9]*' # tests 18 and 19 depend on a github secret that isn't available for fork PRs.
+      fail-fast: false
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.4.13
+version: 5.5.0
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -79,8 +79,8 @@ limitations under the License.
   {{- if and (not (hasKey .Values.config.cluster "storage_min_free_bytes")) ((include "redpanda-atleast-22-2-0" . | fromJson).bool) }}
     storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
   {{- end }}
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
-  {{- $tieredStorageConfig := deepCopy .Values.storage.tieredConfig }}
+{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
+  {{- $tieredStorageConfig := (include "storage-tiered-config" .|fromJson) }}
   {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_cache_directory" }}
   {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
     {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_credentials_source"}}
@@ -275,8 +275,8 @@ limitations under the License.
 {{- with $root.tempConfigMapServerList -}}
   {{- . | trim | nindent 8 }}
 {{- end -}}
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
-  {{- $tieredStorageConfig := deepCopy .Values.storage.tieredConfig }}
+{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
+  {{- $tieredStorageConfig := (include "storage-tiered-config" .|fromJson) }}
   {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
     {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_credentials_source"}}
   {{- end }}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -778,3 +778,29 @@ return licenseSecretRef.key checks deprecated values entry if current values emp
     name: {{ include "redpanda.fullname" . }}
 {{- include "common-volumes" . }}
 {{- end -}}
+
+{{/* support legacy tiered storage type selection */}}
+{{- define "storage-tiered-mountType" -}}
+{{- if dig "tieredStoragePersistentVolume" "enabled" false .Values.storage -}}
+persistentVolume
+{{- else if dig "tieredStorageHostPath" false .Values.storage -}}
+hostPath
+{{- else -}}
+{{- .Values.storage.tiered.mountType -}}
+{{- end -}}
+{{- end -}}
+
+{{/* support legacy storage.tieredStoragePersistentVolume */}}
+{{- define "storage-tiered-persistentvolume" -}}
+{{- dig "tieredStoragePersistentVolume" .Values.storage.tiered.persistentVolume .Values.storage | toJson -}}
+{{- end -}}
+
+{{/* support legacy storage.tieredStorageHostPath */}}
+{{- define "storage-tiered-hostpath" -}}
+{{- dig "tieredStorageHostPath" .Values.storage.tiered.hostPath .Values.storage -}}
+{{- end -}}
+
+{{/* support legacy storage.tieredConfig */}}
+{{- define "storage-tiered-config" -}}
+{{- dig "tieredConfig" .Values.storage.tiered.config .Values.storage | toJson -}}
+{{- end -}}

--- a/charts/redpanda/templates/_statefulset.tpl
+++ b/charts/redpanda/templates/_statefulset.tpl
@@ -38,10 +38,10 @@ app.kubernetes.io/component: {{ (include "redpanda.name" .) | trunc 51 }}-statef
 Set default path for tiered storage cache or use one provided
 */}}
 {{- define "tieredStorage.cacheDirectory" -}}
-{{- if empty .Values.storage.tieredConfig.cloud_storage_cache_directory -}}
+{{- if empty (include "storage-tiered-config" . | fromJson).cloud_storage_cache_directory -}}
   {{- printf "/var/lib/redpanda/data/cloud_storage_cache" -}}
 {{- else -}}
-  {{- .Values.storage.tieredConfig.cloud_storage_cache_directory -}}
+  {{- (include "storage-tiered-config" . | fromJson).cloud_storage_cache_directory -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -102,16 +102,18 @@ spec:
           resources: {{- toYaml .Values.statefulset.initContainers.setDataDirOwnership.resources | nindent 12 }}
   {{- end }}
 {{- end }}
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
+{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
         - name: set-tiered-storage-cache-dir-ownership
           image: {{ .Values.statefulset.initContainerImage.repository }}:{{ .Values.statefulset.initContainerImage.tag }}
-          command: ["/bin/sh", "-c", 'chown {{ $uid }}:{{ $gid }} -R {{ template "tieredStorage.cacheDirectory" . }}']
+          command: ["/bin/sh", "-c", 'chown {{ $uid }}:{{ $gid }} -R {{ include "tieredStorage.cacheDirectory" . }}']
           volumeMounts: {{ include "common-mounts" . | nindent 12 }}
   {{- if dig "initContainers" "setTieredStorageCacheDirOwnership" "extraVolumeMounts" false .Values.statefulset -}}
     {{ tpl .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership.extraVolumeMounts . | nindent 12 }}
   {{- end }}
+  {{- if ne (include "storage-tiered-mountType" .) "none" }}
             - name: tiered-storage-dir
-              mountPath: {{ template "tieredStorage.cacheDirectory" . }}
+              mountPath: {{ include "tieredStorage.cacheDirectory" . }}
+  {{- end }}
   {{- if get .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership "resources" }}
           resources: {{- toYaml .Values.statefulset.initContainers.setTieredStorageCacheDirOwnership.resources | nindent 12 }}
   {{- end }}
@@ -262,9 +264,9 @@ spec:
               mountPath: /var/lifecycle
             - name: datadir
               mountPath: /var/lib/redpanda/data
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
+{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled (ne (include "storage-tiered-mountType" .) "none") }}
             - name: tiered-storage-dir
-              mountPath: {{ template "tieredStorage.cacheDirectory" . }}
+              mountPath: {{ include "tieredStorage.cacheDirectory" . }}
 {{- end }}
           resources:
 {{- if hasKey .Values.resources.memory "min" }}
@@ -336,17 +338,20 @@ spec:
       {{- else }}
           emptyDir: {}
       {{- end }}
-      {{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
+      {{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
+        {{- $tieredType := include "storage-tiered-mountType" . }}
+        {{- if ne $tieredType "none" }}
         - name: tiered-storage-dir
-        {{- if .Values.storage.tieredStoragePersistentVolume.enabled }}
+          {{- if eq $tieredType "persistentVolume" }}
           persistentVolumeClaim:
             claimName: tiered-storage-dir
-        {{- else if .Values.storage.tieredStorageHostPath }}
+          {{- else if eq $tieredType "hostPath" }}
           hostPath:
-            path: {{ .Values.storage.tieredStorageHostPath | quote }}
-        {{- else }}
+            path: {{ include "storage-tiered-hostpath" . }}
+          {{- else }}
           emptyDir:
-            sizeLimit: {{ .Values.storage.tieredConfig.cloud_storage_cache_size }}
+            sizeLimit: {{ (include "storage-tiered-config" . | fromJson).cloud_storage_cache_size }}
+          {{- end }}
         {{- end }}
       {{- end }}
         - name: {{ template "redpanda.fullname" . }}
@@ -410,7 +415,7 @@ spec:
 {{- with ( include "statefulset-tolerations" . ) }}
       tolerations: {{- . | nindent 8 }}
 {{- end }}
-{{- if or .Values.storage.persistentVolume.enabled (and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled .Values.storage.tieredStoragePersistentVolume.enabled) }}
+{{- if or .Values.storage.persistentVolume.enabled (and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled (eq (include "storage-tiered-mountType" .) "persistentVolume" )) }}
   volumeClaimTemplates:
 {{- if .Values.storage.persistentVolume.enabled }}
     - metadata:
@@ -441,33 +446,33 @@ spec:
           requests:
             storage: {{ .Values.storage.persistentVolume.size | quote }}
 {{- end }}
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled .Values.storage.tieredStoragePersistentVolume.enabled }}
+{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled (eq (include "storage-tiered-mountType" .) "persistentVolume") }}
     - metadata:
         name: tiered-storage-dir
         labels:
           app.kubernetes.io/name: {{ template "redpanda.name" . }}
           app.kubernetes.io/instance: {{ .Release.Name | quote }}
           app.kubernetes.io/component: {{ template "redpanda.name" . }}
-  {{- with .Values.storage.tieredStoragePersistentVolume.labels }}
-    {{- toYaml . | nindent 10 }}
+  {{- with (include "storage-tiered-persistentvolume" . | fromJson).labels }}
+    {{ toYaml . | nindent 10 }}
   {{- end }}
   {{- with .Values.commonLabels }}
     {{- toYaml . | nindent 10 }}
   {{- end }}
-  {{- with .Values.storage.tieredStoragePersistentVolume.annotations }}
-        annotations: {{- toYaml . | nindent 10 }}
+  {{- with (include "storage-tiered-persistentvolume" . | fromJson).annotations }}
+        annotations: {{ toYaml . | nindent 10 }}
   {{- end }}
       spec:
         accessModes: ["ReadWriteOnce"]
-  {{- if .Values.storage.tieredStoragePersistentVolume.storageClass }}
-    {{- if (eq "-" .Values.storage.tieredStoragePersistentVolume.storageClass) }}
+  {{- with (include "storage-tiered-persistentvolume" . | fromJson).storageClass }}
+    {{- if eq "-" . }}
         storageClassName: ""
     {{- else }}
-        storageClassName: {{ .Values.storage.tieredStoragePersistentVolume.storageClass | quote }}
+        storageClassName: {{ . }}
     {{- end }}
   {{- end }}
         resources:
           requests:
-            storage: {{ .Values.storage.tieredConfig.cloud_storage_cache_size }}
+            storage: {{ (include "storage-tiered-config" .|fromJson).cloud_storage_cache_size }}
 {{- end }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -53,7 +53,7 @@ spec:
         - |
           set -e
 {{- $cloudStorageFlags := "" }}
-{{- if and (include "is-licensed" . | fromJson).bool .Values.storage.tieredConfig.cloud_storage_enabled }}
+{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
   {{- $cloudStorageFlags = "-c retention.bytes=80 -c segment.bytes=40 -c redpanda.remote.read=true -c redpanda.remote.write=true"}}
 {{- end }}
 {{- if $sasl.enabled }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -349,16 +349,142 @@
       "type": "object",
       "required": [
         "hostPath",
-        "persistentVolume"
+        "persistentVolume",
+        "tiered"
       ],
       "properties": {
         "hostPath": {
           "type": "string"
         },
+        "tiered": {
+          "type": "object",
+          "required": [
+            "mountType"
+          ],
+          "properties": {
+            "mountType": {
+              "type": "string",
+              "pattern": "^(none|hostPath|emptyDir|persistentVolume)$"
+            },
+            "hostPath": {
+              "type": "string"
+            },
+            "persistentVolume": {
+              "type": "object",
+              "required": [
+                "storageClass",
+                "labels",
+                "annotations"
+              ],
+              "properties": {
+                "storageClass": {
+                  "type": "string"
+                },
+                "labels": {
+                  "type": "object"
+                },
+                "annotations": {
+                  "type": "object"
+                }
+              }
+            },
+            "config":{
+              "type": "object",
+              "required": [
+                "cloud_storage_enabled",
+                "cloud_storage_region",
+                "cloud_storage_bucket"
+              ],
+              "properties": {
+                "cloud_storage_enable_remote_write": {
+                  "type": "boolean"
+                },
+                "cloud_storage_enable_remote_read": {
+                  "type": "boolean"
+                },
+                "cloud_storage_credentials_source": {
+                  "type": "string",
+                  "pattern": "^(config_file|aws_instance_metadata|sts|gcp_instance_metadata)$"
+                },
+                "cloud_storage_region": {
+                  "type": "string"
+                },
+                "cloud_storage_bucket": {
+                  "type": "string"
+                },
+                "cloud_storage_api_endpoint": {
+                  "type": "string"
+                },
+                "cloud_storage_cache_size": {
+                  "type": "integer"
+                },
+                "cloud_storage_cache_directory": {
+                  "type": "string"
+                },
+                "cloud_storage_cache_check_interval": {
+                  "type": "integer"
+                },
+                "cloud_storage_initial_backoff_ms": {
+                  "type": "integer"
+                },
+                "cloud_storage_max_connections": {
+                  "type": "integer"
+                },
+                "cloud_storage_segment_upload_timeout_ms": {
+                  "type": "integer"
+                },
+                "cloud_storage_manifest_upload_timeout_ms": {
+                  "type": "integer"
+                },
+                "cloud_storage_max_connection_idle_time_ms": {
+                  "type": "integer"
+                },
+                "cloud_storage_segment_max_upload_interval_sec": {
+                  "type": "integer"
+                },
+                "cloud_storage_trust_file": {
+                  "type": "string"
+                },
+                "cloud_storage_upload_ctrl_update_interval_ms": {
+                  "type": "integer"
+                },
+                "cloud_storage_upload_ctrl_p_coeff": {
+                  "type": "integer"
+                },
+                "cloud_storage_upload_ctrl_d_coeff": {
+                  "type": "integer"
+                },
+                "cloud_storage_upload_ctrl_min_shares": {
+                  "type": "integer"
+                },
+                "cloud_storage_upload_ctrl_max_shares": {
+                  "type": "integer"
+                },
+                "cloud_storage_reconciliation_interval_ms": {
+                  "type": "integer"
+                },
+                "cloud_storage_disable_tls": {
+                  "type": "boolean"
+                },
+                "cloud_storage_api_endpoint_port": {
+                  "type": "integer"
+                },
+                "cloud_storage_azure_adls_endpoint": {
+                  "type": "string"
+                },
+                "cloud_storage_azure_adls_port": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
         "tieredStorageHostPath": {
+          "deprecated": true,
           "type": "string"
         },
         "persistentVolume": {
+          "deprecated": true,
           "type": "object",
           "required": [
             "enabled",
@@ -387,6 +513,7 @@
           }
         },
         "tieredStoragePersistentVolume": {
+          "deprecated": true,
           "type": "object",
           "required": [
             "enabled",
@@ -410,6 +537,7 @@
           }
         },
         "tieredConfig":{
+          "deprecated": true,
           "type": "object",
           "required": [
             "cloud_storage_enabled",

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -389,98 +389,106 @@ storage:
   # Settings for the Tiered Storage cache.
   # For details,
   # see the [Tiered Storage documentation](https://docs.redpanda.com/docs/manage/kubernetes/tiered-storage/#caching).
-  # For the maximum size of the disk cache, see `tieredConfig.cloud_storage_cache_size`.
-  #
-  # -- Absolute path on the host to store Redpanda's Tiered Storage cache.
-  # If unspecified, then an `emptyDir` volume is used.
-  # If specified but `tieredStoragePersistentVolume.enabled` is `true`, `storage.tieredStorageHostPath` has no effect.
-  tieredStorageHostPath: ""
-  # If `tieredStoragePersistentVolume.enabled` is true,
-  # a PersistentVolumeClaim is created for the Tiered Storage cache and
-  # used to store data retrieved from cloud storage, such as S3). Otherwise `storage.tieredStorageHostPath` is used.
-  tieredStoragePersistentVolume:
-    enabled: false
-    # -- To disable dynamic provisioning, set to "-".
-    # If undefined or empty (default), then no storageClassName spec is set,
-    # and the default dynamic provisioner is chosen (gp2 on AWS, standard on
-    # GKE, AWS & OpenStack).
-    storageClass: ""
-    # -- Additional labels to apply to the created PersistentVolumeClaims.
-    labels: {}
-    # -- Additional annotations to apply to the created PersistentVolumeClaims.
-    annotations: {}
-  #
-  # -- Tiered Storage settings
-  # Requires `enterprise.licenseKey` or `enterprised.licenseSecretRef`
-  # For details,
-  # see the [Tiered Storage documentation](https://docs.redpanda.com/docs/manage/kubernetes/tiered-storage/).
-  tieredConfig:
-    # -- Global flag that enables Tiered Storage if a license key is provided.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_enabled).
-    cloud_storage_enabled: false
-    # -- See the [property reference documentation](https://docs.redpanda.com/docs/reference/tunable-properties/#cloud_storage_enable_remote_write).
-    cloud_storage_enable_remote_write: true
-    # -- See the [property reference documentation](https://docs.redpanda.com/docs/reference/tunable-properties/#cloud_storage_enable_remote_read).
-    cloud_storage_enable_remote_read: true
 
-    # -- Required for AWS and GCS.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_region).
-    cloud_storage_region: ""
-    # -- Required for AWS and GCS.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_bucket).
-    cloud_storage_bucket: ""
-    # -- Required for AWS and GCS authentication with access keys.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_access_key).
-    cloud_storage_access_key: ""
-    # -- Required for AWS and GCS authentication with access keys.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_secret_key).
-    cloud_storage_secret_key: ""
-    # -- See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_api_endpoint).
-    cloud_storage_api_endpoint: ""
-    # -- Required for ABS.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_container).
-    cloud_storage_azure_container: null
-    # -- Required for ABS.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_storage_account).
-    cloud_storage_azure_storage_account: null
-    # -- Required for ABS.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_shared_key).
-    cloud_storage_azure_shared_key: null
-    # -- Required for ABS hierarchical namespace
-    # Available starting from 23.2.8
-    # cloud_storage_azure_adls_endpoint: ""
-    # cloud_storage_azure_adls_port: ""
-    # Available starting from 22.3.X
-    # -- Required for AWS and GCS authentication with IAM roles.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_credentials_source).
-    cloud_storage_credentials_source: config_file
+  tiered:
+    # mountType can be one of:
+    # - none: does not mount a volume. Tiered storage will use the data directory.
+    # - hostPath: will allow you to chose a path on the Node the pod is running on
+    # - emptyDir: will mount a fresh empty directory every time the pod starts
+    # - persistentVolume: creates and mounts a PersistentVolumeClaim
+    mountType: emptyDir
 
-    # -- Maximum size of the disk cache used by Tiered Storage.
-    # Default is 20 GiB.
-    # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_cache_size).
-    cloud_storage_cache_size: 5368709120
-    # cloud_storage_cache_directory: ""
-    # cloud_storage_cache_check_interval: 30000
-    # cloud_storage_initial_backoff_ms: 100
-    # cloud_storage_max_connections: 20
-    # cloud_storage_segment_upload_timeout_ms: 30000
-    # cloud_storage_manifest_upload_timeout_ms: 10000
-    # cloud_storage_max_connection_idle_time_ms: 5000
-    # cloud_storage_idle_timeout_ms: 10000
-    # cloud_storage_segment_max_upload_interval_sec: 1
-    # cloud_storage_trust_file: ""
-    # cloud_storage_upload_ctrl_update_interval_ms: 60000
-    # cloud_storage_upload_ctrl_p_coeff: -2
-    # cloud_storage_upload_ctrl_d_coeff: 0
-    # cloud_storage_upload_ctrl_min_shares: 100
-    # cloud_storage_upload_ctrl_max_shares: 1000
-    # DEPRECATED: cloud_storage_reconciliation_interval_ms: 10000
-    # cloud_storage_disable_tls: false
-    # cloud_storage_api_endpoint_port: 443
-    # cloud_storage_idle_threshold_rps: 1
-    # cloud_storage_enable_segment_merging: true
-    # cloud_storage_segment_size_target: # The default segment size is controlled by log_segment_size
-    # cloud_storage_segment_size_min: # Default is 50% of log segment size
+    # For the maximum size of the disk cache, see `tieredConfig.cloud_storage_cache_size`.
+    #
+    # -- Absolute path on the host to store Redpanda's Tiered Storage cache.
+    hostPath: ""
+    # PersistentVolumeClaim to be created for the Tiered Storage cache and
+    # used to store data retrieved from cloud storage, such as S3).
+    persistentVolume:
+      # -- To disable dynamic provisioning, set to "-".
+      # If undefined or empty (default), then no storageClassName spec is set,
+      # and the default dynamic provisioner is chosen (gp2 on AWS, standard on
+      # GKE, AWS & OpenStack).
+      storageClass: ""
+      # -- Additional labels to apply to the created PersistentVolumeClaims.
+      labels: {}
+      # -- Additional annotations to apply to the created PersistentVolumeClaims.
+      annotations: {}
+    #
+    # -- Tiered Storage settings
+    # Requires `enterprise.licenseKey` or `enterprised.licenseSecretRef`
+    # For details,
+    # see the [Tiered Storage documentation](https://docs.redpanda.com/docs/manage/kubernetes/tiered-storage/).
+    config:
+      # -- Global flag that enables Tiered Storage if a license key is provided.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_enabled).
+      cloud_storage_enabled: false
+      # -- See the [property reference documentation](https://docs.redpanda.com/docs/reference/tunable-properties/#cloud_storage_enable_remote_write).
+      cloud_storage_enable_remote_write: true
+      # -- See the [property reference documentation](https://docs.redpanda.com/docs/reference/tunable-properties/#cloud_storage_enable_remote_read).
+      cloud_storage_enable_remote_read: true
+
+      # -- Required for AWS and GCS.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_region).
+      cloud_storage_region: ""
+      # -- Required for AWS and GCS.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_bucket).
+      cloud_storage_bucket: ""
+      # -- Required for AWS and GCS authentication with access keys.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_access_key).
+      cloud_storage_access_key: ""
+      # -- Required for AWS and GCS authentication with access keys.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_secret_key).
+      cloud_storage_secret_key: ""
+      # -- See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_api_endpoint).
+      cloud_storage_api_endpoint: ""
+      # -- Required for ABS.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_container).
+      cloud_storage_azure_container: null
+      # -- Required for ABS.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_storage_account).
+      cloud_storage_azure_storage_account: null
+      # -- Required for ABS.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_azure_shared_key).
+      cloud_storage_azure_shared_key: null
+      # -- Required for ABS hierarchical namespace
+      # Available starting from 23.2.8
+      # cloud_storage_azure_adls_endpoint: ""
+      # cloud_storage_azure_adls_port: ""
+      # Available starting from 22.3.X
+      # -- Required for AWS and GCS authentication with IAM roles.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_credentials_source).
+      cloud_storage_credentials_source: config_file
+
+      # -- Maximum size of the disk cache used by Tiered Storage.
+      # Default is 20 GiB.
+      # See the [property reference documentation](https://docs.redpanda.com/docs/reference/cluster-properties/#cloud_storage_cache_size).
+      cloud_storage_cache_size: 5368709120
+      # cloud_storage_cache_directory: ""
+      # cloud_storage_cache_check_interval: 30000
+      # cloud_storage_initial_backoff_ms: 100
+      # cloud_storage_max_connections: 20
+      # cloud_storage_segment_upload_timeout_ms: 30000
+      # cloud_storage_manifest_upload_timeout_ms: 10000
+      # cloud_storage_max_connection_idle_time_ms: 5000
+      # cloud_storage_idle_timeout_ms: 10000
+      # cloud_storage_segment_max_upload_interval_sec: 1
+      # cloud_storage_trust_file: ""
+      # cloud_storage_upload_ctrl_update_interval_ms: 60000
+      # cloud_storage_upload_ctrl_p_coeff: -2
+      # cloud_storage_upload_ctrl_d_coeff: 0
+      # cloud_storage_upload_ctrl_min_shares: 100
+      # cloud_storage_upload_ctrl_max_shares: 1000
+      # DEPRECATED: cloud_storage_reconciliation_interval_ms: 10000
+      # cloud_storage_disable_tls: false
+      # cloud_storage_api_endpoint_port: 443
+      # cloud_storage_idle_threshold_rps: 1
+      # cloud_storage_enable_segment_merging: true
+      # cloud_storage_segment_size_target: # The default segment size is controlled by log_segment_size
+      # cloud_storage_segment_size_min: # Default is 50% of log segment size
+  # storage.tieredStorageHostPath has been deprecated. Use storage.tiered.hostPath and configure storage.tiered.mountType instead.
+  # storage.tieredStoragePersistentVolume has been deprecated. Use storage.tiered.persistentVolume and configure storage.tiered.mountType instead.
+  # storage.tieredConfig has been deprecated. Use storage.tiered.config instead.
 
 post_install_job:
   enabled: true


### PR DESCRIPTION
move all the tiered storage configuration under `storage.tiered`. Users were expressing confusion that some tiered storage configuration lied outside of the tieredConfig key.

This also now allows a user to choose "none" for the tiered storage mount type, allowing the data to be written to the redpanda data directory.

Fixes #755 