### PR TITLE
bump the minimum required helm to 3.8.0

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.36
+version: 5.6.37
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
@@ -52,7 +52,7 @@ annotations:
   artifacthub.io/links: |
     - name: Documentation
       url: https://docs.redpanda.com
-    - name: "Helm (>= 3.6.0)"
+    - name: "Helm (>= 3.8.0)"
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -426,6 +426,13 @@ than 1 core.
 {{- end -}}
 {{- end -}}
 
+{{- define "fail-on-unsupported-helm-version" -}}
+  {{- $helmVer := (fromYaml (toYaml .Capabilities.HelmVersion)).version -}}
+  {{- if semverCompare "<3.8.0-0" $helmVer -}}
+    {{- fail (printf "helm version %s is not supported. Please use helm version v3.8.0 or newer." $helmVer) -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "redpanda-atleast-22-2-0" -}}
 {{- toJson (dict "bool" (or (not (eq .Values.image.repository "docker.redpanda.com/redpandadata/redpanda")) (include "redpanda.semver" . | semverCompare ">=22.2.0-0 || <0.0.1-0"))) -}}
 {{- end -}}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -15,6 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
+{{- include "fail-on-unsupported-helm-version" . -}}
 {{- include "fail-on-insecure-sasl-logging" . -}}
 
 {{- $values := .Values }}


### PR DESCRIPTION
We're using combined logic that fails prior to 3.8.0. Enforce a minimum helm version.