### PR TITLE
chore: fix post-upgrade job when it is set to null

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.44
+version: 5.6.46
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -91,7 +91,7 @@ spec:
             if [ -d "/etc/secrets/users/" ]; then
                 IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
                 curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
-  {{- if $cert.caEnabled }}
+  {{- if and $cert ( dig "caEnabled" false $cert ) }}
                 --cacert /etc/tls/certs/{{ $service.tls.cert }}/ca.crt \
   {{- end }}
                 -X PUT -u ${USER_NAME}:${PASSWORD} \


### PR DESCRIPTION
If a cert is null, this should still process and work. Here we add checks against that possibility. 