### PR TITLE
fix scientific notation if large float64 is passed to SI-to-bytes

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.35
+version: 5.6.36
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -202,7 +202,10 @@ Use AppVersion if image.tag is not set
   Input can be: b | B | k | K | m | M | g | G | Ki | Mi | Gi
   Or number without suffix
   */}}
-  {{- $si := . | toString -}}
+  {{- $si := . -}}
+  {{- if not (typeIs "string" . ) -}}
+    {{- $si = int64 $si | toString -}}
+  {{- end -}}
   {{- $bytes := 0 -}}
   {{- if or (hasSuffix "B" $si) (hasSuffix "b" $si) -}}
     {{- $bytes = $si | trimSuffix "B" | trimSuffix "b" | float64 | floor -}}


### PR DESCRIPTION
If a float64 is passed to SI-to-bytes, `toString` converts it to scientific notation. Convert it to an int64 first to get a usable number.