### PR TITLE
Set TTL for jobs

### DIFF
--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -40,6 +40,7 @@ metadata:
   {{- toYaml . | nindent 4 }}
 {{- end }}
 spec:
+  ttlSecondsAfterFinished: 10
   template:
     metadata:
       generateName: "{{ .Release.Name }}-post-"


### PR DESCRIPTION
This small change makes the `redpanda-configuration` and `redpanda-post-upgrade` jobs (and their associated pods) automatically be cleaned up after successful runs. This frees up their resources and is recommended (see note [here](https://kubernetes.io/docs/concepts/workloads/controllers/job/#ttl-mechanism-for-finished-jobs).

Keeping in draft for now since I need to ensure the commit happens with the proper email address, and I need to add the change to the 2nd job.