### PR TITLE
Allow append Console environment variables and volumes

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.59
+version: 5.6.60
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/99-none-existent-config-options-with-empty-values.yaml
+++ b/charts/redpanda/ci/99-none-existent-config-options-with-empty-values.yaml
@@ -53,3 +53,17 @@ config:
     node_empty_array_value: []
     node_empty_map_value: {}
     node_empty_string_value: ""
+
+console:
+  extraEnv:
+    - name: TEST
+      value: test
+  extraVolumeMounts:
+    - name: redpanda-license
+      mountPath: /mnt/test
+      readOnly: true
+  extraVolumes:
+    - name: redpanda-license
+      secret:
+        defaultMode: 0420
+        secretName: redpanda-license

--- a/charts/redpanda/templates/console/configmap-and-deployment.yaml
+++ b/charts/redpanda/templates/console/configmap-and-deployment.yaml
@@ -275,7 +275,9 @@ limitations under the License.
   }}
 {{ end }}
 
-{{ $extraEnv := concat $kafkaTLS $schemaRegistryTLS $adminAPI}}
+{{ $extraEnv := concat $kafkaTLS $schemaRegistryTLS $adminAPI .Values.console.extraEnv }}
+{{ $extraVolumes = concat $extraVolumes .Values.console.extraVolumes }}
+{{ $extraVolumeMounts = concat $extraVolumeMounts .Values.console.extraVolumeMounts }}
 {{ $consoleValues := dict
   "Values" (dict
   "extraVolumes" $extraVolumes


### PR DESCRIPTION
To allow user pass secrets as in the example:

```yaml
console:
  console:
    config:
      login:
        jwtSecret: G{{jcfs):a
      cloud:
        prometheusEndpoint:
          basicAuth:
            password: lhj-;qRvXk{{];YM6K1]1`1[
```

This PR allow user to append as environment variables or mount  volumes other secrets.