### PR TITLE
WIP Stretch cluster support

### DIFF
--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -560,6 +560,10 @@ rpk:
     {{- $server := dict "host" (dict "address" . "port" $.Values.listeners.rpc.port) -}}
     {{- $serverList = append $serverList $server -}}
   {{- end -}}
+  {{- range $seed := .Values.additionalSeedServers -}}
+    {{- $server := dict "host" (dict "address" $seed.address "port" $seed.port) -}}
+    {{- $serverList = append $serverList $server -}}
+  {{- end -}}
   {{- toJson (dict "serverList" $serverList) -}}
 {{- end -}}
 

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -282,6 +282,16 @@ Use AppVersion if image.tag is not set
 {{- toJson (dict "bool" $enabled) -}}
 {{- end -}}
 
+{{- define "external-rpc-enabled" -}}
+{{- if (hasKey .Values.external "rpc") -}}
+  {{- if (default false .Values.external.rpc.enabled) -}}
+    {{- toJson (dict "bool" true) -}}
+  {{- else -}}
+    {{- toJson (dict "bool" false) -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda-reserve-memory" -}}
   {{/*
   Determines the value of --reserve-memory flag (in mebibytes with M suffix, per Seastar).

--- a/charts/redpanda/templates/service.loadbalancer.yaml
+++ b/charts/redpanda/templates/service.loadbalancer.yaml
@@ -54,6 +54,12 @@ spec:
   externalTrafficPolicy: Local
   sessionAffinity: None
   ports:
+    {{- range $listener := $values.listeners.rpc }}
+    - name: rpc
+      protocol: TCP
+      targetPort: {{ $values.listeners.rpc.port }}
+      port: {{ $values.listeners.rpc.port }}
+    {{- end }}
     {{- range $name, $listener := $values.listeners.admin.external }}
       {{- $enabled := dig "enabled" $values.external.enabled $listener }}
       {{- if $enabled }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -20,6 +20,10 @@ limitations under the License.
 
 {{- $values := .Values }}
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
+{{- $externalAdvertiseAddress := printf "$(SERVICE_NAME)" -}}
+{{- if (tpl ($values.external.domain | default "") $) -}}
+  {{- $externalAdvertiseAddress = printf "$(SERVICE_NAME).%s" (tpl $values.external.domain $) -}}
+{{- end -}}
 {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset -}}
 {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset -}}
 {{- $root := deepCopy . }}
@@ -65,6 +69,20 @@ spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets: {{- toYaml . | nindent 8 }}
     {{- end }}
+{{- /*
+TODO this needs to be added automatically
+      hostAliases:
+      - ip: "ip-of-redpanda-0-lb"
+        hostnames:
+        - "redpanda-0.external-domain"
+      - ip: "ip-of-redpanda-1-lb"
+        hostnames:
+        - "redpanda-1.external-domain"
+      - ip: "20.221.87.87"
+      - ip: "ip-of-redpanda-2-lb"
+        hostnames:
+        - "redpanda-2.external-domain"
+*/}}
       initContainers:
 {{- if and (hasKey $values.tuning "tune_aio_events") $values.tuning.tune_aio_events }}
         - name: tuning
@@ -260,7 +278,11 @@ spec:
             - rpk
             - redpanda
             - start
+{{- if (include "external-rpc-enabled" . | fromJson).bool }}
+            - "--advertise-rpc-addr={{ $externalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}"
+{{- else }}
             - "--advertise-rpc-addr={{ $internalAdvertiseAddress }}:{{ .Values.listeners.rpc.port }}"
+{{- end }}
           ports:
 {{- range $name, $listener := .Values.listeners }}
             - name: {{ lower $name }}


### PR DESCRIPTION
This PR adds the ability to configure helm deployments so that Redpanda can form a stretch cluster. A few notes:

- allows enabling RPC communication by external hostnames
- allows adding additional seed servers so subsequent deployments can reach out to already existing deployments to find leader
- new parameters are intentionally left out of the values.yaml (but they should likely be added to the schema regardless). The reason is because modifying `additionalSeedServers` or enabling external RPC is error prone and is difficult to configure. The goal is to enable setting these values but then provide a guide showing how a tool like Crossplane could be used to manage multiple helm deployments (and managing the proper values for these new parameters in values.yaml).

TODOs:

- external hostname must be resolvable, so I've ensure this is the case by updating the hosts file on Redpanda pods with the external hostnames and LB IP addresses
- this is the start of other work, including an investigation and PoC with [Crossplane](https://docs.crossplane.io/knowledge-base/guides/multi-tenant/#multi-cluster-multi-tenancy)