### PR TITLE
redpanda: allow recovery_mode 

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.49
+version: 5.6.50
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.48
+version: 5.6.49
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -80,9 +80,11 @@ stringData:
       touch /tmp/postStartHookFinished
     }
 
+  {{- if not ( dig "node" "recovery_mode_enabled" false .Values.config ) }}
     postStartHook
-    true
+  {{- end }}
 
+    true
 
   preStop.sh: |-
     #!/usr/bin/env bash
@@ -118,11 +120,11 @@ stringData:
       touch /tmp/preStopHookFinished
     }
 
-{{- if gt ( .Values.statefulset.replicas | int64 ) 2 }}
+{{- if and ( gt ( .Values.statefulset.replicas | int64 ) 2) ( not ( dig "node" "recovery_mode_enabled" false .Values.config ) ) }}
     preStopHook
 {{- else }}
     touch /tmp/preStopHookFinished
-    echo "Not enough replicas to put a broker into maintenance mode."
+    echo "Not enough replicas or in recovery mode, cannot put a broker into maintenance mode."
 {{- end }}
     true
 {{- if and (not (empty .Values.auth.sasl.secretRef)) (and .Values.auth.sasl.enabled .Values.auth.sasl.users) }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -80,10 +80,7 @@ stringData:
       touch /tmp/postStartHookFinished
     }
 
-  {{- if not ( dig "node" "recovery_mode_enabled" false .Values.config ) }}
     postStartHook
-  {{- end }}
-
     true
 
   preStop.sh: |-

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -250,8 +250,12 @@ spec:
                 - -c
                 - |
                   set -x
+                  {{- if ( dig "node" "recovery_mode_enabled" false .Values.config ) }}
+                  echo "in recovery mode, OK"
+                  {{- else }}
                   rpk cluster health
                   rpk cluster health | grep 'Healthy:.*true'
+                  {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -243,6 +243,7 @@ spec:
           # It's ok that this cluster-wide check affects all the pods as it's only used for the
           # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
           # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+        {{- if not ( dig "node" "recovery_mode_enabled" false .Values.config ) }}
           readinessProbe:
             exec:
               command:
@@ -250,12 +251,9 @@ spec:
                 - -c
                 - |
                   set -x
-                  {{- if ( dig "node" "recovery_mode_enabled" false .Values.config ) }}
-                  echo "in recovery mode, OK"
-                  {{- else }}
                   rpk cluster health
                   rpk cluster health | grep 'Healthy:.*true'
-                  {{- end }}
+        {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -1032,6 +1032,7 @@ config:
     # coproc_supervisor_server: 127.0.0.1:43189                    # IpAddress and port for supervisor service
     # dashboard_dir: None                                          # serve http dashboard on / url
     # developer_mode: true                                         # Skips most of the checks performed at startup
+    # recovery_mode_enabled: false                                 # Sets recovery mode of a cluster
 
   # Reference schema registry client https://docs.redpanda.com/current/reference/node-configuration-sample/
   schema_registry_client: {}


### PR DESCRIPTION
Note that it may be necessary to roll manually (delete the pods) after leaving recovery_mode. This is just a matter of restarting the pods, no need to change update strategy from my own testing. 

Fixes #795 


c.c. @JakeSCahill 