### PR TITLE
redpanda: fix: misspelled serviceAccount in CI

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.23
+version: 5.6.24
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/06-rack-awareness-values.yaml
+++ b/charts/redpanda/ci/06-rack-awareness-values.yaml
@@ -17,5 +17,5 @@ rackAwareness:
   enabled: true
 rbac:
   enabled: true
-serviceaccount:
+serviceAccount:
   create: true

--- a/charts/redpanda/templates/serviceaccount.yaml
+++ b/charts/redpanda/templates/serviceaccount.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 ---
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
CI value is misspelled. Helm does not correct values that are not correct, here this was discovered because of validation in operator api. 