### PR TITLE
Bump operator version to the latest release v2.1.14-23.3.4

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.17
+version: 0.4.18
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
-appVersion: v2.1.13-23.3.4
+appVersion: v2.1.14-23.3.4
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,9 +34,9 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.13-23.3.4
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.14-23.3.4
     - name: configurator
-      image: docker.redpanda.com/redpandadata/configurator:v2.1.13-23.3.4
+      image: docker.redpanda.com/redpandadata/configurator:v2.1.14-23.3.4
     - name: redpanda
       image: docker.redpanda.com/redpandadata/redpanda:v23.3.4
     - name: kube-rbac-proxy

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.17](https://img.shields.io/badge/Version-0.4.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.13-23.3.4](https://img.shields.io/badge/AppVersion-v2.1.13--23.3.4-informational?style=flat-square)
+![Version: 0.4.18](https://img.shields.io/badge/Version-0.4.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.14-23.3.4](https://img.shields.io/badge/AppVersion-v2.1.14--23.3.4-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 


### PR DESCRIPTION
https://github.com/redpanda-data/redpanda-operator/releases/tag/v2.1.14-23.3.4