### PR TITLE
redpanda: expose audit logging feature

### DIFF
--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -41,7 +41,7 @@ jobs:
           - ""
           - v23.1.19
         testvaluespattern:
-          - '9[7-9]*' # some tests depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
+          - '9[6-9]*' # some tests depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
@@ -99,6 +99,7 @@ jobs:
           if [ -z $REDPANDA_LICENSE ]; then echo "License is empty" ; exit 1; fi
           
           envsubst < ./charts/redpanda/ci/97-license-key-values.yaml.tpl > ./charts/redpanda/ci/97-license-key-values.yaml 
+          envsubst < ./charts/redpanda/ci/96-audit-logging-values.yaml.tpl > ./charts/redpanda/ci/96-audit-logging-values.yaml 
 
           kubectl create secret generic redpanda-license \
           --from-literal=license-key="$REDPANDA_LICENSE" \

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.65
+version: 5.7.0
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/96-audit-logging-values.yaml.tpl
+++ b/charts/redpanda/ci/96-audit-logging-values.yaml.tpl
@@ -12,11 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-debug: true
-remote: origin
-target-branch: main
-helm-extra-args: --timeout 600s
-chart-repos:
-  - redpanda=https://charts.redpanda.com
-charts:
-  - charts/redpanda
+---
+enterprise:
+  license: "${REDPANDA_LICENSE}"
+
+auth:
+  sasl:
+    enabled: true
+    users:
+      - name: admin
+        password: change-me
+        mechanism: SCRAM-SHA-512
+
+auditLogging:
+  enabled: true
+  listeners: default

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -90,6 +90,44 @@ bootstrap.yaml: |
   {{- if and (not (hasKey .Values.config.cluster "storage_min_free_bytes")) ((include "redpanda-atleast-22-2-0" . | fromJson).bool) }}
   storage_min_free_bytes: {{ include "storage-min-free-bytes" . }}
   {{- end }}
