### PR TITLE
Bug FIX: Common labels not being assigned to any components

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.3
+version: 0.4.4
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -62,7 +62,7 @@ Other instruction will be visible after installation.
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"docker.redpanda.com/redpandadata/redpanda-operator"` | Repository that Redpanda Operator image is available |
 | imagePullSecrets | list | `[]` | Redpanda Operator container registry pullSecret (ex: specify docker registry credentials) |
-| labels | string | `nil` | Allows to assign labels to the resources created by this helm chart |
+| commonLabels | string | `nil` | Allows to assign commonLabels to the resources created by this helm chart |
 | logLevel | string | `"info"` | Set Redpanda Operator log level (debug, info, error, panic, fatal) |
 | monitoring | object | `{"deployPrometheusKubeStack":false,"enabled":false}` | Add service monitor to the deployment |
 | nameOverride | string | `""` | Override name of app |

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -56,6 +56,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{ with .Values.commonLabels }}
+{{- toYaml . -}}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -107,8 +107,8 @@ podLabels: {}
 additionalCmdFlags: []
 # - --some-flag
 
-# labels -- Allows to assign labels to the resources created by this helm chart
-labels:
+# commonLabels -- Allows to assign labels to the resources created by this helm chart
+commonLabels:
 
 # monitoring -- Add service monitor to the deployment
 monitoring:


### PR DESCRIPTION
- BUG FIX: Common labels were not being assigned to any resources. Fixed this bug
- Rename  `labels` to `commonLabels` which is a common practice for the labels that have to be assigned to all the resources created by helm chart