### PR TITLE
Add schema registry and pandaproxy client node configuration

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.5.1
+version: 5.5.2
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -51,9 +51,9 @@ and tested in a test.
 {{- $flags := fromJson (include "rpk-flags" .) -}}
 {{- $dummySasl := .dummySasl -}}
 {{- if $dummySasl -}}
-{{ .rpk }} topic create test-topic {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
+{{ .rpk }} topic create test-topic -p 3 -r {{ .Values.statefulset.replicas | int64 }} {{ include "rpk-flags-no-admin-no-sasl" . }} {{ include "rpk-dummy-sasl" . }}
 {{- else -}}
-{{ .rpk }} topic create test-topic {{ include "rpk-flags-no-admin" . }}
+{{ .rpk }} topic create test-topic -p 3 -r {{ .Values.statefulset.replicas | int64 }} {{ include "rpk-flags-no-admin" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -69,6 +69,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
+            set -e
             rpk cluster config import -f /etc/redpanda/bootstrap.yaml {{ $rpkFlags }}
 {{- range $key, $value := .Values.config.cluster }}
   {{- if $value }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -69,7 +69,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
           - |
-            rpk cluster config import -f /tmp/base-config/bootstrap.yaml {{ $rpkFlags }}
+            rpk cluster config import -f /etc/redpanda/bootstrap.yaml {{ $rpkFlags }}
 {{- range $key, $value := .Values.config.cluster }}
   {{- if $value }}
             rpk cluster config set {{ $key }} {{ $value }} {{ $rpkFlags }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -1405,6 +1405,41 @@
         },
         "rpk": {
           "type": "object"
+        },
+        "schema_registry_client": {
+          "type": "object",
+          "properties": {
+            "retries": {
+              "type": "integer"
+            },
+            "retry_base_backoff_ms": {
+              "type": "integer"
+            },
+            "produce_batch_record_count": {
+              "type": "integer"
+            },
+            "produce_batch_size_bytes": {
+              "type": "integer"
+            },
+            "produce_batch_delay_ms": {
+              "type": "integer"
+            },
+            "consumer_request_timeout_ms": {
+              "type": "integer"
+            },
+            "consumer_request_max_bytes": {
+              "type": "integer"
+            },
+            "consumer_session_timeout_ms": {
+              "type": "integer"
+            },
+            "consumer_rebalance_timeout_ms": {
+              "type": "integer"
+            },
+            "consumer_heartbeat_interval_ms": {
+              "type": "integer"
+            }
+          }
         }
       }
     }

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -1440,6 +1440,41 @@
               "type": "integer"
             }
           }
+        },
+        "pandaproxy_client": {
+          "type": "object",
+          "properties": {
+            "retries": {
+              "type": "integer"
+            },
+            "retry_base_backoff_ms": {
+              "type": "integer"
+            },
+            "produce_batch_record_count": {
+              "type": "integer"
+            },
+            "produce_batch_size_bytes": {
+              "type": "integer"
+            },
+            "produce_batch_delay_ms": {
+              "type": "integer"
+            },
+            "consumer_request_timeout_ms": {
+              "type": "integer"
+            },
+            "consumer_request_max_bytes": {
+              "type": "integer"
+            },
+            "consumer_session_timeout_ms": {
+              "type": "integer"
+            },
+            "consumer_rebalance_timeout_ms": {
+              "type": "integer"
+            },
+            "consumer_heartbeat_interval_ms": {
+              "type": "integer"
+            }
+          }
         }
       }
     }

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -1039,6 +1039,48 @@ config:
     #  # Default: 500ms
     # consumer_heartbeat_interval_ms: 500
 
