### PR TITLE
Make connectors test failure more verbose

### DIFF
--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.1.5
+version: 0.1.6
 
 # The app version is the default version of Redpanda Connectors to install.
 appVersion: v1.0.2

--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 version: 0.1.6
 
 # The app version is the default version of Redpanda Connectors to install.
-appVersion: v1.0.2
+appVersion: v1.0.6
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
 # pre-release. Our "-0" allows pre-releases to be matched.
@@ -44,6 +44,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: connectors
-      image: docker.redpanda.com/redpandadata/connectors:v1.0.2
+      image: docker.redpanda.com/redpandadata/connectors:v1.0.6
     - name: rpk
       image: docker.redpanda.com/redpandadata/redpanda:latest

--- a/charts/connectors/templates/_helpers.tpl
+++ b/charts/connectors/templates/_helpers.tpl
@@ -107,3 +107,7 @@ Use AppVersion if image.tag is not set
 {{- end -}}
 {{- $tag -}}
 {{- end -}}
+
+{{- define "curl-options" -}}
+{{- print " -svm3 --fail --retry \"120\" --retry-max-time \"120\" --retry-all-errors -o - -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
+{{- end -}}

--- a/charts/connectors/templates/tests/01-mm2-values.yaml
+++ b/charts/connectors/templates/tests/01-mm2-values.yaml
@@ -39,7 +39,20 @@ spec:
         - /bin/bash
         - -c
         - |
-          set -x
+          set -xe
+
+          trap connectorsState ERR
+
+          connectorsState () {
+            echo check connectors expand status
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" . }}:{{ .Values.connectors.restPort }}/connectors?expand=status
+            echo check connectors expand info
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" . }}:{{ .Values.connectors.restPort }}/connectors?expand=info
+            echo check connector configuration
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" . }}:{{ .Values.connectors.restPort }}/connectors/$CONNECTOR_NAME
+            echo check connector topics
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" . }}:{{ .Values.connectors.restPort }}/connectors/$CONNECTOR_NAME/topics
+          }
 
           curl http://{{ include "connectors.serviceName" . }}:{{ .Values.connectors.restPort }}/connectors && echo
 
@@ -51,7 +64,6 @@ spec:
 
           SASL_MECHANISM="PLAIN"
           {{- if .Values.auth.sasl.enabled }}
-          set -e
           set +x
 
           IFS=: read -r CONNECT_SASL_USERNAME KAFKA_SASL_PASSWORD CONNECT_SASL_MECHANISM < $(find /mnt/users/* -print)
@@ -64,7 +76,6 @@ spec:
           fi
 
           set -x
-          set +e
           {{- end }}
 
           {{- if .Values.connectors.brokerTLS.enabled }}

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.14
+version: 5.6.15
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml
+++ b/charts/redpanda/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml
@@ -28,3 +28,5 @@ storage:
 
 connectors:
   enabled: true
+  logging:
+    level: debug

--- a/charts/redpanda/ci/03-one-node-cluster-tls-no-sasl-values.yaml
+++ b/charts/redpanda/ci/03-one-node-cluster-tls-no-sasl-values.yaml
@@ -26,3 +26,5 @@ storage:
 
 connectors:
   enabled: true
+  logging:
+    level: debug

--- a/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/04-one-node-cluster-no-tls-sasl-values.yaml
@@ -32,3 +32,5 @@ storage:
 
 connectors:
   enabled: true
+  logging:
+    level: debug

--- a/charts/redpanda/ci/05-one-node-cluster-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/05-one-node-cluster-tls-sasl-values.yaml
@@ -34,3 +34,5 @@ storage:
 
 connectors:
   enabled: true
+  logging:
+    level: debug


### PR DESCRIPTION
* Manage Connectors now will have debug log level during tests
* When mirror maker 2 test fails bash execution gather much more information about the state of the connectors
* Bump connector image tag/version