### PR TITLE
Provide duration for CA certificate

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.4
+version: 5.6.5
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/cert-issuers.yaml
+++ b/charts/redpanda/templates/cert-issuers.yaml
@@ -21,6 +21,7 @@ limitations under the License.
   {{- range $name, $data := $values.tls.certs }}
     {{/* If secretRef is defined, do not create any of these certificates. */}}
     {{- if not (hasKey $data "secretRef") }}
+      {{- $d := $data.duration }}
 
 ---
 {{/* If issuerRef is defined, use the specified issuer for the certs
@@ -65,6 +66,7 @@ metadata:
   {{- . | nindent 4 }}
 {{- end }}
 spec:
+  duration: {{ $d | default "43800h" }}
   isCA: true
   commonName: {{ template "redpanda.fullname" $ }}-{{ $name }}-root-certificate
   secretName: {{ template "redpanda.fullname" $ }}-{{ $name }}-root-certificate


### PR DESCRIPTION
The value is present in config but was ignored, resulting in the root CA certificates having a default duration of 90 days, which is not ideal in most situations.