### PR TITLE
Change schema registry tests

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.7
+version: 5.6.8
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -720,3 +720,7 @@ RPK_USER RPK_PASS RPK_SASL_MECHANISM
 REDPANDA_SASL_USERNAME REDPANDA_SASL_PASSWORD REDPANDA_SASL_MECHANISM
 {{- end -}}
 {{- end -}}
+
+{{- define "curl-options" -}}
+{{- print " -svm3 --fail --retry \"120\" --retry-max-time \"120\" --retry-all-errors -o - -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
+{{- end -}}

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -138,7 +138,7 @@ spec:
           URL=http://{{ include "console.fullname" $consoleValues }}:{{ include "console.containerPort" $consoleValues }}/api/kafka-connect/clusters/connectors/connectors
           {{/* outputting to /dev/null because the output contains the user password */}}
           echo "Creating mm2 connector"
-          if curl -svm3 --fail --retry 120 --retry-max-time 120 --retry-all-errors -H 'Content-Type: application/json' -o /dev/null "${URL}" -d @/tmp/mm2-conf.json
+          if curl {{ template "curl-options" . }} -H 'Content-Type: application/json' "${URL}" -d @/tmp/mm2-conf.json
           then
             echo "Result successful"
           else
@@ -149,7 +149,7 @@ spec:
           rpk topic consume source.{{ $testTopic }} -n 1
 
           echo "Destroying mm2 connector"
-          if curl -svm3 --fail --retry 120 --retry-max-time 120 --retry-all-errors -o /dev/null -X DELETE "${URL}/${CONNECTOR_NAME}"
+          if curl {{ template "curl-options" . }} -X DELETE "${URL}/${CONNECTOR_NAME}"
           then
             echo "Result successful"
           else

--- a/charts/redpanda/templates/tests/test-console.yaml
+++ b/charts/redpanda/templates/tests/test-console.yaml
@@ -42,7 +42,7 @@ spec:
       - bash
       - -c
       - |
-        curl -svm3 --fail --retry 120 --retry-max-time 120 --retry-all-errors http://{{ include "redpanda.fullname" . }}-console.{{ .Release.Namespace }}.svc:{{ include "console.containerPort" (dict "Values" .Values.console) }}/api/cluster
+        curl {{ template "curl-options" . }} http://{{ include "redpanda.fullname" . }}-console.{{ .Release.Namespace }}.svc:{{ include "console.containerPort" (dict "Values" .Values.console) }}/api/cluster
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       securityContext: {{ include "container-security-context" . | nindent 8 }}
   volumes: {{ include "default-volumes" . | nindent 4 }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -55,13 +55,13 @@ spec:
           if [[ -n "$old_setting" ]]; then set -x; fi
   {{- end }}
 
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          curl {{ template "curl-options" . }} \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
           -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
           http://{{ include "redpanda.servicename" . }}:{{ .Values.listeners.http.port }}/brokers
 
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          curl {{ template "curl-options" . }} \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.http.authenticationMethod }}
           -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}

--- a/charts/redpanda/templates/tests/test-prometheus-targets.yaml
+++ b/charts/redpanda/templates/tests/test-prometheus-targets.yaml
@@ -42,7 +42,7 @@ spec:
         - |
           set -xe
           
