### PR TITLE
Add a workflow for non-chart changes

### DIFF
--- a/.github/workflows/pull_requests_non_chart.yaml
+++ b/.github/workflows/pull_requests_non_chart.yaml
@@ -1,0 +1,56 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This workflow is a hack/workaround.
+#
+# We require that jobs named "lint" and "summary" pass in order to merge PRs.
+# The existing workflows only trigger upon changes to Charts. Sometimes we want
+# to make non-Chart changes but security controls make it difficult to
+# configure this correctly. Something like
+# https://github.com/upsidr/merge-gatekeeper may be a better long term
+# solution.
+#
+# This workflow publishes no-op lint and summary jobs for any PR that doesn't
+# match other workflows.
+name: Non-Chart CI
+
+on:
+  pull_request:
+    branches:
+      - "**"
+    # paths is an explicit allow list to prevent clobbering of existing
+    # workflow runs.
+    # Only add in paths that are known to not trigger other tests runs.
+    paths:
+      # Watch changes to this file.
+      - '.github/workflows/pull_requests_non_chart.yaml'
+      # Watch for any go-related changes are we start to rely on `go test`
+      - '**/*.go'
+      - go.mod
+      - go.sum
+
+jobs:
+
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Noop
+        run: 'echo "LGTM ;)"'
+
+  summary:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Noop
+        run: 'echo "LGTM ;)"'


### PR DESCRIPTION
This repository is configured to require "lint" and "summary" jobs to pass. The existing workflows only run for chart specific changes. This leaves any non-chart changes stuck in limbo as jobs will never run.

This commit adds in a (fragile) github action that can be used to pass CI for any non-chart change. When a PR is stuck in limbo, the author may update the new workflow to explicitly watch for changes to the file they made.