### PR TITLE
Bump Operator chart version

### DIFF
--- a/.github/bump_chart_versions.sh
+++ b/.github/bump_chart_versions.sh
@@ -20,7 +20,7 @@ get_chart_appversion() {
 }
 
 get_chart_app_constraint() {
-    CONSTRAINT=$(yq -r .appVersion "${CHARTFILE}" | awk '{patch=split($1,version,".");version[patch]++; print "~"version[1],version[2]}' OFS=.)
+    CONSTRAINT=$(yq -r .appVersion "${CHARTFILE}" | awk '{patch=split($1,version,".");version[patch]++; print "~"version[1]}' OFS=.)
 }
 
 get_repo() {

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.1
+version: 0.4.2
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v2.0.0
+appVersion: v2.1.0
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,7 +34,7 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.0.0
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.0
     - name: configurator
       image: docker.redpanda.com/redpandadata/configurator:v2.0.0
     - name: redpanda

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -70,8 +70,10 @@ rules:
     - create
     - delete
     - get
+    - list
     - patch
     - update
+    - watch
 - apiGroups:
     - apps
   resources:
@@ -94,8 +96,6 @@ rules:
     - get
     - patch
     - update
-    - list
-    - watch
 - apiGroups:
     - apps
   resources:
@@ -294,8 +294,10 @@ rules:
     - create
     - delete
     - get
+    - list
     - patch
     - update
+    - watch
 - apiGroups:
     - rbac.authorization.k8s.io
   resources:
@@ -315,6 +317,26 @@ rules:
   verbs:
     - create
     - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - redpanda.vectorized.io
+  resources:
+    - clusters
+  verbs:
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - redpanda.vectorized.io
+  resources:
+    - consoles
+  verbs:
     - get
     - list
     - patch
@@ -344,6 +366,36 @@ rules:
     - patch
     - update
     - watch
+- apiGroups:
+    - source.toolkit.fluxcd.io
+  resources:
+    - gitrepository
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - source.toolkit.fluxcd.io
+  resources:
+    - gitrepository/finalizers
+  verbs:
+    - create
+    - delete
+    - get
+    - patch
+    - update
+- apiGroups:
+    - source.toolkit.fluxcd.io
+  resources:
+    - gitrepository/status
+  verbs:
+    - get
+    - patch
+    - update
 - apiGroups:
     - source.toolkit.fluxcd.io
   resources:
@@ -404,17 +456,6 @@ rules:
     - get
     - patch
     - update
-- apiGroups:
-    - ""
-  resources:
-    - persistentvolumeclaims
-  verbs:
-    - delete
-    - get
-    - list
-    - patch
-    - update
-    - watch
 - apiGroups:
     - cluster.redpanda.com
   resources:


### PR DESCRIPTION
In this PR:

* nightly script that detects version bump
  * works in Mac and Linux environment
  * can bump minor and patch release
* bumps Operator chart version and AppVersion
* Introduces new Roles required for automatic migration