### PR TITLE
convert values passed to SI-to-bytes to a string before processing

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.33
+version: 5.6.34
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -202,7 +202,7 @@ Use AppVersion if image.tag is not set
   Input can be: b | B | k | K | m | M | g | G | Ki | Mi | Gi
   Or number without suffix
   */}}
-  {{- $si := . -}}
+  {{- $si := . | toString -}}
   {{- $bytes := 0 -}}
   {{- if or (hasSuffix "B" $si) (hasSuffix "b" $si) -}}
     {{- $bytes = $si | trimSuffix "B" | trimSuffix "b" | float64 | floor -}}


### PR DESCRIPTION
Buildkite nightlies are failing with:

```
Error: INSTALLATION FAILED: template: redpanda/templates/statefulset.yaml:56:41: executing "redpanda/templates/statefulset.yaml" at <include "statefulset-checksum-annotation" .>: error calling include: template: redpanda/templates/_statefulset.tpl:116:44: executing "statefulset-checksum-annotation" at <include "configmap-content-no-seed" .>: error calling include: template: redpanda/templates/_configmap.tpl:91:23: executing "configmap-content-no-seed" at <include "SI-to-bytes" $element>: error calling include: template: redpanda/templates/_helpers.tpl:207:27: executing "SI-to-bytes" at <$si>: wrong type for value; expected string; got float64
```
because the value being passed to the helper is a float64. Convert it to a string so `hasSuffix` doesn't error.