### PR TITLE
redpanda: correctly set tiered storage keys

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.20
+version: 5.7.21
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.7.20](https://img.shields.io/badge/Version-5.7.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
+![Version: 5.7.21](https://img.shields.io/badge/Version-5.7.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -354,13 +354,13 @@ stringData:
     {{- if (include "storage-tiered-credentials-secret-key" . | fromJson).bool }}
     set +x
     echo Setting {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} configuration
-    rpk redpanda config --config "$CONFIG" set {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} $CLOUD_STORAGE_SECRET_KEY
+    rpk cluster config --config "$CONFIG" set {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} $CLOUD_STORAGE_SECRET_KEY
     set -x
     {{- end }}
     {{- if and .Values.storage.tiered.credentialsSecretRef.accessKey.name .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
     set +x
     echo Setting {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} configuration
-    rpk redpanda config --config "$CONFIG" set {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} $CLOUD_STORAGE_ACCESS_KEY
+    rpk cluster config --config "$CONFIG" set {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} $CLOUD_STORAGE_ACCESS_KEY
     set -x
     {{- end }}
 {{- if .Values.statefulset.initContainers.fsValidator.enabled}}


### PR DESCRIPTION
Previously, tiered storage access and secret keys were being set by running `rpk redpanda config set`. Doing set pushes the configurations to the `redpanda.yml` file, where they do nothing.

As `cloud_storage_{access,secret}_key` are cluster level settings, they must be set via `rpk cluster config set`.

This commit updates the commands accordingly.

See #968