-          HEALTHY=$( curl -s --fail --retry "120" --retry-max-time "120" --retry-all-errors --retry-delay 2 -o /dev/null -w "%{http_code}" http://prometheus-operated.prometheus.svc.cluster.local:9090/-/healthy)          
+          HEALTHY=$( curl {{ template "curl-options" . }} http://prometheus-operated.prometheus.svc.cluster.local:9090/-/healthy)
           if [ $HEALTHY != 200 ]; then
             echo "prometheus is not healthy, exiting"
             exit 1
@@ -50,7 +50,7 @@ spec:
           
           echo "prometheus is healthy, checking if ready..."
 
-          READY=$( curl -s --fail --retry "120" --retry-max-time "120" --retry-all-errors --retry-delay 2 -o /dev/null -w "%{http_code}" http://prometheus-operated.prometheus.svc.cluster.local:9090/-/ready)          
+          READY=$( curl {{ template "curl-options" . }} http://prometheus-operated.prometheus.svc.cluster.local:9090/-/ready)
           if [ $READY != 200 ]; then
             echo "prometheus is not ready, exiting"
             exit 1
@@ -63,7 +63,7 @@ spec:
 
             # Run the command, and save the exit code
             # from: https://prometheus.io/docs/prometheus/latest/querying/api/
-            local RESULT=$( curl -s --fail --retry "120" --retry-max-time "120" --retry-all-errors http://prometheus-operated.prometheus.svc.cluster.local:9090/api/v1/targets?scrapePool=serviceMonitor/{{ .Release.Namespace }}/{{ include "redpanda.fullname" . }}/0 | jq '.data.activeTargets[].health | select(. == "up")' | wc -l  )
+            local RESULT=$( curl {{ template "curl-options" . }} http://prometheus-operated.prometheus.svc.cluster.local:9090/api/v1/targets?scrapePool=serviceMonitor/{{ .Release.Namespace }}/{{ include "redpanda.fullname" . }}/0 | jq '.data.activeTargets[].health | select(. == "up")' | wc -l  )
 
             echo $RESULT
           }

--- a/charts/redpanda/templates/tests/test-rack-awareness.yaml
+++ b/charts/redpanda/templates/tests/test-rack-awareness.yaml
@@ -40,8 +40,7 @@ spec:
       - |
         set -e
 {{- if and .Values.rackAwareness.enabled (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
-        curl --silent --fail --retry 120 \
-          --retry-max-time 120 --retry-all-errors \
+        curl {{ template "curl-options" . }} \
   {{- if (include "tls-enabled" . | fromJson).bool }}
     {{- if (dig "default" "caEnabled" false .Values.tls.certs) }}
           --cacert "/etc/tls/certs/default/ca.crt" \

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -22,7 +22,7 @@ limitations under the License.
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "redpanda.fullname" . }}-test-schemaregistry-internal-tls-status
+  name: {{ include "redpanda.fullname" . }}-test-sr-internal-tls-status-{{ randNumeric 3 }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- with include "full.labels" . }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -60,6 +60,43 @@ spec:
 
           set -ex
 
+          trap reportSchema ERR
+
+          reportSchema () {
+            echo Retrieving schemas/types
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/types
+            echo Retrieving schemas/ids/1
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
+            echo Retrieving subjects
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+            echo Retrieving subjects?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects?deleted=true
+            echo Retrieving subjects/sensor-value/versions
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+            echo Retrieving subjects/sensor-value/versions?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions?deleted=true
+            echo Retrieving subjects/sensor-value/versions/latest
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest
+            echo Retrieving subjects/sensor-value/versions/latest?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest?deleted=true
+            echo Retrieving subjects/sensor-value/versions/latest/schema
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema
+            echo Retrieving subjects/sensor-value/versions/latest/schema?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema?deleted=true
+            echo
+          }
+
+          schemaCurlIgnore () {
+            curl -vm3 -w "\n" --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u "${RPK_USER}:${RPK_PASS}" \
+              {{- end }}
+              {{- if $cert.caEnabled }}
+              --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+              {{- end }}
+              $* || true
+          }
+
           schemaCurl () {
             curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -19,10 +19,11 @@ limitations under the License.
   {{- $cert := get .Values.tls.certs $service.tls.cert -}}
   {{- $root := deepCopy . }}
   {{- $sasl := .Values.auth.sasl }}
+  {{- $randNumber := randNumeric 3 }}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "redpanda.fullname" . }}-test-sr-internal-tls-status-{{ randNumeric 3 }}
+  name: {{ include "redpanda.fullname" . }}-test-sr-internal-tls-status-{{ $randNumber }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- with include "full.labels" . }}
@@ -71,18 +72,18 @@ spec:
             schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
             echo Retrieving subjects?deleted=true
             schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects?deleted=true
-            echo Retrieving subjects/sensor-value/versions
-            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
-            echo Retrieving subjects/sensor-value/versions?deleted=true
-            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions?deleted=true
-            echo Retrieving subjects/sensor-value/versions/latest
-            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest
-            echo Retrieving subjects/sensor-value/versions/latest?deleted=true
-            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest?deleted=true
-            echo Retrieving subjects/sensor-value/versions/latest/schema
-            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema
-            echo Retrieving subjects/sensor-value/versions/latest/schema?deleted=true
-            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema?deleted=true
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions?deleted=true
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest?deleted=true
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest/schema
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest/schema
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest/schema?deleted=true
+            schemaCurlIgnore https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest/schema?deleted=true
             echo
           }
 
@@ -122,7 +123,7 @@ spec:
             {{- if $cert.caEnabled }}
               --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
             {{- end }}
-            https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+            https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions
 
           echo "Get schema 1"
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
@@ -138,7 +139,7 @@ spec:
             {{- if $cert.caEnabled }}
               --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
             {{- end }}
-              https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+              https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/1
 
           echo "Delete schema 1 permanently"
           curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
@@ -148,7 +149,7 @@ spec:
             {{- if $cert.caEnabled }}
               --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
             {{- end }}
-              https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+              https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/1?permanent=true
 
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources: {{ toYaml .Values.statefulset.resources | nindent 12 }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -58,7 +58,7 @@ spec:
           if [[ -n "$old_setting" ]]; then set -x; fi
   {{- end }}
 
-          set -ex
+          set -e
 
           trap reportSchema ERR
 

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -87,9 +87,9 @@ spec:
             echo
           }
 
-{{- $curlOptions := " -svm3 -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
+
           schemaCurlIgnore () {
-            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            curl {{ template "curl-options" . }} \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u "${RPK_USER}:${RPK_PASS}" \
               {{- end }}
@@ -100,7 +100,7 @@ spec:
           }
 
           schemaCurl () {
-            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            curl {{ template "curl-options" . }} \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u "${RPK_USER}:${RPK_PASS}" \
               {{- end }}
@@ -114,7 +114,7 @@ spec:
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
           echo "Create schema"
-          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+          curl {{ template "curl-options" . }} \
             -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
             -d '{"schema": "{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
@@ -132,7 +132,7 @@ spec:
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
           echo "Delete schema 1"
-          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
+          curl {{ template "curl-options" . }} -X DELETE \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}
@@ -142,7 +142,7 @@ spec:
               https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/1
 
           echo "Delete schema 1 permanently"
-          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
+          curl {{ template "curl-options" . }} -X DELETE \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -86,8 +86,9 @@ spec:
             echo
           }
 
+{{- $curlOptions := " -svm3 -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
           schemaCurlIgnore () {
-            curl -vm3 -w "\n" --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u "${RPK_USER}:${RPK_PASS}" \
               {{- end }}
@@ -98,7 +99,7 @@ spec:
           }
 
           schemaCurl () {
-            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u "${RPK_USER}:${RPK_PASS}" \
               {{- end }}
@@ -112,7 +113,7 @@ spec:
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
           echo "Create schema"
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
             -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
             -d '{"schema": "{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
@@ -130,7 +131,7 @@ spec:
           schemaCurl https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
           echo "Delete schema 1"
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
+          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}
@@ -140,7 +141,7 @@ spec:
               https://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
 
           echo "Delete schema 1 permanently"
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
+          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -X DELETE -o - \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -16,10 +16,11 @@ limitations under the License.
 */}}
 {{- if and (not (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool) .Values.listeners.schemaRegistry.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool }}
   {{- $sasl := .Values.auth.sasl }}
+  {{- $randNumber := randNumeric 3 }}
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "redpanda.fullname" . }}-test-sr-status-{{ randNumeric 3 }}
+  name: {{ include "redpanda.fullname" . }}-test-sr-status-{{ $randNumber }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- with include "full.labels" . }}
@@ -68,18 +69,18 @@ spec:
             schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
             echo Retrieving subjects?deleted=true
             schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects?deleted=true
-            echo Retrieving subjects/sensor-value/versions
-            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
-            echo Retrieving subjects/sensor-value/versions?deleted=true
-            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions?deleted=true
-            echo Retrieving subjects/sensor-value/versions/latest
-            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest
-            echo Retrieving subjects/sensor-value/versions/latest?deleted=true
-            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest?deleted=true
-            echo Retrieving subjects/sensor-value/versions/latest/schema
-            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema
-            echo Retrieving subjects/sensor-value/versions/latest/schema?deleted=true
-            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema?deleted=true
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions?deleted=true
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest?deleted=true
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest/schema
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest/schema
+            echo Retrieving subjects/sensor-{{ $randNumber }}-value/versions/latest/schema?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/latest/schema?deleted=true
             echo
           }
 
@@ -112,7 +113,7 @@ spec:
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
           -u ${RPK_USER}:${RPK_PASS} \
           {{- end }}
-          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+          http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions
 
           echo "Get schema 1"
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
@@ -129,7 +130,7 @@ spec:
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}
-              http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1
+              http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/1
             result=$?
             if [[ $result -eq 0 ]]
             then
