### PR TITLE
redpanda/fix: Fix line breaks in statefulset.affinity

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.30
+version: 5.6.32
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.29
+version: 5.6.30
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_statefulset.tpl
+++ b/charts/redpanda/templates/_statefulset.tpl
@@ -105,7 +105,7 @@ podAntiAffinity: {{ toYaml .Values.affinity.podAntiAffinity | nindent 2 }}
 
 {{/*
 statefulset-checksum-annotation calculates a checksum that is used
-as the value for the annotation, "checksum/conifg". When this value
+as the value for the annotation, "checksum/config". When this value
 changes, kube-controller-manager will roll the pods.
 
 Append any additional dependencies that require the pods to restart

--- a/charts/redpanda/templates/_statefulset.tpl
+++ b/charts/redpanda/templates/_statefulset.tpl
@@ -75,13 +75,13 @@ Set affinity for statefulset, defaults to global affinity if not defined in stat
 nodeAffinity: {{ toYaml .Values.statefulset.nodeAffinity | nindent 2 }}
 {{- else if not ( empty .Values.affinity.nodeAffinity ) -}}
 nodeAffinity: {{ toYaml .Values.affinity.nodeAffinity | nindent 2 }}
-{{- end }}
+{{- end -}}
 {{- if not ( empty .Values.statefulset.podAffinity ) -}}
 podAffinity: {{ toYaml .Values.statefulset.podAffinity | nindent 2 }}
 {{- else if not ( empty .Values.affinity.podAffinity ) -}}
 podAffinity: {{ toYaml .Values.affinity.podAffinity | nindent 2 }}
-{{- end }}
-{{- if not ( empty .Values.statefulset.podAntiAffinity ) -}}
+{{- end -}}
+{{- if not ( empty .Values.statefulset.podAntiAffinity ) }}
 podAntiAffinity:
   {{- if eq .Values.statefulset.podAntiAffinity.type "hard" }}
   requiredDuringSchedulingIgnoredDuringExecution:
@@ -100,7 +100,7 @@ podAntiAffinity:
   {{- end -}}
 {{- else if not ( empty .Values.affinity.podAntiAffinity ) -}}
 podAntiAffinity: {{ toYaml .Values.affinity.podAntiAffinity | nindent 2 }}
-{{- end }}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -842,6 +842,9 @@
             }
           }
         },
+        "nodeAffinity": {
+          "type": "object"
+        },
         "podAffinity": {
           "type": "object"
         },


### PR DESCRIPTION
- redpanda/fix: Fix line breaks in statefulset.affinity

Hi there, I encountered  `YAML parse error on redpanda/templates/statefulset.yaml` when I set nodeAffinity. Introduced in #747 

```yaml
# expected
affinity:
  nodeAffinity:
    requiredDuringSchedulingInogredDuringExecution:
      nodeSelectorTerms:
      - matchExpressions:
        - key: foobar
          operator: Exists
  podAntiAffinity:
  
# generated
...
        - key: foobar
          operator: ExistspodAntiAffinity:
```