### PR TITLE
Tiered storage configuration bytes calculations

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -57,6 +57,7 @@ jobs:
           - '1[0-2]*'
           - '1[3-5]*'
           - '1[6-7]*'
+          - '9[7-9]*' # some tests depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
@@ -107,6 +108,26 @@ jobs:
           mv external-tls-secret.yaml charts/redpanda/templates/
           cp .github/external-service.yaml charts/redpanda/templates/
           mv some-users-updated.yaml charts/redpanda/templates
+
+      - name: Create redpanda license secret
+        if: steps.list-changed.outputs.changed == 'true'
+        env:
+          REDPANDA_LICENSE: ${{ secrets.REDPANDA_LICENSE }}
+        run: |
+          if [ -z $REDPANDA_LICENSE ]; then echo "License is empty" ; exit 1; fi
+          kubectl create secret generic redpanda-license \
+          --from-literal=license-key="$REDPANDA_LICENSE" \
+          --dry-run=client -o yaml > redpanda-license.yaml.tmp
+
+          kubectl annotate -f redpanda-license.yaml.tmp \
+          helm.sh/hook-delete-policy="before-hook-creation" \
+          helm.sh/hook="pre-install" \
+          helm.sh/hook-weight="-100" \
+          --local --dry-run=none -o yaml > redpanda-license.yaml
+
+          rm redpanda-license.yaml.tmp
+
+          mv redpanda-license.yaml ./charts/redpanda/templates/
 
     #===== Required Test Files === end
 

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -97,6 +97,8 @@ jobs:
         env:
           REDPANDA_LICENSE: ${{ secrets.REDPANDA_LICENSE }}
         run: |
+          if [ -z $REDPANDA_LICENSE ]; then echo "License is empty" ; exit 1; fi
+          
           envsubst < ./charts/redpanda/ci/97-license-key-values.yaml.tpl > ./charts/redpanda/ci/97-license-key-values.yaml 
 
           kubectl create secret generic redpanda-license \

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.9
+version: 5.6.10
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/99-none-existent-config-options-with-empty-values.yaml
+++ b/charts/redpanda/ci/99-none-existent-config-options-with-empty-values.yaml
@@ -19,17 +19,19 @@ enterprise:
     key: license-key
 
 storage:
-  tieredConfig:
-    cloud_storage_enabled: true
-    cloud_storage_secret_key: test
-    cloud_storage_access_key: test
-    cloud_storage_region: test
-    cloud_storage_bucket: test
-    storage_zero_value: 0
-    storage_null_value: null
-    storage_empty_array_value: []
-    storage_empty_map_value: {}
-    storage_empty_string_value: ""
+  tiered:
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_cache_size: 11G
+      cloud_storage_secret_key: test
+      cloud_storage_access_key: test
+      cloud_storage_region: test
+      cloud_storage_bucket: test
+      storage_zero_value: 0
+      storage_null_value: null
+      storage_empty_array_value: []
+      storage_empty_map_value: {}
+      storage_empty_string_value: ""
 
 config:
   cluster:

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -87,7 +87,11 @@ bootstrap.yaml: |
   {{- end }}
   {{- range $key, $element := $tieredStorageConfig}}
     {{- if or (eq (typeOf $element) "bool") $element }}
-      {{- dict $key $element | toYaml | nindent 2 }}
+      {{- if eq $key "cloud_storage_cache_size" }}
+        {{- dict $key (include "SI-to-bytes" $element) | toYaml | nindent 2 -}}
+      {{- else }}
+        {{- dict $key $element | toYaml | nindent 2 -}}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
@@ -289,7 +293,11 @@ redpanda.yaml: |
   {{- end }}
   {{- range $key, $element := $tieredStorageConfig }}
     {{- if or (eq (typeOf $element) "bool") $element }}
-      {{- dict $key $element | toYaml | nindent 2 -}}
+      {{- if eq $key "cloud_storage_cache_size" }}
+        {{- dict $key (include "SI-to-bytes" $element) | toYaml | nindent 2 -}}
+      {{- else }}
+        {{- dict $key $element | toYaml | nindent 2 -}}
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
Redpanda doesn't allow `cloud_storage_secret_key` to be defined as string.

Output from the `post-upgrade` job:
```
PROPERTY                            PRIOR                NEW
cloud_storage_cache_size  11000000000  11G
cloud_storage_secret_key  [secret]             [redacted]

Validation errors:
 * cloud_storage_cache_size: expected type integer
```