### PR TITLE
feat: when rp chart has rbac.enabled, we need permissions to deploy. 

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.22
+version: 0.3.23
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -10,7 +10,7 @@ version: 0.3.22
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v23.2.7
+appVersion: v23.2.11
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,9 +34,9 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.5
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.11
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.2.5
+      image: docker.redpanda.com/redpandadata/redpanda:v23.2.11
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
   artifacthub.io/crds: |

--- a/charts/operator/templates/clusterrole.yaml
+++ b/charts/operator/templates/clusterrole.yaml
@@ -9,7 +9,8 @@ the Business Source License, use of this software will be governed
 by the Apache License, Version 2.0
 */}}
 
-{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) -}}
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -285,13 +286,60 @@ rules:
     - get
     - patch
     - update
-{{- end -}}
-{{- if and .Values.rbac.create (and ( eq .Values.scope "Namespace" ) .Values.rbac.createAdditionalControllerCRs ) -}}
+{{- end }}
+{{- if and .Values.rbac.create ( and ( eq .Values.scope "Namespace" ) .Values.rbac.createRPKBundleCRs ) }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "redpanda-operator.fullname" . }}
+  name: {{ include "redpanda-operator.fullname" . }}-rpk-bundle
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+rules:
+- apiGroups:
+    - rbac.authorization.k8s.io
+  resources:
+    - clusterrolebindings
+    - clusterroles
+  verbs:
+    - create
+    - get
+    - delete
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - configmaps
+    - endpoints
+    - events
+    - limitranges
+    - persistentvolumeclaims
+    - pods
+    - pods/log
+    - replicationcontrollers
+    - resourcequotas
+    - serviceaccounts
+    - services
+  verbs:
+    - get
+    - list
+- apiGroups:
+    - apiextensions.k8s.io
+  resources:
+    - customresourcedefinitions
+  verbs:
+    - get
+    - list
+{{- end }}
+{{- if and .Values.rbac.create ( and ( eq .Values.scope "Namespace" ) .Values.rbac.createAdditionalControllerCRs ) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-additional-controllers
   labels:
 {{ include "redpanda-operator.labels" . | indent 4 }}
 rules:
@@ -313,4 +361,4 @@ rules:
     - patch
     - update
     - watch
-{{- end -}}
+{{- end }}

--- a/charts/operator/templates/clusterrole_binding.yaml
+++ b/charts/operator/templates/clusterrole_binding.yaml
@@ -9,7 +9,8 @@ the Business Source License, use of this software will be governed
 by the Apache License, Version 2.0
 */}}
 
-{{- if .Values.rbac.create -}}
+{{- if and .Values.rbac.create ( eq .Values.scope "Cluster" ) }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
@@ -24,4 +25,38 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "redpanda-operator.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}
+{{- if and .Values.rbac.create ( and ( eq .Values.scope "Namespace" ) .Values.rbac.createAdditionalControllerCRs ) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-additional-controllers
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redpanda-operator.fullname" . }}-additional-controllers
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "redpanda-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- if and .Values.rbac.create ( and ( eq .Values.scope "Namespace" ) .Values.rbac.createRPKBundleCRs ) }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "redpanda-operator.fullname" . }}-rpk-bundle
+  labels:
+{{ include "redpanda-operator.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "redpanda-operator.fullname" . }}-rpk-bundle
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "redpanda-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -52,9 +52,12 @@ logLevel: "info"
 rbac:
   # rbac.create -- Specifies whether the RBAC resources should be created
   create: true
-  # rbac.create -- Specified whether to create additional rbac cluster roles
+  # rbac.createAdditionalControllerCRs -- Enable to create additional rbac cluster roles
   # needed to run additional-controllers, set to true to opt-in
   createAdditionalControllerCRs: false
+  # rbac.createRPKBundleCRs -- Specified to create additional rbac cluster roles
+  # needed when you will set 'rbac.enabled' to the Redpanda Spec (See redpanda chart values file)
+  createRPKBundleCRs: false
 
 webhook:
   # webhook.create -- Specifies whether the Webhook resources should configured


### PR DESCRIPTION
fixes https://github.com/redpanda-data/redpanda/issues/13825 

Cluster roles needed to allow for operator to deploy redpanda when rbac.enabled is set to Redpanda chart. 