### PR TITLE
chore: redpanda remove extra quotes for probes

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.41
+version: 5.6.42
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/rbac.yaml
+++ b/charts/redpanda/templates/rbac.yaml
@@ -129,6 +129,7 @@ rules:
       - ""
     resources:
       - nodes
+      - pods
     verbs:
       - get
       - list
@@ -179,6 +180,13 @@ annotations:
   {{- toYaml . | nindent 4 }}
     {{- end }}
 rules:
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/status
+    verbs:
+      - patch
+      - update
   - apiGroups:
       - ""
     resources:

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -309,8 +309,8 @@ spec:
           args:
             - --operator-mode=false
             - --namespace={{ .Release.Namespace }}
-            - --health-probe-bind-address={{ .Values.statefulset.sideCars.controllers.healthProbeAddress | quote }}
-            - --metrics-bind-address={{ .Values.statefulset.sideCars.controllers.metricsAddress | quote }}
+            - --health-probe-bind-address={{ .Values.statefulset.sideCars.controllers.healthProbeAddress }}
+            - --metrics-bind-address={{ .Values.statefulset.sideCars.controllers.metricsAddress }}
             - --additional-controllers={{ join "," .Values.statefulset.sideCars.controllers.run }}
           env:
             - name: REDPANDA_HELM_RELEASE_NAME

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -627,11 +627,20 @@ statefulset:
       resources: {}
       securityContext: {}
       extraVolumeMounts: |-
+    # Configure extra controllers to run as sidecars inside the Pods running Redpanda brokers.
+    # Available controllers:
+    # - Decommission Controller: The Decommission Controller ensures smooth scaling down operations.
+    # This controller is responsible for monitoring changes in the number of StatefulSet replicas and orchestrating
+    # the decommissioning of brokers when necessary. It also sets the reclaim policy for the decommissioned
+    # broker's PersistentVolume to `Retain` and deletes the corresponding PersistentVolumeClaim.
+    # - Node-PVC Controller: The Node-PVC Controller handles the PVCs of deleted brokers.
+    # By setting the PV Retain policy to retain, it facilitates the rescheduling of brokers to new, healthy nodes when
+    # an existing node is removed.
     controllers:
       image:
-        tag: v23.2.8
+        tag: v23.2.14
         repository: docker.redpanda.com/redpandadata/redpanda-operator
-      # You must enable, this feature is experimental, and so you must opt in
+      # You must also enable RBAC, `rbac.enabled=true`, to deploy this sidecar
       enabled: false
       resources: {}
       securityContext: {}


### PR DESCRIPTION
Also fixes #854

The sts template added extra quotes to the template

from the values file
```
      securityContext: {}
      healthProbeAddress: ":8085"
      metricsAddress: ":9082"
```

then from the sts
```
            - --health-probe-bind-address={{ .Values.statefulset.sideCars.controllers.healthProbeAddress | quote }}
            - --metrics-bind-address={{ .Values.statefulset.sideCars.controllers.metricsAddress | quote }}
```

that quote directive  would cause the following error 
```
{"level":"error","ts":"2023-11-06T14:55:57.908Z","logger":"setup","msg":"Unable to start manager","error":"error listening on \":8085\": listen tcp: address tcp/8085\": unknown port"}
```

Notice the quotes in the error message. Once we removed this the containers were starting as expected.  