### PR TITLE
redpanda: don't set `tlsConfig` in ServiceMonitor if `tls.enabled` is false

### DIFF
--- a/charts/redpanda/templates/servicemonitor.yaml
+++ b/charts/redpanda/templates/servicemonitor.yaml
@@ -37,7 +37,7 @@ spec:
     {{- if dig "enableHttp2" "" .Values.monitoring }}
     enableHttp2: .Values.monitoring.enableHttp2
     {{- end }}
-  {{- if or .Values.tls.enabled .Values.monitoring.tlsConfig }}
+  {{- if .Values.tls.enabled }}
     scheme: https
     tlsConfig:
       {{- if  dig "tlsConfig" dict .Values.monitoring }}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -308,6 +308,7 @@ monitoring:
   # Enables http2 for scraping metrics for prometheus. Used when Istio's mTLS is enabled and using tlsConfig.
   # enableHttp2: true
   tlsConfig: {}
+    # Note: `tlsConfig` will be ignored unless `tls.enabled` is true.
     # caFile: /etc/prom-certs/root-cert.pem
     # certFile: /etc/prom-certs/cert-chain.pem
     # insecureSkipVerify: true


### PR DESCRIPTION
Previously, if `tls.enabled` was false but monitoring was enabled (`monitoring.enabled=true`) the `ServiceMonitor` object would incorrectly render a `tlsConfig` and set `scheme` to `https`.

This was due to the default value of `monitoring.tlsConfig={}` being evaluated as truthy.

This commit removes the `monitoring.tlsConfig` check entirely as there are further checks within the stanza. To mitigate any confusion an note as been added to the values.yml file.

Fixes #573

---

This is a _speculative_ fix. I've realized that I can't reproduce the original problem as described. Though I do not have a cluster on hand to test against so I've just been using `--dry-run='client'`.

`helm template foo . --dry-run='client' --debug --set 'tls.enabled=false,monitoring.enabled=true'` doesn't produce the bugged output and I haven't been able to track down helm's documentation on truthiness vs falseyness. Just yet.