### PR TITLE
chore: restart schema registry on upgrade

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.38
+version: 5.6.39
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -17,7 +17,6 @@ limitations under the License.
 {{- if .Values.post_install_job.enabled }}
 {{- $values := .Values }}
 {{- $root := deepCopy . }}
-
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -95,7 +95,7 @@ spec:
                 --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
   {{- end }}
                 -X PUT -u ${USER_NAME}:${PASSWORD} \
-  {{- if .Values.tls.enabled }}
+  {{- if (include "admin-internal-tls-enabled" . | fromJson).bool }}
                 https://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
   {{- else }}
                 http://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -89,7 +89,7 @@ spec:
 {{- end }}
 {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
             IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
-            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+            curl -svm3 --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
   {{- if $cert.caEnabled }}
             --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
   {{- end }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -89,15 +89,15 @@ spec:
 {{- end }}
 {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
             IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
-            curl -svm3 --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
   {{- if $cert.caEnabled }}
             --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
   {{- end }}
             -X PUT -u ${USER_NAME}:${PASSWORD} \
   {{- if .Values.tls.enabled }}
-            https://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry
+            https://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
   {{- else }}
-            http://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry
+            http://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
   {{- end }}
 {{- end }}
         {{- with .Values.post_upgrade_job.resources }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -15,6 +15,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.post_upgrade_job.enabled }}
+{{- $service := .Values.listeners.admin -}}
+{{- $cert := get .Values.tls.certs $service.tls.cert -}}
 {{- $root := deepCopy . }}
 apiVersion: batch/v1
 kind: Job
@@ -64,7 +66,7 @@ spec:
       containers:
       - name: {{ template "redpanda.name" . }}-post-upgrade
         image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-        command: ["/bin/sh", "-c"]
+        command: ["/bin/bash", "-c"]
         args:
           - |
             set -e
@@ -84,6 +86,19 @@ spec:
 {{- end }}
 {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
             rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }}
+{{- end }}
+{{- if .Values.auth.sasl.enabled }}
+            IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+  {{- if $cert.caEnabled }}
+            --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+  {{- end }}
+            -X PUT -u ${USER_NAME}:${PASSWORD} \
+  {{- if .Values.tls.enabled }}
+            https://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry
+  {{- else }}
+            http://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry
+  {{- end }}
 {{- end }}
         {{- with .Values.post_upgrade_job.resources }}
         resources:

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -87,7 +87,7 @@ spec:
 {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
             rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }}
 {{- end }}
-{{- if .Values.auth.sasl.enabled }}
+{{- if and .Values.auth.sasl.enabled (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
             IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
             curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
   {{- if $cert.caEnabled }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -87,7 +87,7 @@ spec:
 {{- if not (hasKey .Values.config.cluster "storage_min_free_bytes") }}
             rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }}
 {{- end }}
-{{- if and .Values.auth.sasl.enabled (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+{{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
             IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
             curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
   {{- if $cert.caEnabled }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -88,17 +88,19 @@ spec:
             rpk cluster config set storage_min_free_bytes {{ include "storage-min-free-bytes" . }}
 {{- end }}
 {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
-            IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
-            curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
   {{- if $cert.caEnabled }}
-            --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
+                --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
   {{- end }}
-            -X PUT -u ${USER_NAME}:${PASSWORD} \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
   {{- if .Values.tls.enabled }}
-            https://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
+                https://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
   {{- else }}
-            http://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
+                http://{{ include "redpanda.internal.domain" . }}:{{ $service.port }}/v1/debug/restart_service?service=schema-registry || true
   {{- end }}
+            fi
 {{- end }}
         {{- with .Values.post_upgrade_job.resources }}
         resources:


### PR DESCRIPTION
Should fix issue where sasl has been turned on but schema-registry needs to restart. 