+{{/* AUDIT LOGS */}}
+{{- if (include "redpanda-atleast-23-3-0" . | fromJson).bool }}
+  {{- if and ( dig "enabled" "false" .Values.auditLogging ) (include "sasl-enabled" $root | fromJson).bool }}
+  audit_enabled: true
+  {{- if not (eq (int .Values.auditLogging.clientMaxBufferSize) 16777216 ) }}
+  audit_client_max_buffer_size: {{ .Values.auditLogging.clientMaxBufferSize }}
+  {{- end }}
+  {{- if not (eq (int .Values.auditLogging.queueDrainIntervalMs) 500) }}
+  audit_queue_drain_interval_ms: {{ .Values.auditLogging.queueDrainIntervalMs }}
+  {{- end }}
+  {{- if not (eq (int .Values.auditLogging.queueMaxBufferSizePerShard) 1048576) }}
+  audit_queue_max_buffer_size_per_shard: {{ .Values.auditLogging.queueMaxBufferSizePerShard }}
+  {{- end }}
+  {{- if not (eq (int .Values.auditLogging.partitions) 12) }}
+  audit_log_num_partitions: {{ .Values.auditLogging.partitions }}
+  {{- end }}
+    {{- if dig "enabledEventTypes" "" .Values.auditLogging }}
+  audit_enabled_event_types:
+      {{- with .Values.auditLogging.enabledEventTypes }}
+        {{- toYaml . | nindent 2 }}
+      {{- end }}
+    {{- end }}
+    {{- if dig "excludedTopics" "" .Values.auditLogging }}
+  audit_excluded_topics:
+      {{- with .Values.auditLogging.excludedTopics }}
+        {{- toYaml . | nindent 2 }}
+      {{- end }}
+    {{- end }}
+    {{- if dig "excludedPrincipals" "" .Values.auditLogging }}
+  audit_excluded_principals:
+      {{- with .Values.auditLogging.excludedPrincipals }}
+        {{- toYaml . | nindent 2 }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+  audit_enabled: false
+  {{- end }}
+{{- end }}
 {{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
   {{- $tieredStorageConfig := (include "storage-tiered-config" .|fromJson) }}
   {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_cache_directory" }}
@@ -163,6 +201,44 @@ redpanda.yaml: |
     {{- end }}
   {{- end }}
 {{- end -}}
+{{/* AUDIT LOGS */}}
+{{- if (include "redpanda-atleast-23-3-0" . | fromJson).bool }}
+  {{- if and ( dig "enabled" "false" .Values.auditLogging ) (include "sasl-enabled" $root | fromJson).bool }}
+    audit_enabled: true
+  {{- if not (eq (int .Values.auditLogging.clientMaxBufferSize) 16777216) }}
+    audit_client_max_buffer_size: {{ .Values.auditLogging.clientMaxBufferSize }}
+  {{- end }}
+  {{- if not (eq (int .Values.auditLogging.queueDrainIntervalMs) 500) }}
+    audit_queue_drain_interval_ms: {{ .Values.auditLogging.queueDrainIntervalMs }}
+  {{- end }}
+  {{- if not (eq (int .Values.auditLogging.queueMaxBufferSizePerShard) 1048576) }}
+    audit_queue_max_buffer_size_per_shard: {{ .Values.auditLogging.queueMaxBufferSizePerShard }}
+  {{- end }}
+  {{- if not (eq (int .Values.auditLogging.partitions) 12) }}
+    audit_log_num_partitions: {{ .Values.auditLogging.partitions }}
+  {{- end }}
+    {{- if dig "enabledEventTypes" "" .Values.auditLogging }}
+    audit_enabled_event_types:
+      {{- with .Values.auditLogging.enabledEventTypes }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
+    {{- if dig "excludedTopics" "" .Values.auditLogging }}
+    audit_excluded_topics:
+      {{- with .Values.auditLogging.excludedTopics }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
+    {{- if dig "excludedPrincipals" "" .Values.auditLogging }}
+    audit_excluded_principals:
+      {{- with .Values.auditLogging.excludedPrincipals }}
+        {{- toYaml . | nindent 4 }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    audit_enabled: false
+  {{- end }}
+{{- end }}
 {{/* LISTENERS */}}
 {{/* Admin API */}}
 {{- $service := .Values.listeners.admin }}
@@ -186,7 +262,7 @@ redpanda.yaml: |
         require_client_auth: {{ $service.tls.requireClientAuth }}
   {{- $cert := get .Values.tls.certs $service.tls.cert }}
   {{- if empty $cert }}
-    {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- fail (printf "Certificate used but not defined")}}
   {{- end }}
   {{- if $cert.caEnabled }}
         truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
@@ -247,7 +323,7 @@ redpanda.yaml: |
         require_client_auth: {{ $kafkaService.tls.requireClientAuth }}
   {{- $cert := get .Values.tls.certs $kafkaService.tls.cert }}
   {{- if empty $cert }}
-    {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- fail (printf "Certificate used but not defined")}}
   {{- end }}
   {{- if $cert.caEnabled }}
         truststore_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/ca.crt
@@ -293,7 +369,7 @@ redpanda.yaml: |
       require_client_auth: {{ $service.tls.requireClientAuth }}
   {{- $cert := get .Values.tls.certs $service.tls.cert }}
   {{- if empty $cert }}
-    {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- fail (printf "Certificate used but not defined")}}
   {{- end }}
   {{- if $cert.caEnabled }}
       truststore_file: /etc/tls/certs/{{ $service.tls.cert }}/ca.crt
@@ -325,10 +401,10 @@ redpanda.yaml: |
   {{- $schemaRegistryService := .Values.listeners.schemaRegistry }}
   schema_registry_client:
     brokers:
-      {{- range (include "seed-server-list" $root | mustFromJson) }}
-    - address: {{ . }}
+    {{- range $id, $item := $root.tempConfigMapServerList }}
+    - address: {{ $item.host.address }}
       port: {{  $kafkaService.port }}
-      {{- end }}
+    {{- end }}
     {{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
     broker_tls:
       enabled: true
@@ -337,7 +413,7 @@ redpanda.yaml: |
       key_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/tls.key
       {{- $cert := get .Values.tls.certs $kafkaService.tls.cert }}
       {{- if empty $cert }}
-        {{- fail (printf "Certificate, '%s', used but not defined")}}
+        {{- fail (printf "Certificate used but not defined")}}
       {{- end }}
       {{- if $cert.caEnabled }}
       truststore_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/ca.crt
@@ -383,7 +459,7 @@ redpanda.yaml: |
         require_client_auth: {{ $schemaRegistryService.tls.requireClientAuth }}
     {{- $cert := get .Values.tls.certs $schemaRegistryService.tls.cert }}
     {{- if empty $cert }}
-      {{- fail (printf "Certificate, '%s', used but not defined")}}
+      {{- fail ( printf "Certificate used but not defined" )}}
     {{- end }}
     {{- if $cert.caEnabled }}
         truststore_file: /etc/tls/certs/{{ $schemaRegistryService.tls.cert }}/ca.crt
@@ -401,7 +477,7 @@ redpanda.yaml: |
       {{- $certPath := printf "/etc/tls/certs/%s" $certName }}
       {{- $cert := get $values.tls.certs $certName }}
       {{- if empty $cert }}
-        {{- fail (printf "Certificate, '%s', used but not defined")}}
+        {{- fail ( printf "Certificate, '%s', used but not defined" $certName )}}
       {{- end }}
       - name: {{ $name }}
         enabled: true
@@ -417,13 +493,22 @@ redpanda.yaml: |
     {{- end }}
   {{- end }}
 {{- end -}}
+{{/* AUDIT LOGS: Client Details */}}
+{{- if (include "redpanda-atleast-23-3-0" . | fromJson).bool }}
+  {{- if and ( dig "enabled" "false" .Values.auditLogging ) (include "sasl-enabled" $root | fromJson).bool }}
+    {{- if not ( empty ( include "kafka-brokers-sasl-enabled" . | fromJson ) ) }}
+  audit_log_client:
+    {{- include "kafka-brokers-sasl-enabled" . | nindent 4 -}}
+    {{- end }}
+  {{- end }}
+{{- end }}
 {{/* HTTP Proxy */}}
 {{- if and .Values.listeners.http.enabled (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
   {{- $HTTPService := .Values.listeners.http }}
   pandaproxy_client:
     brokers:
-  {{- range (include "seed-server-list" $root | mustFromJson) }}
-    - address: {{ . }}
+  {{- range $id, $item := $root.tempConfigMapServerList }}
+    - address: {{ $item.host.address }}
       port: {{  $kafkaService.port }}
   {{- end }}
   {{- if (include "kafka-internal-tls-enabled" . | fromJson).bool }}
@@ -434,7 +519,7 @@ redpanda.yaml: |
       key_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/tls.key
   {{- $cert := get .Values.tls.certs $kafkaService.tls.cert }}
   {{- if empty $cert }}
-    {{- fail (printf "Certificate, '%s', used but not defined")}}
+    {{- fail (printf "Certificate used but not defined")}}
   {{- end }}
   {{- if $cert.caEnabled }}
       truststore_file: /etc/tls/certs/{{ $kafkaService.tls.cert }}/ca.crt
@@ -473,7 +558,7 @@ redpanda.yaml: |
         require_client_auth: {{ $HTTPService.tls.requireClientAuth }}
     {{- $cert := get .Values.tls.certs $HTTPService.tls.cert }}
     {{- if empty $cert }}
-      {{- fail (printf "Certificate, '%s', used but not defined")}}
+      {{- fail (printf "Certificate used but not defined")}}
     {{- end }}
     {{- if $cert.caEnabled }}
         truststore_file: /etc/tls/certs/{{ $HTTPService.tls.cert }}/ca.crt
@@ -491,7 +576,7 @@ redpanda.yaml: |
       {{- $certPath := printf "/etc/tls/certs/%s" $certName }}
       {{- $cert := get $values.tls.certs $certName }}
       {{- if empty $cert }}
-        {{- fail (printf "Certificate, '%s', used but not defined")}}
+        {{- fail (printf "Certificate, '%s', used but not defined" $certName )}}
       {{- end }}
       - name: {{ $name }}
         enabled: true

--- a/charts/redpanda/templates/tests/test-auditLogging.yaml
+++ b/charts/redpanda/templates/tests/test-auditLogging.yaml
@@ -1,0 +1,94 @@
+{{/*
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+  
+  http://www.apache.org/licenses/LICENSE-2.0
+  
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+*/}}
+{{/* 
+  This feature is gated by having a license, and it must have sasl enabled, we assume these conditions are met
+  as part of setting auditLogging being enabled.
+*/}}
+{{- if and .Values.auditLogging.enabled (include "redpanda-atleast-23-3-0" . | fromJson).bool }}
+{{- $rpk := deepCopy . }}
+{{- $sasl := .Values.auth.sasl }}
+{{- $_ := set $rpk "rpk" "rpk" }}
+{{- $_ := set $rpk "dummySasl" false }}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "redpanda.fullname" . }}-test-audit-logging"
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+  {{- with include "full.labels" . }}
+  {{- . | nindent 4 }}
+  {{- end }}
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  restartPolicy: Never
+  securityContext: {{ include "pod-security-context" . | nindent 4 }}
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets: { { - toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: {{ template "redpanda.name" . }}
+      image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
+      command:
+        - /usr/bin/timeout
+        - "120"
+        - bash
+        - -c
+        - |
+          set -xe
+          old_setting=${-//[^x]/}
+          audit_topic_name="_redpanda.audit_log"
+          expected_partitions={{ .Values.auditLogging.partitions }}
+          
+          # sasl configurations
+          set +x
+          IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
+          {{- if (include "redpanda-atleast-23-2-1" . | fromJson).bool }}
+          RPK_SASL_MECHANISM=${RPK_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- else }}
+          REDPANDA_SASL_MECHANISM=${REDPANDA_SASL_MECHANISM:-{{ .Values.auth.sasl.mechanism | upper }}}
+          {{- end }}
+          export {{ include "rpk-sasl-environment-variables" . }}
+          if [[ -n "$old_setting" ]]; then set -x; fi
+        
+          {{- $i := .Values.statefulset.replicas }}
+          {{- $default_topic_replicas := sub (add $i (mod $i 2)) 1 }}
+          # wait for post-upgrade job to update the default_topic_replications value
+          timeout 600 bash -c "until [[ $(rpk cluster config get default_topic_replications) = {{ $default_topic_replicas }} ]]; do sleep 1; done"
+          
+          # now run the to determine if we have the right results
+          # should describe topic without error
+          rpk topic describe ${audit_topic_name}
+          # should get the expected values
+          result=$(rpk topic list | grep ${audit_topic_name})
+          name=$(echo $result | awk '{print $1}')
+          partitions=$(echo $result | awk '{print $2}')
+          if [ "${name}" != "${audit_topic_name}" ]; then
+            echo "expected topic name does not match"
+            exit 1
+          fi
+          if [ ${partitions} != ${expected_partitions} ]; then
+            echo "expected partition size did not match"
+            exit 1
+          fi
+      volumeMounts: {{ include "default-mounts" . | nindent 8 }}
+      resources:
+{{- toYaml .Values.statefulset.resources | nindent 12 }}
+      securityContext: {{ include "container-security-context" . | nindent 8 }}
+  volumes: {{ include "default-volumes" . | nindent 4 }}
+{{- end }}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -1552,6 +1552,38 @@
           }
         }
       }
+    },
+    "auditLogging": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        },
+        "listener": {
+          "type": "string"
+        },
+        "partitions": {
+          "type": "integer"
+        },
+        "enabledEventTypes": {
+          "type": ["array", "null"]
+        },
+        "excludedTopics": {
+          "type": ["array", "null"]
+        },
+        "excludedPrincipals": {
+          "type": ["array", "null"]
+        },
+        "clientMaxBufferSize": {
+          "type": "integer"
+        },
+        "queueDrainIntervalMs": {
+          "type": "integer"
+        },
+        "queueMaxBufferSizePerShard": {
+          "type": "integer"
+        }
+      }
     }
   }
 }

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -87,6 +87,30 @@ license_secret_ref: {}
   # secret_name: my-secret
   # secret_key: key-where-license-is-stored
 
