### PR TITLE
chore: remove 22.3.X from testing matrix

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -49,7 +49,6 @@ jobs:
         version:
           - ""
           - v23.1.19
-          - v22.3.24
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -40,7 +40,6 @@ jobs:
         version:
           - ""
           - v23.1.19
-          - v22.3.24
         testvaluespattern:
           - '9[7-9]*' # some tests depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
       fail-fast: false

--- a/.github/workflows/pull_requests_redpanda.yaml
+++ b/.github/workflows/pull_requests_redpanda.yaml
@@ -88,7 +88,6 @@ jobs:
         version:
           - ""
           - v23.1.19
-          - v22.3.24
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'


### PR DESCRIPTION
version 22.3.4 will soon be deprecated. we are removing it from testing moving forward. 