### PR TITLE
charts/kminion - allow setting priorityClassName for kminion pod

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.12.6
+version: 0.12.7
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -47,6 +47,9 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8}}
       serviceAccountName: {{ include "kminion.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       volumes:
         - name: config
           configMap:

--- a/charts/kminion/templates/daemonset.yaml
+++ b/charts/kminion/templates/daemonset.yaml
@@ -47,8 +47,8 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8}}
       serviceAccountName: {{ include "kminion.serviceAccountName" . }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       volumes:
         - name: config

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -52,6 +52,9 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end}}
       serviceAccountName: {{include "kminion.serviceAccountName" .}}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8}}
       volumes:

--- a/charts/kminion/templates/deployment.yaml
+++ b/charts/kminion/templates/deployment.yaml
@@ -52,8 +52,8 @@ spec:
         {{- toYaml . | nindent 8}}
       {{- end}}
       serviceAccountName: {{include "kminion.serviceAccountName" .}}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
       {{- end }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8}}

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -38,6 +38,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+priorityClassName:
+
 podAnnotations: {}
 #  prometheus.io/scrape: "true"
 #  prometheus.io/port: "8080"


### PR DESCRIPTION
Hey,

I've been using [cloudworkz/kafka-minion-helm-chart](https://github.com/cloudworkz/kafka-minion-helm-chart) and I was able to set `priorityClassName` on pods, which is not the case in this Chart.

Tell me if you expect anything else in the PR 🙏

Also I would need a new version to be released as soon as this PR is merged, should I change the version in `Chart.yaml` myself?