### PR TITLE
Allow single template for all Redpanda Pods external advertise addresses

### DIFF
--- a/.github/workflows/pull_requests_redpanda.yaml
+++ b/.github/workflows/pull_requests_redpanda.yaml
@@ -98,6 +98,7 @@ jobs:
           - '14*'
           - '15*'
           - '1[6-7]*'
+          - '18*'
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.18
+version: 5.7.19
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.7.18](https://img.shields.io/badge/Version-5.7.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
+![Version: 5.7.19](https://img.shields.io/badge/Version-5.7.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/ci/18-single-external-address-values.yaml
+++ b/charts/redpanda/ci/18-single-external-address-values.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# the number of replicas should match the length of the addresses
+statefulset:
+  replicas: 3
+
+external:
+  enabled: true
+  domain: my-domain
+  addresses:
+  - $PREFIX_TEMPLATE
+  prefixTemplate: $POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum
+    | head -c 7)

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -524,10 +524,16 @@ advertised-host returns a json string with the data needed for configuring the a
 {{- define "advertised-host" -}}
   {{- $host := dict "name" .externalName "address" .externalAdvertiseAddress "port" .port -}}
   {{- if .values.external.addresses -}}
-    {{- if ( .values.external.domain | default "" ) }}
-      {{- $host = dict "name" .externalName "address" (printf "%s.%s" (index .values.external.addresses .replicaIndex) (.values.external.domain)) "port" .port -}}
+    {{- $address := "" -}}
+    {{- if gt (len .values.external.addresses) 1 -}}
+      {{- $address = (index .values.external.addresses .replicaIndex) -}}
     {{- else -}}
-      {{- $host = dict "name" .externalName  "address" (index .values.external.addresses .replicaIndex) "port" .port -}}
+      {{- $address = (index .values.external.addresses 0) -}}
+    {{- end -}}
+    {{- if ( .values.external.domain | default "" ) }}
+      {{- $host = dict "name" .externalName "address" (printf "%s.%s" $address .values.external.domain) "port" .port -}}
+    {{- else -}}
+      {{- $host = dict "name" .externalName  "address" $address "port" .port -}}
     {{- end -}}
   {{- end -}}
   {{- toJson $host -}}

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -267,6 +267,8 @@ external:
   # The number of brokers is defined in statefulset.replicas.
   # The values can be IP addresses or DNS names.
   # If external.domain is set, the domain is appended to these values.
+  # There is an option to define a single external address for all brokers and leverage
+  # prefixTemplate as it will be calculated during initContainer execution.
   # addresses:
   # - redpanda-0
   # - redpanda-1


### PR DESCRIPTION
The implementation of external addresses was done for static list. In some environments there could be automation developed to register DNS name dynamically based on certain property of a Pod like:
* The K8S Node IP that can be hash out
* Pod ordinal

With the combination of `external` `domain`, `prefixTemplate` and single entry in `addresses` list the full StatefulSet rollout wouldn't be needed when user scale up or down the cluster.

## Reference

https://github.com/redpanda-data/helm-charts/blob/75ec4bb892124a9e8a71b911e3a920f227a8e7d7/charts/redpanda/templates/statefulset.yaml#L57
https://github.com/redpanda-data/helm-charts/pull/814
https://github.com/redpanda-data/helm-charts/issues/813
https://github.com/redpanda-data/helm-charts/issues/996
