### PR TITLE
feat(kminion): add tpl to config

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.12.4
+version: 0.12.5
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/kminion/templates/configmap.yaml
+++ b/charts/kminion/templates/configmap.yaml
@@ -23,4 +23,4 @@ metadata:
     {{- include "kminion.labels" . | nindent 4}}
 data:
   config.yaml: |
-    {{- toYaml .Values.kminion.config | nindent 4}}
+    {{- tpl (toYaml .Values.kminion.config) $ | nindent 4 }}


### PR DESCRIPTION
In case you would have an umbrella chart which would install both kafka and kminion, it would be impossible to inject e.g. the service name for the brokers (which is by default prefixed with the release name).
With this PR for example the following values could be used in an umbrella chart:

```
kminion:
  config:
    kafka:
      brokers:
        - "{{ $.Release.Name }}-kafka.{{ $.Release.Namespace }}:9092"
```