### PR TITLE
feat(console): add option to disable tests

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.7.20
+version: 0.7.21
 
 # The app version is the version of the Chart application
 appVersion: v2.4.3

--- a/charts/console/templates/tests/test-connection.yaml
+++ b/charts/console/templates/tests/test-connection.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.tests.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -17,3 +18,4 @@ spec:
       args: ['{{ include "console.fullname" . }}:{{ .Values.service.port }}']
   restartPolicy: Never
   priorityClassName: {{ .Values.priorityClassName }}
+{{- end }}

--- a/charts/console/values.schema.json
+++ b/charts/console/values.schema.json
@@ -304,6 +304,14 @@
     },
     "strategy": {
       "type": "object"
+    },
+    "tests": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "type": "boolean"
+        }
+      }
     }
   }
 }

--- a/charts/console/values.yaml
+++ b/charts/console/values.yaml
@@ -269,3 +269,6 @@ deployment:
   create: true
 
 strategy: {}
+
+tests:
+  enabled: true


### PR DESCRIPTION
Aligning to https://github.com/redpanda-data/helm-charts/pull/1028 and https://github.com/redpanda-data/helm-charts/pull/1038, adding an option to disable the tests in the redpanda-console helm chart