### PR TITLE
redpanda: sidecar controllers were not being tested

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.57
+version: 5.6.58
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/16-controller-sidecar-values.yaml
+++ b/charts/redpanda/ci/16-controller-sidecar-values.yaml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
+rbac:
+  enabled: true
+
 statefulset:
   sideCars:
     controllers:


### PR DESCRIPTION
Needed rbac roles to deploy controllers, this enables the ci testing of the additional controllers. 