### PR TITLE
charts/values.yaml: rename delete_retention_ms->log_retention_ms

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.6
+version: 5.6.7
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -926,7 +926,7 @@ config:
     # create_topic_timeout_ms: 2000ms                              # Timeout (ms) to wait for new topic creation
     # default_num_windows: 10                                      # Default number of quota tracking windows
     # default_window_sec: 1000ms                                   # Default quota tracking window size in milliseconds
-    # delete_retention_ms: 10080min                                # delete segments older than this (default 1 week)
+    # log_retention_ms: 10080min                                   # delete segments older than this (default 1 week)
     # disable_batch_cache: false                                   # Disable batch cache in log manager
     # fetch_reads_debounce_timeout: 1ms                            # Time to wait for next read in fetch request when requested min bytes wasn't reached
     # fetch_session_eviction_timeout_ms: 60s                       # Minimum time before which unused session will get evicted from sessions; Maximum time after which inactive session will be deleted is two time given configuration valuecache


### PR DESCRIPTION
redpanda v23.3 deprecates delete_retention_ms for log_retention_ms (this is just a rename, since the semantic of delete_retention_ms was already aligned to kafka's log.retention.ms)

This commit is just a cleanup for a commented-out value

see https://github.com/redpanda-data/redpanda/pull/13257