### PR TITLE
fix: sidecar-controllers RBAC resources incorrectly format serviceAccount.annotations

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.12
+version: 5.7.13
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/templates/rbac.yaml
+++ b/charts/redpanda/templates/rbac.yaml
@@ -121,7 +121,7 @@ metadata:
   {{- . | nindent 4 }}
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
-annotations:
+  annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
@@ -154,7 +154,7 @@ metadata:
   {{- . | nindent 4 }}
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
-annotations:
+  annotations:
   {{- toYaml . | nindent 4 }}
     {{- end }}
 roleRef:
@@ -175,7 +175,7 @@ metadata:
   {{- . | nindent 4 }}
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
-annotations:
+  annotations:
   {{- toYaml . | nindent 4 }}
     {{- end }}
 rules:
@@ -226,7 +226,7 @@ metadata:
   {{- . | nindent 4 }}
   {{- end }}
   {{- with .Values.serviceAccount.annotations }}
-annotations:
+  annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:


### PR DESCRIPTION
The generated YAML for `Role` / `RoleBinding` / `ClusterRole` / `ClusterRoleBinding` for sidecar-controllers
incorrectly indents annotations YAML when `serviceAccount.annotations` is set

```yaml
sideCars:
  controllers:
    enabled: true
```


