### PR TITLE
Size can be expressed by integer or string

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.0
+version: 5.6.1
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -416,7 +416,7 @@
                   "type": "string"
                 },
                 "cloud_storage_cache_size": {
-                  "type": "integer"
+                  "type": ["integer", "string"]
                 },
                 "cloud_storage_cache_directory": {
                   "type": "string"


### PR DESCRIPTION
When tiered storage is defined as `200Gi` then schema is violated and helm release fails. 