+# -- Audit logging for a redpanda cluster, must have enabled sasl and have one kafka listener supporting sasl authentication
+# for audit logging to work. Note this feature is only available for redpanda versions >= v23.3.0.
+auditLogging:
+  # -- Enable or disable audit logging, for production clusters we suggest you enable,
+  # however, this will only work if you also enable sasl and a listener with sasl enabled.
+  enabled: false
+  # -- Kafka listener name, note that it must have `authenticationMethod` set to sasl
+  # 'internal' if using internal listener, else use external listener name, e.g., default.
+  listener: internal
+  # -- Integer value defining the number of partitions used by a newly created audit topic.
+  partitions: 12
+  # -- Event types that should be captured by audit logs, default is ["admin", "authenticate", "management"].
+  enabledEventTypes:
+  # -- List of topics to exclude from auditing, default is null.
+  excludedTopics:
+  # -- List of principals to exclude from auditing, default is null.
+  excludedPrincipals:
+  # -- Defines the number of bytes (in bytes) allocated by the internal audit client for audit messages.
+  clientMaxBufferSize: 16777216
+  # -- In ms, frequency in which per shard audit logs are batched to client for write to audit log.
+  queueDrainIntervalMs: 500
+  # -- Defines the maximum amount of memory used (in bytes) by the audit buffer in each shard.
+  queueMaxBufferSizePerShard: 1048576
+
 # -- Enterprise (optional)
 # For details,
 # see the [License documentation](https://docs.redpanda.com/docs/get-started/licenses/?platform=kubernetes#redpanda-enterprise-edition).


### PR DESCRIPTION
Fixes https://github.com/redpanda-data/team-kubernetes-internal/issues/31

Note that this is essentially a new feature we are adding to the helm chart, as such, we expect the following to happen to consider this complete:


Sample values: 
```
auditLogging:
  enabled: true
  listener: default
  partitions: 12
```
