### PR TITLE
Remove last line from users

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.21
+version: 5.6.22
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.20
+version: 5.6.21
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/connectors/connectors.yaml
+++ b/charts/redpanda/templates/connectors/connectors.yaml
@@ -43,7 +43,7 @@ limitations under the License.
 {{ $command := list }}
 {{ if (include "sasl-enabled" . | fromJson).bool }}
   {{ $command = concat $command (list "sh" "-c") }}
-  {{ $consoleSASLConfig := (printf "set -e; IFS=: read -r CONNECT_SASL_USERNAME KAFKA_SASL_PASSWORD CONNECT_SASL_MECHANISM < $(find /mnt/users/* -print); CONNECT_SASL_MECHANISM=${CONNECT_SASL_MECHANISM:-%s}; export CONNECT_SASL_USERNAME CONNECT_SASL_PASSWORD_FILE CONNECT_SASL_MECHANISM;" (( include "sasl-mechanism" . ) | lower)) }}
+  {{ $consoleSASLConfig := (printf "set -e; IFS=: read -r CONNECT_SASL_USERNAME KAFKA_SASL_PASSWORD CONNECT_SASL_MECHANISM < <(grep \"\" $(find /mnt/users/* -print)); CONNECT_SASL_MECHANISM=${CONNECT_SASL_MECHANISM:-%s}; export CONNECT_SASL_USERNAME CONNECT_SASL_PASSWORD_FILE CONNECT_SASL_MECHANISM;" (( include "sasl-mechanism" . ) | lower)) }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " [[ $CONNECT_SASL_MECHANISM == \"SCRAM-SHA-256\" ]] && CONNECT_SASL_MECHANISM=scram-sha-256;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " [[ $CONNECT_SASL_MECHANISM == \"SCRAM-SHA-512\" ]] && CONNECT_SASL_MECHANISM=scram-sha-512;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " export CONNECT_SASL_MECHANISM;" }}

--- a/charts/redpanda/templates/connectors/connectors.yaml
+++ b/charts/redpanda/templates/connectors/connectors.yaml
@@ -43,7 +43,7 @@ limitations under the License.
 {{ $command := list }}
 {{ if (include "sasl-enabled" . | fromJson).bool }}
   {{ $command = concat $command (list "sh" "-c") }}
-  {{ $consoleSASLConfig := (printf "set -e; IFS=: read -r CONNECT_SASL_USERNAME KAFKA_SASL_PASSWORD CONNECT_SASL_MECHANISM < <(grep \"\" $(find /mnt/users/* -print)); CONNECT_SASL_MECHANISM=${CONNECT_SASL_MECHANISM:-%s}; export CONNECT_SASL_USERNAME CONNECT_SASL_PASSWORD_FILE CONNECT_SASL_MECHANISM;" (( include "sasl-mechanism" . ) | lower)) }}
+  {{ $consoleSASLConfig := (printf "set -e; IFS=':' read -r CONNECT_SASL_USERNAME KAFKA_SASL_PASSWORD CONNECT_SASL_MECHANISM < <(grep \"\" $(find /mnt/users/* -print)); CONNECT_SASL_MECHANISM=${CONNECT_SASL_MECHANISM:-%s}; export CONNECT_SASL_USERNAME CONNECT_SASL_PASSWORD_FILE CONNECT_SASL_MECHANISM;" (( include "sasl-mechanism" . ) | lower)) }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " [[ $CONNECT_SASL_MECHANISM == \"SCRAM-SHA-256\" ]] && CONNECT_SASL_MECHANISM=scram-sha-256;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " [[ $CONNECT_SASL_MECHANISM == \"SCRAM-SHA-512\" ]] && CONNECT_SASL_MECHANISM=scram-sha-512;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " export CONNECT_SASL_MECHANISM;" }}

--- a/charts/redpanda/templates/console/configmap-and-deployment.yaml
+++ b/charts/redpanda/templates/console/configmap-and-deployment.yaml
@@ -139,7 +139,7 @@ limitations under the License.
 {{ $command := list }}
 {{ if (include "sasl-enabled" . | fromJson).bool }}
   {{ $command = concat $command (list "sh" "-c") }}
-  {{ $consoleSASLConfig := (printf "set -e; IFS=: read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM < $(find /mnt/users/* -print); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-%s}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;" ( include "sasl-mechanism" . )) }}
+  {{ $consoleSASLConfig := (printf "set -e; IFS=':' read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM < <(grep \"\" $(find /mnt/users/* -print)); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-%s}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;" ( include "sasl-mechanism" . )) }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;" }}
   {{ $consoleSASLConfig = cat $consoleSASLConfig " /app/console $@" }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -72,7 +72,7 @@ stringData:
 
 {{- if and .Values.auth.sasl.enabled (not (empty .Values.auth.sasl.secretRef )) }}
       # Setup and export SASL bootstrap-user
-      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep \"\" $(find /etc/secrets/users/* -print))
+      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
       MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
       rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
 {{- end }}
@@ -205,6 +205,9 @@ stringData:
           IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
           # Do not process empty lines
           if [ -z "$USER_NAME" ]; then
+            continue
+          fi
+          if [[ ${$USER_NAME// /} != "$USER_NAME" ]]; then
             continue
           fi
           echo "Creating user ${USER_NAME}..."

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -207,7 +207,7 @@ stringData:
           if [ -z "$USER_NAME" ]; then
             continue
           fi
-          if [[ ${$USER_NAME// /} != "$USER_NAME" ]]; then
+          if [[ "${USER_NAME// /}" != "$USER_NAME" ]]; then
             continue
           fi
           echo "Creating user ${USER_NAME}..."

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -72,7 +72,7 @@ stringData:
 
 {{- if and .Values.auth.sasl.enabled (not (empty .Values.auth.sasl.secretRef )) }}
       # Setup and export SASL bootstrap-user
-      IFS=":" read -r USER_NAME PASSWORD MECHANISM < $(find /etc/secrets/users/* -print)
+      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep \"\" $(find /etc/secrets/users/* -print))
       MECHANISM=${MECHANISM:-{{- include "sasl-mechanism" . }}}
       rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
 {{- end }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -146,7 +146,6 @@ stringData:
     {{ printf "%s:%s" $user.name $user.password}}
     {{- end }}
   {{- end }}
-    # intentional empty line
 {{- else if and .Values.auth.sasl.enabled  ( empty .Values.auth.sasl.secretRef)  }}
 {{- fail "auth.sasl.secretRef cannot be empty when auth.sasl.enabled=true" }}
 {{- end }}

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -76,7 +76,7 @@ spec:
           set +x
 
           echo "SASL enabled: reading credentials from $(find /etc/secrets/users/* -print)"
-          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -76,7 +76,7 @@ spec:
           set +x
 
           echo "SASL enabled: reading credentials from $(find /etc/secrets/users/* -print)"
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -76,7 +76,7 @@ spec:
           set +x
 
           echo "SASL enabled: reading credentials from $(find /etc/secrets/users/* -print)"
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -59,7 +59,7 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -59,7 +59,7 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -59,7 +59,7 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -51,7 +51,7 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -51,7 +51,7 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -51,7 +51,7 @@ spec:
 {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -46,7 +46,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -46,7 +46,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -46,7 +46,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -43,7 +43,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-status.yaml
@@ -43,7 +43,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
+++ b/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
@@ -68,7 +68,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
+++ b/charts/redpanda/templates/tests/test-rpk-debug-bundle.yaml
@@ -68,7 +68,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -48,7 +48,7 @@ spec:
         - -c
         - |
           set -e
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -48,7 +48,7 @@ spec:
         - -c
         - |
           set -e
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -47,7 +47,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -47,7 +47,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -44,7 +44,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-status.yaml
@@ -44,7 +44,7 @@ spec:
   {{- if .Values.auth.sasl.enabled }}
           old_setting=${-//[^x]/}
           set +x
-          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < $(find /etc/secrets/users/* -print)
+          IFS=: read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep \"\" $(find /etc/secrets/users/* -print))
           {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
           RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
           {{- else }}


### PR DESCRIPTION
The following logs output shows that last line shouldn't be taken into users creation:

```
$ kubectl logs -c config-watcher redpanda-1
...
Creating user # intentional empty line...
error creating user # intentional empty line: Error: accepts at most 1 arg(s), received 4
Usage:
  rpk acl user create [USER] -p [PASS] [flags]

Flags:
  -h, --help               Help for create
      --mechanism string   SASL mechanism to use for the user you are
                           creating (scram-sha-256, scram-sha-512, case
                           insensitive) (default "scram-sha-256")
      --password string    New user's password (NOTE: if using --password
                           for the admin API, use --new-password)

Global Flags:
      --config string            Redpanda or rpk config file; default
                                 search paths are ~/.config/rpk/rpk.yaml,
                                 $PWD, and /etc/redpanda/redpanda.yaml
  -X, --config-opt stringArray   Override rpk configuration settings; '-X
                                 help' for detail or '-X list' for terser
                                 detail
      --profile string           rpk profile to use
  -v, --verbose                  Enable verbose logging
```