### PR TITLE
add `commonLabels` to console helm chart

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.7.6
+version: 0.7.7
 
 # The app version is the version of the Chart application
 appVersion: v2.3.5

--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -51,6 +51,9 @@ helm.sh/chart: {{ include "console.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ with .Values.commonLabels }}
+{{- toYaml . -}}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -52,6 +52,9 @@ serviceAccount:
   # a name is generated using the `console.fullname` template
   name: ""
 
+# Common labels to add to all the pods
+commonLabels: {}
+
 # -- Annotations to add to the deployment.
 annotations: {}
 


### PR DESCRIPTION
Add `commonLabels` to the console helm chart.
- This added custom Lable to all the components of the deployment