### PR TITLE
Add roles required for managed decommission

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.15
+version: 0.4.16
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.15](https://img.shields.io/badge/Version-0.4.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.12-23.3.3](https://img.shields.io/badge/AppVersion-v2.1.12--23.3.3-informational?style=flat-square)
+![Version: 0.4.16](https://img.shields.io/badge/Version-0.4.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.12-23.3.3](https://img.shields.io/badge/AppVersion-v2.1.12--23.3.3-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/operator/templates/role.yaml
+++ b/charts/operator/templates/role.yaml
@@ -223,9 +223,19 @@ rules:
   resources:
     - pods
   verbs:
+    - delete
     - get
     - list
+    - patch
+    - update
     - watch
+- apiGroups:
+    - ""
+  resources:
+    - pods/status
+  verbs:
+    - patch
+    - update
 - apiGroups:
     - ""
   resources:


### PR DESCRIPTION
If managed decommission is enabled for Redpanda resource, then operator is unable to update/patch Pod.Status filed. This change corrects configuration drift.

### Reference

https://github.com/redpanda-data/redpanda-operator/pull/49

specifically

https://github.com/redpanda-data/redpanda-operator/blob/1cc502e985d012290b6fe448dadf7b4daa6f46f7/src/go/k8s/internal/controller/redpanda/managed_decommission_controller.go#L48

Fixes https://github.com/redpanda-data/redpanda-operator/issues/74