@@ -153,7 +154,7 @@ spec:
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}
-              http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/1?permanent=true
+              http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-{{ $randNumber }}-value/versions/1?permanent=true
             result=$?
             if [[ $result -eq 0 ]]
             then

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -19,7 +19,7 @@ limitations under the License.
 apiVersion: v1
 kind: Pod
 metadata:
-  name: "{{ include "redpanda.fullname" . }}-test-schemaregistry-status"
+  name: {{ include "redpanda.fullname" . }}-test-sr-status-{{ randNumeric 3 }}
   namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- with include "full.labels" . }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -83,8 +83,9 @@ spec:
             echo
           }
 
+{{- $curlOptions := " -svm3 -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
           schemaCurlIgnore () {
-            curl -vm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u "${RPK_USER}:${RPK_PASS}" \
               {{- end }}
@@ -92,7 +93,7 @@ spec:
           }
 
           schemaCurl () {
-            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
             -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}
@@ -101,7 +102,7 @@ spec:
 
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/types
 
-          curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors \
           -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
           -d '{"schema":"{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
@@ -117,7 +118,7 @@ spec:
 
           for i in $(seq 1 $max_iteration)
           do
-            curl -vv -X DELETE \
+            curl -vv -w "\n" -X DELETE \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}
@@ -140,7 +141,7 @@ spec:
 
           for i in $(seq 1 $max_iteration)
           do
-            curl -vv -X DELETE \
+            curl -vv -w "\n" -X DELETE \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -84,9 +84,8 @@ spec:
             echo
           }
 
