### PR TITLE
bump image versions

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.3.26
+version: 0.4.0
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v23.2.14
+appVersion: v2.0.0
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,11 +34,13 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v23.2.14
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.0.0
+    - name: configurator
+      image: docker.redpanda.com/redpandadata/configurator:v2.0.0
     - name: redpanda
       image: docker.redpanda.com/redpandadata/redpanda:v23.2.13
     - name: kube-rbac-proxy
-      image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+      image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   artifacthub.io/crds: |
     - kind: Redpanda
       version: v1alpha1

--- a/charts/operator/templates/deployment.yaml
+++ b/charts/operator/templates/deployment.yaml
@@ -95,7 +95,8 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=10
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: {{ .Values.kubeRbacProxy.image.repository }}:{{ .Values.kubeRbacProxy.image.tag }}
+        imagePullPolicy: {{ .Values.kubeRbacProxy.image.pullPolicy }}
         ports:
         - containerPort: 8443
           name: https

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -22,6 +22,15 @@ image:
   # image.pullPolicy -- Define the pullPolicy for Redpanda Operator image
   pullPolicy: IfNotPresent
 
+kubeRbacProxy:
+  image:
+    # image.repository -- Repository in which the kube-rbac-proxy image is available
+    repository: gcr.io/kubebuilder/kube-rbac-proxy
+    # image.tag -- Define the kube-rbac-proxy image tag
+    tag: v0.14.0
+    # image.pullPolicy -- Define the pullPolicy for kube-rbac-proxy image
+    pullPolicy: IfNotPresent
+
 configurator:
   # configurator.repository -- Repository that Redpanda configurator image is available
   repository: docker.redpanda.com/redpandadata/configurator


### PR DESCRIPTION
* Bump the operator image version from the Redpanda tags to the operator's tags. This actually only represents a patch-release as there were no features added since v23.2.14.

* Bump the kube-rbac-proxy image from 0.8.0 to the same one we use in testing, 0.14.0. 

### Redpanda Operator changes:

* build(deps): bump github.com/moby/moby in /src/go/k8s
    
    Bumps [github.com/moby/moby](https://github.com/moby/moby) from 24.0.6+incompatible to 24.0.7+incompatible.
    - [Release notes](https://github.com/moby/moby/releases)
* build(deps): bump github.com/cert-manager/cert-manager in /src/go/k8s
    
    Bumps [github.com/cert-manager/cert-manager](https://github.com/cert-manager/cert-manager) from 1.13.1 to 1.13.2.
    - [Release notes](https://github.com/cert-manager/cert-manager/releases)
    - [Commits](https://github.com/cert-manager/cert-manager/compare/v1.13.1...v1.13.2)
* build(deps): bump github.com/testcontainers/testcontainers-go
    
    Bumps [github.com/testcontainers/testcontainers-go](https://github.com/testcontainers/testcontainers-go) from 0.25.0 to 0.26.0.
    - [Release notes](https://github.com/testcontainers/testcontainers-go/releases)
    - [Commits](https://github.com/testcontainers/testcontainers-go/compare/v0.25.0...v0.26.0)
* build(deps): bump github.com/testcontainers/testcontainers-go/modules/redpanda
    
    Bumps [github.com/testcontainers/testcontainers-go/modules/redpanda](https://github.com/testcontainers/testcontainers-go) from 0.25.0 to 0.2>
    - [Release notes](https://github.com/testcontainers/testcontainers-go/releases)
    - [Commits](https://github.com/testcontainers/testcontainers-go/compare/v0.25.0...v0.26.0)
* build(deps): bump github.com/go-logr/logr in /src/go/k8s
    
    Bumps [github.com/go-logr/logr](https://github.com/go-logr/logr) from 1.2.4 to 1.3.0.
    - [Release notes](https://github.com/go-logr/logr/releases)
    - [Changelog](https://github.com/go-logr/logr/blob/master/CHANGELOG.md)
    - [Commits](https://github.com/go-logr/logr/compare/v1.2.4...v1.3.0)
* operator: allow "force" value to change tls configuration
