### PR TITLE
redpanda: set tiered storage configuration in a batch

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.23
+version: 5.7.24
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.7.22](https://img.shields.io/badge/Version-5.7.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
+![Version: 5.7.24](https://img.shields.io/badge/Version-5.7.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.4](https://img.shields.io/badge/AppVersion-v23.3.4-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -131,22 +131,6 @@ bootstrap.yaml: |
   audit_enabled: false
   {{- end }}
 {{- end }}
-{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
-  {{- $tieredStorageConfig := (include "storage-tiered-config" .|fromJson) }}
-  {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_cache_directory" }}
-  {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
-    {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_credentials_source"}}
-  {{- end }}
-  {{- range $key, $element := $tieredStorageConfig}}
-    {{- if or (eq (typeOf $element) "bool") $element }}
-      {{- if eq $key "cloud_storage_cache_size" }}
-        {{- dict $key (include "SI-to-bytes" $element) | toYaml | nindent 2 -}}
-      {{- else }}
-        {{- dict $key $element | toYaml | nindent 2 -}}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-{{- end }}
 
 redpanda.yaml: |
   config_file: /etc/redpanda/redpanda.yaml

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -68,25 +68,46 @@ spec:
       containers:
       - name: {{ template "redpanda.name" . }}-post-install
         image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-        {{- if not ( empty (include "enterprise-secret" . ) ) }}
-        env:
-          - name: REDPANDA_LICENSE
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "enterprise-secret-name" . }}
-                key: {{ include "enterprise-secret-key" . }}
-        {{- end }}
+        {{ (dict "env" (prepend
+            (include "tiered-storage-env-vars" . | fromJsonArray)
+            (include "secret-ref-or-value" (dict
+                "Name" "REDPANDA_LICENSE"
+                "Value" (include "enterprise-license" .)
+                "SecretName" (include "enterprise-secret-name" .)
+                "SecretKey" (include "enterprise-secret-key" .)
+            ) | fromJson)
+         | compact)) | toYaml | nindent 8 }}
         command: ["bash","-c"]
         args:
           - |
             set -e
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
-          {{- if not (empty (include "enterprise-secret" . )) }}
-            rpk cluster license set "$REDPANDA_LICENSE"
-          {{- else if not (empty (include "enterprise-license" . )) }}
-            rpk cluster license set {{ include "enterprise-license" . | quote }}
-          {{- end }}
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
         {{- end }}
+
+            {{/* ### Here be dragons ### 
+            This block of bash configures cluster configuration settings by
+            pulling them from environment variables.
+
+            This allows us to support configurations from secrets or their raw
+            values.
+
+            The loop itself looks for all envvars prefixed with "RPK_"
+            ("${!RPK_@}") and then writes them to a yaml file in the form:
+            {envar.strip("RPK_").lower()}: {value}
+
+            This file is then loaded via `rpk cluster config import` which
+            ensures that conditional configurations (cloud_storage_enabled)
+            "see" all their dependent keys.
+            */}}
+            touch /tmp/cfg.yml
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              echo "${config,,}: ${!KEY}" >> /tmp/cfg.yml
+            done
+            rpk cluster config import -f /tmp/cfg.yml
         {{- with .Values.post_install_job.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -351,18 +351,6 @@ stringData:
     rpk --config "$CONFIG" redpanda config set redpanda.rack "${RACK}"
       {{- end }}
     {{- end }}
-    {{- if (include "storage-tiered-credentials-secret-key" . | fromJson).bool }}
-    set +x
-    echo Setting {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} configuration
-    rpk cluster config --config "$CONFIG" set {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} $CLOUD_STORAGE_SECRET_KEY
-    set -x
-    {{- end }}
-    {{- if and .Values.storage.tiered.credentialsSecretRef.accessKey.name .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
-    set +x
-    echo Setting {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} configuration
-    rpk cluster config --config "$CONFIG" set {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} $CLOUD_STORAGE_ACCESS_KEY
-    set -x
-    {{- end }}
 {{- if .Values.statefulset.initContainers.fsValidator.enabled}}
 ---
 apiVersion: v1

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -163,20 +163,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.hostIP
-            {{- if (include "storage-tiered-credentials-secret-key" . | fromJson).bool }}
-            - name: CLOUD_STORAGE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: {{ (include "storage-tiered-credentials-secret-key" . | fromJson).key }}
-                  name: {{ (include "storage-tiered-credentials-secret-key" . | fromJson).name }}
-            {{- end }}
-            {{- if and .Values.storage.tiered.credentialsSecretRef.accessKey.name .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
-            - name: CLOUD_STORAGE_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
-                  name: {{ .Values.storage.tiered.credentialsSecretRef.accessKey.name }}
-            {{- end }}
           securityContext: {{ include "container-security-context" . | nindent 12 }}
           volumeMounts: {{ include "common-mounts" . | nindent 12 }}
 {{- if dig "initContainers" "configurator" "extraVolumeMounts" false .Values.statefulset -}}


### PR DESCRIPTION
Previously, tiered storage settings where being set via the `bootstrap.yml` and via an init container.

Only non-secret values could be set via `bootstrap.yml` which could result in validation errors as `cloud_storage_enabled` requires `cloud_storage_{access,secret}_key` to be set.

Secret settings set via the init container could fail in newly configured clusters as quorum had yet to be established.

This commit moves all tiered storage configuration to the post-install-upgrade-job. It passes secret and non-secret values via environment variables and then stitches them into a yaml file suitable for `rpk cluster config import`. This ensures that dependent configurations "see" their dependents and that the cluster is configured post quorum/bootstrap.