### PR TITLE
feat(kminion): add option to disable tests

### DIFF
--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.12.5
+version: 0.12.6
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/kminion/templates/tests/01-rpk-test-consume-from-test-topic.yaml
+++ b/charts/kminion/templates/tests/01-rpk-test-consume-from-test-topic.yaml
@@ -15,7 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- $brokers := dig "kafka" "brokers" "" .Values.kminion.config -}}
-{{- if gt (len $brokers) 0 -}}
+{{- if and (.Values.tests.enabled) (gt (len $brokers) 0) -}}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -289,3 +289,6 @@ kminion:
 #    logger:
 #      # Level is a logging priority. Higher levels are more important. Valid values are: debug, info, warn, error, fatal, panic
 #      level: info
+
+tests:
+  enabled: true


### PR DESCRIPTION
We are using the `kminion` chart as a dependency in an umbrella chart. Now we want to start using helm's chart tester tool on this umbrella chart, which uses `helm test` under the hood for it's `install` tests. There are a couple of issue with the kminion tests though for us. So this PR adds a flag to allow disabling the tests altogether.

I've added `tests` as a map in the values file so we could maybe also extend it with the topics to test in a later addition. For now only `enabled` is in there though.


We had the following issues btw:

1. We don't have `endToEnd` enabled in kminion as we don't need it. So the tests would fail as they are checking topics behind this flag.
2. When enabling `endToEnd` we only had 2 partitions instead of 3 which resulted again in failing tests.

I didn't look too deeply in the second issue as it probably depends also on the way we set up things. But more importantly we wouldn't want to enable `endToEnd` in the first place (as we don't use those metrics).