### PR TITLE
Increase test timeout

### DIFF
--- a/.github/ct-redpanda.yaml
+++ b/.github/ct-redpanda.yaml
@@ -15,7 +15,7 @@
 debug: true
 remote: origin
 target-branch: main
-helm-extra-args: --timeout 300s
+helm-extra-args: --timeout 360s
 chart-repos:
   - redpanda=https://charts.redpanda.com
 charts:


### PR DESCRIPTION
Few times tests couldn't finish helm upgrade as it take more than 5 minutes sometimes.

REF:

https://github.com/redpanda-data/helm-charts/actions/runs/6500551496?pr=762
https://github.com/redpanda-data/helm-charts/actions/runs/6499127422?pr=762