### PR TITLE
fix: indent in trustore_file was incorrect

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.27
+version: 5.6.28
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -419,7 +419,7 @@ redpanda.yaml: |
       truststore_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/ca.crt
   {{- else }}
         {{- /* This is a required field so we use the default in the redpanda debian container */}}
-        truststore_file: /etc/ssl/certs/ca-certificates.crt
+      truststore_file: /etc/ssl/certs/ca-certificates.crt
   {{- end }}
   {{- with .Values.config.pandaproxy_client }}
     {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
Customer issue, found that could not start redpanda due to incorrect indentation. 