### PR TITLE
Create template prefix for advertised addresses

### DIFF
--- a/.github/ct-redpanda.yaml
+++ b/.github/ct-redpanda.yaml
@@ -15,7 +15,7 @@
 debug: true
 remote: origin
 target-branch: main
-helm-extra-args: --timeout 360s
+helm-extra-args: --timeout 480s
 chart-repos:
   - redpanda=https://charts.redpanda.com
 charts:

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.16
+version: 5.6.17
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -732,3 +732,11 @@ REDPANDA_SASL_USERNAME REDPANDA_SASL_PASSWORD REDPANDA_SASL_MECHANISM
 {{- define "curl-options" -}}
 {{- print " -svm3 --fail --retry \"120\" --retry-max-time \"120\" --retry-all-errors -o - -w \"\\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\\\"%{content_type}\\\"\\n\" "}}
 {{- end -}}
+
+{{- define "advertised-address-template" -}}
+  {{- $prefixTemplate := dig "prefixTemplate" "" .externalListener -}}
+  {{- if empty $prefixTemplate -}}
+    {{- $prefixTemplate = dig "prefixTemplate" "" .externalVals -}}
+  {{- end -}}
+  {{ quote $prefixTemplate }}
+{{- end -}}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -289,31 +289,6 @@ stringData:
     KUBERNETES_NODE_NAME=$2
     POD_ORDINAL=${SERVICE_NAME##*-}
     BROKER_INDEX=`expr $POD_ORDINAL + 1`
-{{- range $listenerName := (list "kafka" "http") }}
-{{- $listenerVals := get $values.listeners $listenerName }}
-  {{- $ordList := list }}
-  {{- /* do this for each pod in the statefulset */}}
-  {{- range $replicaIndex := until ($values.statefulset.replicas | int) }}
-    {{- /* build a list of listeners */}}
-    {{- $listenerList := list (toJson (dict "name" "internal" "address" $internalAdvertiseAddress "port" $listenerVals.port)) }}
-    {{- if $listenerVals.external }}
-      {{- /* add each external listener */}}
-      {{- range $externalName, $externalVals := $listenerVals.external }}
-        {{- $tmplVals := dict "listenerVals" $listenerVals "externalVals" $externalVals "externalName" $externalName "externalAdvertiseAddress" $externalAdvertiseAddress "values" $values "replicaIndex" $replicaIndex }}
-        {{- $port := int (include "advertised-port" $tmplVals) }}
-        {{- $host := tpl (include "advertised-host" (mustMerge $tmplVals (dict "port" $port)) ) $ }}
-        {{- $listenerList = mustAppend $listenerList $host }}
-      {{- end }}
-    {{- end }}
-    {{- /*
-    This is making a semicolon list of listeners, one list for each pod.
-    We can safely remove all the spaces as there cannot be a space in a name, address, or port, and this fixes
-    a problem where a user can feed in a trailing space on a hostname.
-    */}}
-    {{- $ordList = mustAppend $ordList (nospace (join ";" $listenerList)) }}
-  {{- end }}
-    ADVERTISED_{{ upper $listenerName }}_ADDRESSES={{ quote (join " " $ordList) }}
-{{- end }}
 
     CONFIG=/etc/redpanda/redpanda.yaml
     
@@ -329,29 +304,44 @@ stringData:
         rpk --config "${CONFIG}" redpanda config set redpanda.seed_servers '[]' --format yaml
     fi
     {{- end }}
-    
-    LISTENER_INDEX=1
-    # So the first cut is to give us the listeners for that NODE (deliminated by a ' ' space), 
-    # the second cut just starts us with the first listener since these are deliminated by ';'
-    LISTENER=`echo $ADVERTISED_KAFKA_ADDRESSES | cut -d ' ' -f $BROKER_INDEX | cut -d ';' -f $LISTENER_INDEX`
-    until [ "$LISTENER" == "" ]; do
-        rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[$(($LISTENER_INDEX-1))] "$LISTENER"
-        let "LISTENER_INDEX+=1"
-        LISTENER=`echo $ADVERTISED_KAFKA_ADDRESSES | cut -d ' ' -f $BROKER_INDEX | cut -d ';' -f $LISTENER_INDEX`
-    done
-    
-    LISTENER_INDEX=1
-    # So the first cut is to give us the listeners for that NODE (deliminated by a ' ' space),  
-    # the second cut just starts us with the first listener since these are deliminated by ';'
-    LISTENER=`echo $ADVERTISED_HTTP_ADDRESSES | cut -d ' ' -f $BROKER_INDEX | cut -d ';' -f $LISTENER_INDEX`
-    until [ "$LISTENER" == "" ]; do
-        rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[$(($LISTENER_INDEX-1))] "$LISTENER"
-        let "LISTENER_INDEX+=1"
-        LISTENER=`echo $ADVERTISED_HTTP_ADDRESSES | cut -d ' ' -f $BROKER_INDEX | cut -d ';' -f $LISTENER_INDEX`
-    done
-    
+
+{{- range $listenerName := (list "kafka" "http") }}
+  {{- $listenerAdvertisedName := $listenerName }}
+  {{- $redpandaConfigPart := "redpanda" }}
+  {{- if eq $listenerAdvertisedName "http" }}
+    {{- $listenerAdvertisedName = "pandaproxy" }}
+    {{- $redpandaConfigPart = "pandaproxy" }}
+  {{- end }}
+  {{- $listenerVals := get $values.listeners $listenerName }}
+
+    LISTENER={{ quote (toJson (dict "name" "internal" "address" $internalAdvertiseAddress "port" $listenerVals.port))}}
+    rpk redpanda config --config "$CONFIG" set {{ $redpandaConfigPart }}.advertised_{{ $listenerAdvertisedName }}_api[0] "$LISTENER"
+
+  {{- if $listenerVals.external }}
+  {{- $externalCounter := 1 }}
+    {{- range $externalName, $externalVals := $listenerVals.external }}
+
+    ADVERTISED_{{ upper $listenerName }}_ADDRESSES=()
+      {{- range $replicaIndex := until ($values.statefulset.replicas | int) }}
+
+        {{- $tmplVals := dict "listenerVals" $listenerVals "externalVals" $externalVals "externalName" $externalName "externalAdvertiseAddress" $externalAdvertiseAddress "values" $values "replicaIndex" $replicaIndex }}
+        {{- $port := int (include "advertised-port" $tmplVals) }}
+        {{- $host := tpl (include "advertised-host" (mustMerge $tmplVals (dict "port" $port)) ) $ }}
+
+    PREFIX_TEMPLATE={{ (include "advertised-address-template" (dict "externalVals" $values.external "externalListener" $externalVals)) }}
+    ADVERTISED_{{ upper $listenerName }}_ADDRESSES+=({{ quote ($host) }})
+      {{- end }}
+
+    rpk redpanda config --config "$CONFIG" set {{ $redpandaConfigPart }}.advertised_{{ $listenerAdvertisedName }}_api[{{ $externalCounter }}] "${ADVERTISED_{{ upper $listenerName }}_ADDRESSES[$POD_ORDINAL]}"
+
+      {{- $externalCounter = add $externalCounter 1 }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+
     {{- if (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
       {{- if .Values.rackAwareness.enabled }}
+
     # Configure Rack Awareness
     set +x
     RACK=$(curl --silent --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt --fail -H 'Authorization: Bearer '$(cat /run/secrets/kubernetes.io/serviceaccount/token) "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}/api/v1/nodes/${KUBERNETES_NODE_NAME}?pretty=true" | grep {{ .Values.rackAwareness.nodeAnnotation | quote | squote }} | grep -v '\"key\":' | sed 's/.*": "\([^"]\+\).*/\1/')

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -137,6 +137,11 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
           securityContext: {{ include "container-security-context" . | nindent 12 }}
           volumeMounts: {{ include "common-mounts" . | nindent 12 }}
 {{- if dig "initContainers" "configurator" "extraVolumeMounts" false .Values.statefulset -}}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -250,6 +250,9 @@
         "sourceRanges": {
           "type": "array"
         },
+        "prefixTemplate": {
+          "type": "string"
+        },
         "annotations": {
           "type": "object"
         },
@@ -1179,6 +1182,9 @@
                     "port"
                   ],
                   "properties": {
+                    "prefixTemplate": {
+                      "type": "string"
+                    },
                     "enabled": {
                       "type": "boolean"
                     },
@@ -1258,6 +1264,9 @@
                     "port"
                   ],
                   "properties": {
+                    "prefixTemplate": {
+                      "type": "string"
+                    },
                     "enabled": {
                       "type": "boolean"
                     },

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -252,6 +252,7 @@ external:
   # matching external.addresses + external.domain
   # externalDns:
   #   enabled: true
+  # prefixTemplate: ""
 
 # -- Log-level settings.
 logging:
@@ -801,6 +802,7 @@ listeners:
         # enabled: true
         # -- The port used for external client connections.
         port: 9094
+        # prefixTemplate: ""
         # -- If undefined, `listeners.kafka.external.default.port` is used.
         advertisedPorts:
         - 31092
@@ -856,6 +858,7 @@ listeners:
       default:
         # enabled: true
         port: 8083
+        # prefixTemplate: ""
         advertisedPorts:
           - 30082
         tls:


### PR DESCRIPTION
Allow runtime information, like node IP, to be part of DNS name for advertised addresses.