### PR TITLE
chore: bump version of operator chart to v2.1.11-23.3.1

### DIFF
--- a/.github/workflows/pull_requests_operator.yaml
+++ b/.github/workflows/pull_requests_operator.yaml
@@ -99,11 +99,10 @@ jobs:
           version: v3.11.1
 
       - name: Get appVersion
+        id: app_version
         uses: mikefarah/yq@master
-        run: |
-          appVersion=$(yq .appVersion charts/operator/Chart.yaml)
-          echo $appVersion
-          echo appVersion=$appVersion >> "$GITHUB_OUTPUT"
+        with:
+          cmd: yq .appVersion charts/operator/Chart.yaml
 
       - name: Set up chart-testing
         uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
@@ -143,7 +142,7 @@ jobs:
       - name: Install CRDs
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=$(steps.list-changed.outputs.appVersion) | kubectl apply -f -
+          kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=${{ steps.app_version.outputs.result }} | kubectl apply -f -
 
       - name: Run chart-testing (install and upgrade)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/pull_requests_operator.yaml
+++ b/.github/workflows/pull_requests_operator.yaml
@@ -74,7 +74,6 @@ jobs:
           git checkout main
           git checkout -
 
-
       - name: install dyff
         run: curl -Ls https://github.com/homeport/dyff/releases/download/v1.5.6/dyff_1.5.6_linux_amd64.tar.gz | tar xzv dyff
       - name: compare operator values with main
@@ -94,11 +93,17 @@ jobs:
           git checkout main
           git checkout -
 
-
       - name: Set up Helm
         uses: azure/setup-helm@v3
         with:
           version: v3.11.1
+
+      - name: Get appVersion
+        uses: mikefarah/yq@master
+        run: |
+          appVersion=$(yq .appVersion charts/operator/Chart.yaml)
+          echo $appVersion
+          echo appVersion=$appVersion >> "$GITHUB_OUTPUT"
 
       - name: Set up chart-testing
         uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
@@ -138,7 +143,7 @@ jobs:
       - name: Install CRDs
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
+          kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=$(steps.list-changed.outputs.appVersion) | kubectl apply -f -
 
       - name: Run chart-testing (install and upgrade)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.12
+version: 0.4.13
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
-appVersion: v2.1.10-23.2.18
+appVersion: v2.1.11-23.3.1
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,11 +34,11 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.10-23.2.18
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.11-23.3.1
     - name: configurator
-      image: docker.redpanda.com/redpandadata/configurator:v2.1.10-23.2.18
+      image: docker.redpanda.com/redpandadata/configurator:v2.1.11-23.3.1
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.2.20
+      image: docker.redpanda.com/redpandadata/redpanda:v23.3.1
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   artifacthub.io/crds: |

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -23,8 +23,10 @@ discovered.
 1. Install Redpanda operator CRDs:
 
 ```sh
-kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd | kubectl apply -f -
+kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=<appVersion> | kubectl apply -f -
 ```
+
+where `appVersion` is the version of the operator image you are installing.
 
 > The CRDs are decoupled from helm chart, so that helm release can be managed with fewer privileges.
 > The CRDs need to be installed by someone with cluster-level privileges, but once installed the

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -26,7 +26,7 @@ discovered.
 kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref=<appVersion> | kubectl apply -f -
 ```
 
-where `appVersion` is the version of the operator image you are installing.
+where `appVersion` is the [version of the operator](https://github.com/redpanda-data/redpanda-operator/releases) image you are installing.
 
 > The CRDs are decoupled from helm chart, so that helm release can be managed with fewer privileges.
 > The CRDs need to be installed by someone with cluster-level privileges, but once installed the


### PR DESCRIPTION
Update documentation and version of operator chart to use latest redpanda-operator version. 