### PR TITLE
fix(redpanda): Allow strings for post upgrade job cpu type

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.7.30
+version: 5.7.31
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -748,7 +748,7 @@
               "type": "object",
               "properties": {
                 "cpu": {
-                  "type": "integer"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "type": "string",
@@ -760,7 +760,7 @@
               "type": "object",
               "properties": {
                 "cpu": {
-                  "type": "integer"
+                  "type": ["integer", "string"]
                 },
                 "memory": {
                   "type": "string",


### PR DESCRIPTION
Add opportunity to set also smaller units for cpu limits and requests in post upgrade job.

Reference: https://github.com/redpanda-data/helm-charts/pull/1035#pullrequestreview-1893240370