### PR TITLE
fix: config parsing

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.0
+version: 5.6.1
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.1
+version: 5.6.2
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -130,7 +130,7 @@ redpanda.yaml: |
 {{- end }}
 {{- with dig "node" dict .Values.config }}
   {{- range $key, $element := .}}
-    {{- if and (or (eq (typeOf $element) "bool") $element) (and (eq $key "crash_loop_limit") (include "redpanda-atleast-23-1-1" $root | fromJson).bool) }}
+    {{- if and (or (eq (typeOf $element) "bool") $element) (or (and (eq $key "crash_loop_limit") (include "redpanda-atleast-23-1-1" $root | fromJson).bool) (ne $key "crash_loop_limit")) }}
     {{ $key }}: {{ $element | toYaml }}
     {{- end }}
   {{- end }}
@@ -487,7 +487,9 @@ rpk:
   additional_start_flags:
     - "--smp={{ include "redpanda-smp" . }}"
     - "--memory={{ template "redpanda-memory" . }}M"
+    {{- if not .Values.config.node.developer_mode }}
     - "--reserve-memory={{ template "redpanda-reserve-memory" . }}M"
+    {{- end }}
     - "--default-log-level={{ .Values.logging.logLevel }}"
   {{- with .Values.statefulset.additionalRedpandaCmdFlags -}}
   {{- toYaml . | nindent 4 }}

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -130,8 +130,15 @@ redpanda.yaml: |
 {{- end }}
 {{- with dig "node" dict .Values.config }}
   {{- range $key, $element := .}}
-    {{- if and (or (eq (typeOf $element) "bool") $element) (or (and (eq $key "crash_loop_limit") (include "redpanda-atleast-23-1-1" $root | fromJson).bool) (ne $key "crash_loop_limit")) }}
-    {{ $key }}: {{ $element | toYaml }}
+    {{- $line := dict $key (toYaml $element) }}
+    {{- if and (eq $key "crash_loop_limit") (not (include "redpanda-atleast-23-1-1" $root | fromJson).bool) }}
+      {{- $line = dict }}
+    {{- end }}
+    {{- if not (or (eq (typeOf $element) "bool") $element) }}
+      {{- $line = dict }}
+    {{- end }}
+    {{- with $line }}
+      {{  toYaml . | nindent 4 }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -328,8 +328,10 @@ Use AppVersion if image.tag is not set
   {{- if lt $result 256 -}}
     {{- printf "\n%d is below the minimum value for Redpanda" $result | fail -}}
   {{- end -}}
+  {{- if not .Values.config.node.developer_mode }}
   {{- if gt (add $result (include "redpanda-reserve-memory" .)) (include "container-memory" . | int64) -}}
     {{- printf "\nNot enough container memory for Redpanda memory values\nredpanda: %d, reserve: %d, container: %d" $result (include "redpanda-reserve-memory" . | int64) (include "container-memory" . | int64) | fail -}}
+  {{- end -}}
   {{- end -}}
   {{- $result -}}
 {{- end -}}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -71,7 +71,7 @@ spec:
             set -e
             rpk cluster config import -f /etc/redpanda/bootstrap.yaml
 {{- range $key, $value := .Values.config.cluster }}
-  {{- if $value }}
+  {{- if or (typeIs "bool" $value ) $value }}
             rpk cluster config set {{ $key }} {{ $value }}
   {{- end }}
 {{- end }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -995,7 +995,7 @@ config:
     # api_doc_dir: /usr/share/redpanda/proxy-api-doc               # API doc directory
     # coproc_supervisor_server: 127.0.0.1:43189                    # IpAddress and port for supervisor service
     # dashboard_dir: None                                          # serve http dashboard on / url
-    # developer_mode: optional                                     # Skips most of the checks performed at startup
+    # developer_mode: true                                         # Skips most of the checks performed at startup
 
   # Reference schema registry client https://docs.redpanda.com/current/reference/node-configuration-sample/
   schema_registry_client: {}


### PR DESCRIPTION
fixes a bug introduced at 11b82c515c704da1600abb5f589e2fbc3af92fcb that prevented the configuration set in values.yaml from being parsed. Any other key but `crash_loop_limit` would be removed from the output.

verify and check if other values are still added correctly:

```
$ helm upgrade --install --namespace infra --create-namespace --set config.node.developer_mode=true --set config.node.crash_loop_limit=3 --dry-run --debug redpanda charts/redpanda | grep -C1 developer_mode

history.go:56: [debug] getting history for release redpanda
install.go:193: [debug] Original chart version: ""
install.go:210: [debug] CHART PATH: /Users/aram/projects/redpanda-helm-charts/charts/redpanda

    crash_loop_limit: 3
    developer_mode: true

--
    crash_loop_limit: 3
    developer_mode: true
  pandaproxy_client: {}
--
      crash_loop_limit: 3
      developer_mode: true
```

closes #770