### PR TITLE
Enable users to add connectors extra environment variables

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.5
+version: 5.7.6
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/connectors/connectors.yaml
+++ b/charts/redpanda/templates/connectors/connectors.yaml
@@ -40,6 +40,7 @@ limitations under the License.
 
 {{ $extraVolumes := list }}
 {{ $extraVolumeMounts := list }}
+{{ $extraEnv := .Values.connectors.deployment.extraEnv }}
 {{ $command := list }}
 {{ if (include "sasl-enabled" . | fromJson).bool }}
   {{ $command = concat $command (list "bash" "-c") }}
@@ -75,6 +76,10 @@ limitations under the License.
     "name" (printf "%s-user-password" ((include "redpanda.fullname" .)) | trunc 49)
     "mountPath" "/opt/kafka/connect-password/rc-credentials"
   )}}
+  {{ $extraEnv = append $extraEnv (dict
+            "name" "CONNECT_SASL_PASSWORD_FILE"
+            "value" "rc-credentials/password"
+  )}}
   {{  $connectorsValues := merge $connectorsValues (dict
     "Values" (dict
       "storage" (dict
@@ -88,12 +93,7 @@ limitations under the License.
       )
       "deployment" (dict
         "command" $command
-        "extraEnv" (list
-          (dict
-            "name" "CONNECT_SASL_PASSWORD_FILE"
-            "value" "rc-credentials/password"
-          )
-        )
+        "extraEnv" $extraEnv
       )
     )
   )}}


### PR DESCRIPTION
Using the following helm values I was able to confirm that extra environment variable was added.

```
auth:
  sasl:
    enabled: true
connectors:
  enabled: true
  deployment:
    extraEnv:
    - name: test
      value: some-test
```

Fix #959 