### PR TITLE
Fix volumeMounts when tiered storage uses nameOverwrite

### DIFF
--- a/.buildkite/hooks/pre-command
+++ b/.buildkite/hooks/pre-command
@@ -59,6 +59,8 @@ test_eks() {
     export KUBECONFIG
 
     envsubst < ./charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl > ./charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml
+    envsubst < ./charts/redpanda/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl > ./charts/redpanda/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml
+    envsubst < ./charts/redpanda/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl > ./charts/redpanda/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml
 }
 
 test_gke() {
@@ -105,6 +107,8 @@ test_gke() {
     buildkite-agent artifact upload $KUBECONFIG
 
     envsubst < ./charts/redpanda/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl > ./charts/redpanda/ci/22-gke-tiered-storage-with-creds-values.yaml
+    envsubst < ./charts/redpanda/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl > ./charts/redpanda/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml
+    envsubst < ./charts/redpanda/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl > ./charts/redpanda/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml
 }
 
 test_aks() {
@@ -172,6 +176,8 @@ test_aks() {
     buildkite-agent artifact upload $KUBECONFIG
 
     envsubst < ./charts/redpanda/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl > ./charts/redpanda/ci/23-aks-tiered-storage-with-creds-values.yaml
+    envsubst < ./charts/redpanda/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl > ./charts/redpanda/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml
+    envsubst < ./charts/redpanda/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl > ./charts/redpanda/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml
 }
 
 test_"${CLOUD_PROVIDER}"

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.22
+version: 5.7.23
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl
@@ -1,0 +1,38 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+storage:
+  persistentVolume:
+    nameOverwrite: shadow-index-cache
+  tiered:
+    mountType: persistentVolume
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file
+      cloud_storage_access_key: "${AWS_ACCESS_KEY_ID}"
+      cloud_storage_secret_key: "${AWS_SECRET_ACCESS_KEY}"
+      cloud_storage_region: "${AWS_REGION}"
+      cloud_storage_bucket: "${TEST_BUCKET}"
+      cloud_storage_segment_max_upload_interval_sec: 1
+enterprise:
+  license: "${REDPANDA_SAMPLE_LICENSE}"
+
+console:
+  # Until https://github.com/redpanda-data/console-enterprise/pull/256 is released the console
+  # test named `test-license-with-console.yaml` needs to work with unreleased Redpanda Console version.
+  image:
+    registry: redpandadata
+    repository: console-unstable
+    tag: master-8a51854

--- a/charts/redpanda/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+storage:
+  persistentVolume:
+    nameOverwrite: shadow-index-cache
+  tiered:
+    mountType: persistentVolume
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_api_endpoint: storage.googleapis.com
+      cloud_storage_credentials_source: config_file
+      cloud_storage_region: "US-WEST1"
+      cloud_storage_bucket: "${TEST_BUCKET}"
+      cloud_storage_segment_max_upload_interval_sec: 1
+      cloud_storage_access_key: "${GCP_ACCESS_KEY_ID}"
+      cloud_storage_secret_key: "${GCP_SECRET_ACCESS_KEY}"
+enterprise:
+  license: "${REDPANDA_SAMPLE_LICENSE}"
+
+
+resources:
+  cpu:
+    cores: 400m
+  memory:
+    container:
+      max: 2.0Gi
+    redpanda:
+      memory: 1Gi
+      reserveMemory: 100Mi
+
+console:
+  # Until https://github.com/redpanda-data/console-enterprise/pull/256 is released the console
+  # test named `test-license-with-console.yaml` needs to work with unreleased Redpanda Console version.
+  image:
+    registry: redpandadata
+    repository: console-unstable
+    tag: master-8a51854

--- a/charts/redpanda/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl
+++ b/charts/redpanda/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+storage:
+  persistentVolume:
+    storageClass: managed-csi
+    nameOverwrite: shadow-index-cache
+  tiered:
+    mountType: persistentVolume
+    persistentVolume:
+      storageClass: managed-csi
+    config:
+      cloud_storage_enabled: true
+      cloud_storage_credentials_source: config_file
+      cloud_storage_segment_max_upload_interval_sec: 1
+      cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
+      cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
+      cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
+enterprise:
+    license: "${REDPANDA_SAMPLE_LICENSE}"
+
+resources:
+  cpu:
+    cores: 400m
+  memory:
+    container:
+      max: 2.0Gi
+    redpanda:
+      memory: 1Gi
+      reserveMemory: 100Mi
+
+console:
+  # Until https://github.com/redpanda-data/console-enterprise/pull/256 is released the console
+  # test named `test-license-with-console.yaml` needs to work with unreleased Redpanda Console version.
+  image:
+    registry: redpandadata
+    repository: console-unstable
+    tag: master-8a51854

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -131,7 +131,7 @@ spec:
             - name: datadir
               mountPath: /var/lib/redpanda/data
   {{- if ne (include "storage-tiered-mountType" .) "none" }}
-            - name: tiered-storage-dir
+            - name: {{ default "tiered-storage-dir" .Values.storage.persistentVolume.nameOverwrite }}
               mountPath: {{ include "tieredStorage.cacheDirectory" . }}
   {{- end }}
   {{- if dig "initContainers" "setTieredStorageCacheDirOwnership" "extraVolumeMounts" false .Values.statefulset -}}
@@ -303,7 +303,7 @@ spec:
             - name: datadir
               mountPath: /var/lib/redpanda/data
 {{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled (ne (include "storage-tiered-mountType" .) "none") }}
-            - name: tiered-storage-dir
+            - name: {{ default "tiered-storage-dir" .Values.storage.persistentVolume.nameOverwrite }}
               mountPath: {{ include "tieredStorage.cacheDirectory" . }}
 {{- end }}
           resources:


### PR DESCRIPTION
The nameOverwrite should be applied to all occourances to `tiered-storage-dir` which is a default volumeClaimTemplate name. If user would use the `nameOverwrite` then the following event is emitted by StatefulSet controller:

```
  Warning  FailedCreate      7m17s (x18 over 8m59s)  statefulset-controller create Pod redpanda in StatefulSet redpanda failed error: Pod "redpanda" is invalid: [spec.containers[0].volumeMounts[8].name: Not found: "tiered-storage-dir", spec.initContainers[3].volumeMounts[5].name: Not found: "tiered-storage-dir"]
```