### PR TITLE
Fix volume name reference when name is overwritten

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.19
+version: 5.7.20
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.7.19](https://img.shields.io/badge/Version-5.7.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
+![Version: 5.7.20](https://img.shields.io/badge/Version-5.7.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -383,7 +383,7 @@ spec:
         - name: tiered-storage-dir
           {{- if eq $tieredType "persistentVolume" }}
           persistentVolumeClaim:
-            claimName: tiered-storage-dir
+            claimName: {{ default "tiered-storage-dir" .Values.storage.persistentVolume.nameOverwrite }}
           {{- else if eq $tieredType "hostPath" }}
           hostPath:
             path: {{ include "storage-tiered-hostpath" . }}


### PR DESCRIPTION
After setting `.storage.persistentVolume.nameOverwrite` the volume that
references `persistentVolumeClaim` should be adjusted too, because StatefulSet
controller rightfully reports an event:
```
0/6 nodes are available: 6 persistentvolumeclaim "tiered-storage-dir" not found. preemption: 0/6 nodes are available: 6 Preemption is not helpful for scheduling.
```