### PR TITLE
Fix readiness probe definition

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.58
+version: 5.6.59
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -254,11 +254,11 @@ spec:
                   set -x
                   rpk cluster health
                   rpk cluster health | grep 'Healthy:.*true'
-        {{- end }}
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}
             successThreshold: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
+        {{- end }}
           command:
             - rpk
             - redpanda


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/redpanda-operator/issues/36

The following definition doesn't work as 3 key are duplicated.

```
          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
          livenessProbe:
            exec:
              command:
                - /bin/sh
                - -c
                - curl --silent --fail -k  "http://${SERVICE_NAME}.redpanda.public-api.svc.cluster.local.:9644/v1/status/ready"
            initialDelaySeconds: 10
            failureThreshold: 3
            periodSeconds: 10
          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
          # It's ok that this cluster-wide check affects all the pods as it's only used for the
          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
          # All services set `publishUnreadyAddresses:true` to prevent this from affecting cluster access
            initialDelaySeconds: 1
            failureThreshold: 3
            periodSeconds: 10
            successThreshold: 1
          command:
            - rpk
            - redpanda
            - start
            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.public-api.svc.cluster.local.:33145"
```