### PR TITLE
operator: fix missing podmonitor role

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.9
+version: 0.4.10
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -267,6 +267,18 @@ rules:
 - apiGroups:
     - monitoring.coreos.com
   resources:
+    - podmonitors
+  verbs:
+    - create
+    - delete
+    - get
+    - list
+    - patch
+    - update
+    - watch
+- apiGroups:
+    - monitoring.coreos.com
+  resources:
     - servicemonitors
   verbs:
     - create


### PR DESCRIPTION
pod monitor role missing causing installation and upgrade errors when connector monitoring turned on.

Fixes #927