### PR TITLE
Fix volume definition when volumeClaimTemplate is used

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.21
+version: 5.7.22
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.7.21](https://img.shields.io/badge/Version-5.7.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
+![Version: 5.7.22](https://img.shields.io/badge/Version-5.7.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+storage:
+  tiered:
+    mountType: persistentVolume
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file
+      cloud_storage_access_key: "${AWS_ACCESS_KEY_ID}"
+      cloud_storage_secret_key: "${AWS_SECRET_ACCESS_KEY}"
+      cloud_storage_region: "${AWS_REGION}"
+      cloud_storage_bucket: "${TEST_BUCKET}"
+      cloud_storage_segment_max_upload_interval_sec: 1
+enterprise:
+  license: "${REDPANDA_SAMPLE_LICENSE}"
+
+console:
+  # Until https://github.com/redpanda-data/console-enterprise/pull/256 is released the console
+  # test named `test-license-with-console.yaml` needs to work with unreleased Redpanda Console version.
+  image:
+    registry: redpandadata
+    repository: console-unstable
+    tag: master-8a51854

--- a/charts/redpanda/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl
@@ -1,0 +1,48 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+storage:
+  tiered:
+    mountType: persistentVolume
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_api_endpoint: storage.googleapis.com
+      cloud_storage_credentials_source: config_file
+      cloud_storage_region: "US-WEST1"
+      cloud_storage_bucket: "${TEST_BUCKET}"
+      cloud_storage_segment_max_upload_interval_sec: 1
+      cloud_storage_access_key: "${GCP_ACCESS_KEY_ID}"
+      cloud_storage_secret_key: "${GCP_SECRET_ACCESS_KEY}"
+enterprise:
+  license: "${REDPANDA_SAMPLE_LICENSE}"
+
+
+resources:
+  cpu:
+    cores: 400m
+  memory:
+    container:
+      max: 2.0Gi
+    redpanda:
+      memory: 1Gi
+      reserveMemory: 100Mi
+
+console:
+  # Until https://github.com/redpanda-data/console-enterprise/pull/256 is released the console
+  # test named `test-license-with-console.yaml` needs to work with unreleased Redpanda Console version.
+  image:
+    registry: redpandadata
+    repository: console-unstable
+    tag: master-8a51854

--- a/charts/redpanda/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl
@@ -1,0 +1,49 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+storage:
+  persistentVolume:
+    storageClass: managed-csi
+  tiered:
+    mountType: persistentVolume
+    persistentVolume:
+      storageClass: managed-csi
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file
+      cloud_storage_segment_max_upload_interval_sec: 1
+      cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
+      cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
+      cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
+enterprise:
+    license: "${REDPANDA_SAMPLE_LICENSE}"
+
+resources:
+  cpu:
+    cores: 400m
+  memory:
+    container:
+      max: 2.0Gi
+    redpanda:
+      memory: 1Gi
+      reserveMemory: 100Mi
+
+console:
+  # Until https://github.com/redpanda-data/console-enterprise/pull/256 is released the console
+  # test named `test-license-with-console.yaml` needs to work with unreleased Redpanda Console version.
+  image:
+    registry: redpandadata
+    repository: console-unstable
+    tag: master-8a51854

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -379,12 +379,9 @@ spec:
       {{- end }}
       {{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
         {{- $tieredType := include "storage-tiered-mountType" . }}
-        {{- if ne $tieredType "none" }}
+        {{- if and (ne $tieredType "none") (ne $tieredType "persistentVolume") }}
         - name: tiered-storage-dir
-          {{- if eq $tieredType "persistentVolume" }}
-          persistentVolumeClaim:
-            claimName: {{ default "tiered-storage-dir" .Values.storage.persistentVolume.nameOverwrite }}
-          {{- else if eq $tieredType "hostPath" }}
+          {{- if eq $tieredType "hostPath" }}
           hostPath:
             path: {{ include "storage-tiered-hostpath" . }}
           {{- else }}


### PR DESCRIPTION
Dedicated PesistentVolumeClaim will be created by the volumeClaimTemplate definition inside StatefulSet and reference will be added to Pod volume list.

Currently Pods are getting none existent reference to PersistentVolumeClaim if storage.tiered.mountType is set to `persistentVolume`.
```
volumes:
  - name: shadow-index-cache
    persistentVolumeClaim:
      claimName: shadow-index-cache-rp-cmue6bgoajp9du05hqvg-2
  - name: datadir
    persistentVolumeClaim:
      claimName: datadir-rp-cmue6bgoajp9du05hqvg-2
  - name: tiered-storage-dir
    persistentVolumeClaim:
      claimName: shadow-index-cache
```