### PR TITLE
Move TLS parameters inside if statements

### DIFF
--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -240,8 +240,8 @@ redpanda.yaml: |
         port: {{ $listener.port }}
   {{- end }}
 {{- end }}
-    admin_api_tls:
 {{- if (include "admin-internal-tls-enabled" . | fromJson).bool }}
+    admin_api_tls:
       - name: internal
         enabled: true
         cert_file: /etc/tls/certs/{{ $service.tls.cert }}/tls.crt
@@ -301,8 +301,8 @@ redpanda.yaml: |
     {{- end }}
   {{- end }}
 {{- end }}
-    kafka_api_tls:
 {{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
+    kafka_api_tls:
       - name: internal
         enabled: true
         cert_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/tls.crt


### PR DESCRIPTION
Small change to move the start of the two TLS sections `admin_api_tls` and `kafka_api_tls` into their associated if statement.