### PR TITLE
Set container ports only if they are configured for external exposure

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.29
+version: 5.7.30
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.7.27](https://img.shields.io/badge/Version-5.7.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.5](https://img.shields.io/badge/AppVersion-v23.3.5-informational?style=flat-square)
+![Version: 5.7.30](https://img.shields.io/badge/Version-5.7.30-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.6](https://img.shields.io/badge/AppVersion-v23.3.6-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
@@ -1120,6 +1120,10 @@ Additional labels to apply to the created PersistentVolumeClaims.
 To disable dynamic provisioning, set to "-". If undefined or empty (default), then no storageClassName spec is set, and the default dynamic provisioner is chosen (gp2 on AWS, standard on GKE, AWS & OpenStack).
 
 **Default:** `""`
+
+### [tests.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=tests.enabled)
+
+**Default:** `true`
 
 ### [tls](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=tls)
 

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -283,7 +283,7 @@ spec:
             - name: {{ lower $name }}
               containerPort: {{ $listener.port }}
   {{- range $externalName, $external := $listener.external }}
-  {{- if or ($external.enabled) (and ($values.external.enabled) (not (eq $external.enabled false))) }}
+  {{- if and $external.port (or $external.enabled (and $values.external.enabled (dig "enabled" true $external))) }}
             - name: {{ lower $name | trunc 6 }}-{{ lower $externalName | trunc 8 }}
               containerPort: {{ $external.port }}
     {{- end }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -283,7 +283,7 @@ spec:
             - name: {{ lower $name }}
               containerPort: {{ $listener.port }}
   {{- range $externalName, $external := $listener.external }}
-    {{- if $external.port }}
+  {{- if or ($external.enabled) (and ($values.external.enabled) (not (eq $external.enabled false))) }}
             - name: {{ lower $name | trunc 6 }}-{{ lower $externalName | trunc 8 }}
               containerPort: {{ $external.port }}
     {{- end }}


### PR DESCRIPTION
The idea is:

- If the listener is explicitly configured for external port, then set it (setting listener.external.default.enabled). No matter what is configured for external.enabled, as it's stated in the docs that this value overrides the global external.enabled if set

- If external.enabled is set to true, then also add those container ports if those are not explicitly disabled (listener.external.default.enabled = false). If the listener setting is not set or set to true as well, then add it. If the listener setting is set to false, then do not set it.

Closes #1029 