### PR TITLE
prometheus service monitor change to fix deprecated api field

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.6.65
+version: 5.6.66
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/servicemonitor.yaml
+++ b/charts/redpanda/templates/servicemonitor.yaml
@@ -33,7 +33,7 @@ spec:
   endpoints:
   - interval: {{ .Values.monitoring.scrapeInterval }}
     path: /public_metrics
-    targetPort: admin
+    port: admin
     {{- if dig "enableHttp2" "" .Values.monitoring }}
     enableHttp2: .Values.monitoring.enableHttp2
     {{- end }}


### PR DESCRIPTION
Fixes #936 

Updates and addresses the deprecated servicemonitor field: spec.targetPort in favor of the replacement spec.port