### PR TITLE
charts/secrets.yaml: handle missing EOL in USER_FILE

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.5
+version: 5.6.6
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -200,7 +200,8 @@ stringData:
         USERS_FILE=$(find ${USERS_DIR}/* -print)
         USERS_LIST=""
         READ_LIST_SUCCESS=0
-        while read p; do
+        # Read line by line, handle a missing EOL at the end of file
+        while read p || [ -n $p ] ; do
           IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
           # Do not process empty lines
           if [ -z "$USER_NAME" ]; then


### PR DESCRIPTION
bash's construct `while read p; do ...; done < $USER_FILE` expects that each line in USER_FILE is terminated by a EOL.
This commit handles an unterminated line by checking if the buffer `p` is not empty. 

Fixes https://github.com/redpanda-data/redpanda/issues/13880