### PR TITLE
skip generating unused resources if issuerRef is set

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.23
+version: 5.7.24
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/ci/19-customer-issuer-ref-values.yaml
+++ b/charts/redpanda/ci/19-customer-issuer-ref-values.yaml
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+tls:
+  enabled: true
+  certs:
+    default:
+      issuerRef:
+        name: custom-internal-issuer-ref
+        kind: ClusterIssuer
+
+external:
+  enabled: false

--- a/charts/redpanda/templates/cert-issuers.yaml
+++ b/charts/redpanda/templates/cert-issuers.yaml
@@ -79,4 +79,5 @@ spec:
     group: cert-manager.io
       {{- end }}
   {{- end }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
Hi,
I added one change avoiding the generation of not used/usable issuers and certificates if a custom issuer is provided.
I added a dedicated values.yaml with a working test configuration.
But I'm missing the required custom cluster issuer: "custom-internal-issuer-ref"
Where can I add this cluster issuer to be available during the test run?
Regards