+  # Reference panda proxy client https://docs.redpanda.com/current/reference/node-configuration-sample/
+  pandaproxy_client: {}
+    #  # Number of times to retry a request to a broker
+    #  # Default: 5
+    # retries: 5
+    #
+    #  # Delay (in milliseconds) for initial retry backoff
+    #  # Default: 100ms
+    # retry_base_backoff_ms: 100
+    #
+    #  # Number of records to batch before sending to broker
+    #  # Default: 1000
+    # produce_batch_record_count: 1000
+    #
+    #  # Number of bytes to batch before sending to broker
+    #  # Defautl 1MiB
+    # produce_batch_size_bytes: 1048576
+    #
+    #  # Delay (in milliseconds) to wait before sending batch
+    #  # Default: 100ms
+    # produce_batch_delay_ms: 100
+    #
+    #  # Interval (in milliseconds) for consumer request timeout
+    #  # Default: 100ms
+    # consumer_request_timeout_ms: 100
+    #
+    #  # Max bytes to fetch per request
+    #  # Default: 1MiB
+    # consumer_request_max_bytes: 1048576
+    #
+    #  # Timeout (in milliseconds) for consumer session
+    #  # Default: 10s
+    # consumer_session_timeout_ms: 10000
+    #
+    #  # Timeout (in milliseconds) for consumer rebalance
+    #  # Default: 2s
+    # consumer_rebalance_timeout_ms: 2000
+    #
+    #  # Interval (in milliseconds) for consumer heartbeats
+    #  # Default: 500ms
+    # consumer_heartbeat_interval_ms: 500
+
   # Invalid properties
   # Any of these properties will be ignored. These otherwise valid properties are not allowed
   # to be used in this section since they impact deploying Redpanda in Kubernetes.

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -997,6 +997,48 @@ config:
     # dashboard_dir: None                                          # serve http dashboard on / url
     # developer_mode: optional                                     # Skips most of the checks performed at startup
 
+  # Reference schema registry client https://docs.redpanda.com/current/reference/node-configuration-sample/
+  schema_registry_client: {}
+    #  # Number of times to retry a request to a broker
+    #  # Default: 5
+    # retries: 5
+    #
+    #  # Delay (in milliseconds) for initial retry backoff
+    #  # Default: 100ms
+    # retry_base_backoff_ms: 100
+    #
+    #  # Number of records to batch before sending to broker
+    #  # Default: 1000
+    # produce_batch_record_count: 1000
+    #
+    #  # Number of bytes to batch before sending to broker
+    #  # Defautl 1MiB
+    # produce_batch_size_bytes: 1048576
+    #
+    #  # Delay (in milliseconds) to wait before sending batch
+    #  # Default: 100ms
+    # produce_batch_delay_ms: 100
+    #
+    #  # Interval (in milliseconds) for consumer request timeout
+    #  # Default: 100ms
+    # consumer_request_timeout_ms: 100
+    #
+    #  # Max bytes to fetch per request
+    #  # Default: 1MiB
+    # consumer_request_max_bytes: 1048576
+    #
+    #  # Timeout (in milliseconds) for consumer session
+    #  # Default: 10s
+    # consumer_session_timeout_ms: 10000
+    #
+    #  # Timeout (in milliseconds) for consumer rebalance
+    #  # Default: 2s
+    # consumer_rebalance_timeout_ms: 2000
+    #
+    #  # Interval (in milliseconds) for consumer heartbeats
+    #  # Default: 500ms
+    # consumer_heartbeat_interval_ms: 500
+
   # Invalid properties
   # Any of these properties will be ignored. These otherwise valid properties are not allowed
   # to be used in this section since they impact deploying Redpanda in Kubernetes.


### PR DESCRIPTION
Console shows the following error
```
{"level":"fatal","ts":"2023-09-27T15:55:53.821Z","msg":"failed to create kafka service","error":"failed to verify connectivity to schema registry: Get \"https://redpanda-0.redpanda.redpanda.svc.cluster.local.:8081/subjects\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)"}
```

That error comes form the missing Redpanda miss configuration.

Fixes https://github.com/redpanda-data/helm-charts/issues/752