-{{- $curlOptions := " -svm3 -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
           schemaCurlIgnore () {
-            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+            curl {{ template "curl-options" . }} \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u "${RPK_USER}:${RPK_PASS}" \
               {{- end }}
@@ -94,7 +93,7 @@ spec:
           }
 
           schemaCurl () {
-            curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+            curl {{ template "curl-options" . }} \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
             -u ${RPK_USER}:${RPK_PASS} \
             {{- end }}
@@ -107,7 +106,7 @@ spec:
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
           echo "Create schema"
-          curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors \
+          curl {{ template "curl-options" . }} \
           -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
           -d '{"schema":"{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
           {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
@@ -126,7 +125,7 @@ spec:
           echo "Delete schema 1"
           for i in $(seq 1 $max_iteration)
           do
-            curl -vv -w "\n" -X DELETE \
+            curl {{ template "curl-options" . }} -X DELETE \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}
@@ -150,7 +149,7 @@ spec:
           echo "Delete schema 1 permanently"
           for i in $(seq 1 $max_iteration)
           do
-            curl -vv -w "\n" -X DELETE \
+            curl {{ template "curl-options" . }} -X DELETE \
               {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
               -u ${RPK_USER}:${RPK_PASS} \
               {{- end }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -55,6 +55,42 @@ spec:
           if [[ -n "$old_setting" ]]; then set -x; fi
   {{- end }}
 
+          set -e
+
+          trap reportSchema ERR
+
+          reportSchema () {
+            echo Retrieving schemas/types
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/types
+            echo Retrieving schemas/ids/1
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
+            echo Retrieving subjects
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+            echo Retrieving subjects?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects?deleted=true
+            echo Retrieving subjects/sensor-value/versions
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
+            echo Retrieving subjects/sensor-value/versions?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions?deleted=true
+            echo Retrieving subjects/sensor-value/versions/latest
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest
+            echo Retrieving subjects/sensor-value/versions/latest?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest?deleted=true
+            echo Retrieving subjects/sensor-value/versions/latest/schema
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema
+            echo Retrieving subjects/sensor-value/versions/latest/schema?deleted=true
+            schemaCurlIgnore http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions/latest/schema?deleted=true
+            echo
+          }
+
+          schemaCurlIgnore () {
+            curl -vm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - \
+              {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}
+              -u "${RPK_USER}:${RPK_PASS}" \
+              {{- end }}
+              $* || true
+          }
+
           schemaCurl () {
             curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors \
             {{- if or (include "sasl-enabled" .|fromJson).bool .Values.listeners.schemaRegistry.authenticationMethod }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -102,6 +102,10 @@ spec:
 
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/types
 
+          echo "Get existng schemas"
+          schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
+
+          echo "Create schema"
           curl {{ $curlOptions }} --fail --retry "120" --retry-max-time "120" --retry-all-errors \
           -X POST -H 'Content-Type:application/vnd.schemaregistry.v1+json' \
           -d '{"schema":"{\"type\":\"record\",\"name\":\"sensor_sample\",\"fields\":[{\"name\":\"timestamp\",\"type\":\"long\",\"logicalType\":\"timestamp-millis\"},{\"name\":\"identifier\",\"type\":\"string\",\"logicalType\":\"uuid\"},{\"name\":\"value\",\"type\":\"long\"}]}"}' \
@@ -110,12 +114,15 @@ spec:
           {{- end }}
           http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects/sensor-value/versions
 
+          echo "Get schema 1"
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/schemas/ids/1
 
+          echo "Get existng schemas"
           schemaCurl http://{{ include "redpanda.internal.domain" . }}:{{ .Values.listeners.schemaRegistry.port }}/subjects
 
           max_iteration=10
 
+          echo "Delete schema 1"
           for i in $(seq 1 $max_iteration)
           do
             curl -vv -w "\n" -X DELETE \
@@ -139,6 +146,7 @@ spec:
             echo "All of the trials failed to delete schema!!!"
           fi
 
+          echo "Delete schema 1 permanently"
           for i in $(seq 1 $max_iteration)
           do
             curl -vv -w "\n" -X DELETE \


### PR DESCRIPTION
To better understand schema registry tests:

* do not `set -x` to not print credentials with schema registry test
* add trap function to report everything about schema registry
* add logs to better trace one of the schema registry test executions
* make curl display information on stdout after a completed transfer - https://curl.se/docs/manpage.html#-w
* Generate unique test to track `ct` execution
* Randomize schema registry subject name