### PR TITLE
chore: fix task up, removed license task as not needed

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -50,10 +50,6 @@ tasks:
     cmds:
       - .github/create-sasl-secret.sh "some-users"
 
-  create-test-license-secret-template:
-    cmds:
-      - .github/create-license-secret.sh "redpanda-license"
-
   create-test-mv-files:
     cmds:
       - mv external-tls-secret.yaml charts/redpanda/templates/
@@ -65,7 +61,6 @@ tasks:
       - task: create-test-rack-awareness
       - task: create-test-tls-template
       - task: create-test-sasl-secret-template
-      - task: create-test-license-secret-template
       - task: create-test-mv-files
       - task: create-test-metallb-resources
 


### PR DESCRIPTION
Removing items from task, the original script was removed, and the license creation is involved and needs more input that is given here. Users can create their own if they wish. 

Fixes #812 