### PR TITLE
Removes version checks for operator helm chart

### DIFF
--- a/.github/workflows/nightly_version_checks.yaml
+++ b/.github/workflows/nightly_version_checks.yaml
@@ -26,7 +26,8 @@ jobs:
         chart:
           - redpanda
           - console
-          - operator
+# Operator changed it's versioning scheme, so that version checks wrongly open PRs
+#          - operator
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
## Reference

Wrong version bump PR https://github.com/redpanda-data/helm-charts/pull/978