### PR TITLE
redpanda: set tiered storage configuration in a batch

### DIFF
--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -131,22 +131,6 @@ bootstrap.yaml: |
   audit_enabled: false
   {{- end }}
 {{- end }}
-{{- if and (include "is-licensed" . | fromJson).bool (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}
-  {{- $tieredStorageConfig := (include "storage-tiered-config" .|fromJson) }}
-  {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_cache_directory" }}
-  {{- if not (include "redpanda-atleast-22-3-0" . | fromJson).bool }}
-    {{- $tieredStorageConfig = unset $tieredStorageConfig "cloud_storage_credentials_source"}}
-  {{- end }}
-  {{- range $key, $element := $tieredStorageConfig}}
-    {{- if or (eq (typeOf $element) "bool") $element }}
-      {{- if eq $key "cloud_storage_cache_size" }}
-        {{- dict $key (include "SI-to-bytes" $element) | toYaml | nindent 2 -}}
-      {{- else }}
-        {{- dict $key $element | toYaml | nindent 2 -}}
-      {{- end }}
-    {{- end }}
-  {{- end }}
-{{- end }}
 
 redpanda.yaml: |
   config_file: /etc/redpanda/redpanda.yaml

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -35,7 +35,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
-    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-weight": "-5"
 {{- with .Values.post_install_job.annotations }}
   {{- toYaml . | nindent 4 }}
 {{- end }}
@@ -68,25 +68,69 @@ spec:
       containers:
       - name: {{ template "redpanda.name" . }}-post-install
         image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-        {{- if not ( empty (include "enterprise-secret" . ) ) }}
-        env:
-          - name: REDPANDA_LICENSE
-            valueFrom:
-              secretKeyRef:
-                name: {{ include "enterprise-secret-name" . }}
-                key: {{ include "enterprise-secret-key" . }}
-        {{- end }}
+        {{ (dict "env" (prepend
+            (include "tiered-storage-env-vars" . | fromJsonArray)
+            (include "secret-ref-or-value" (dict
+                "Name" "REDPANDA_LICENSE"
+                "Value" (include "enterprise-license" .)
+                "SecretName" (include "enterprise-secret-name" .)
+                "SecretKey" (include "enterprise-secret-key" .)
+            ) | fromJson)
+         | compact)) | toYaml | nindent 8 }}
         command: ["bash","-c"]
         args:
           - |
             set -e
         {{- if (include "redpanda-atleast-22-2-0" . | fromJson).bool }}
-          {{- if not (empty (include "enterprise-secret" . )) }}
-            rpk cluster license set "$REDPANDA_LICENSE"
-          {{- else if not (empty (include "enterprise-license" . )) }}
-            rpk cluster license set {{ include "enterprise-license" . | quote }}
-          {{- end }}
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
         {{- end }}
+
+            {{/* ### Here be dragons ### 
+            This block of bash configures cluster configuration settings by
+            pulling them from environment variables.
+
+            This allows us to support configurations from secrets or their raw
+            values.
+
+            WARNING: There is a small race condition here. `rpk cluster config
+            import` will reset any values that are not specified. To work
+            around this, we first export the the configuration. If there's a
+            change to the configuration while we're updating the exported
+            config on disk, said change will be reverted.
+
+            TODO(chrisseto): Consolidate all cluster configuration setting to
+            this job.
+            */}}
+
+            {{/* First: dump the existing cluster configuration.
+
+            We need to use config import to handle conditional configurations
+            (e.g. cloud_storage_enabled). Maintaining a DAG of configurations
+            is not an option for the helm chart. */}}
+            rpk cluster config export -f /tmp/cfg.yml
+
+            {{/* Second: For each environment variable with the prefix RPK
+            ("${!RPK_@}"), use `rpk redpanda config set` to update the exported
+            config.
+
+            Lots of Bash Jargon here:
+                "${KEY#*RPK_}" => Strip the RPK_ prefix from KEY.
+                "${config,,}" => config.toLower()
+                "${!KEY}" => Dynamic variable resolution. ie: What is the value of the variable with a name equal to the value of $KEY?
+            */}}
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            {{/*
+            The updated file is then loaded via `rpk cluster config import` which
+            ensures that conditional configurations (cloud_storage_enabled)
+            "see" all their dependent keys.
+            */}}
+            rpk cluster config import -f /tmp/cfg.yml
         {{- with .Values.post_install_job.resources }}
         resources:
           {{- toYaml . | nindent 10 }}

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -32,7 +32,8 @@ metadata:
 {{- end }}
   annotations:
     "helm.sh/hook": post-upgrade
-    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
 {{- with .Values.post_upgrade_job.annotations }}
   {{- toYaml . | nindent 4 }}
 {{- end }}

--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -351,18 +351,6 @@ stringData:
     rpk --config "$CONFIG" redpanda config set redpanda.rack "${RACK}"
       {{- end }}
     {{- end }}
-    {{- if (include "storage-tiered-credentials-secret-key" . | fromJson).bool }}
-    set +x
-    echo Setting {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} configuration
-    rpk cluster config --config "$CONFIG" set {{ (include "storage-tiered-credentials-secret-key" . | fromJson).configurationKey }} $CLOUD_STORAGE_SECRET_KEY
-    set -x
-    {{- end }}
-    {{- if and .Values.storage.tiered.credentialsSecretRef.accessKey.name .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
-    set +x
-    echo Setting {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} configuration
-    rpk cluster config --config "$CONFIG" set {{ .Values.storage.tiered.credentialsSecretRef.accessKey.configurationKey }} $CLOUD_STORAGE_ACCESS_KEY
-    set -x
-    {{- end }}
 {{- if .Values.statefulset.initContainers.fsValidator.enabled}}
 ---
 apiVersion: v1

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -163,20 +163,6 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: status.hostIP
-            {{- if (include "storage-tiered-credentials-secret-key" . | fromJson).bool }}
-            - name: CLOUD_STORAGE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: {{ (include "storage-tiered-credentials-secret-key" . | fromJson).key }}
-                  name: {{ (include "storage-tiered-credentials-secret-key" . | fromJson).name }}
-            {{- end }}
-            {{- if and .Values.storage.tiered.credentialsSecretRef.accessKey.name .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
-            - name: CLOUD_STORAGE_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: {{ .Values.storage.tiered.credentialsSecretRef.accessKey.key }}
-                  name: {{ .Values.storage.tiered.credentialsSecretRef.accessKey.name }}
-            {{- end }}
           securityContext: {{ include "container-security-context" . | nindent 12 }}
           volumeMounts: {{ include "common-mounts" . | nindent 12 }}
 {{- if dig "initContainers" "configurator" "extraVolumeMounts" false .Values.statefulset -}}


### PR DESCRIPTION
Previously, tiered storage settings where being set via the `bootstrap.yml` and via an init container.

Only non-secret values could be set via `bootstrap.yml` which could result in validation errors as `cloud_storage_enabled` requires `cloud_storage_{access,secret}_key` to be set.

Secret settings set via the init container could fail in newly configured clusters as quorum had yet to be established.

This commit moves all tiered storage configuration to the post-install-upgrade-job. It passes secret and non-secret values via environment variables and then stitches them into a yaml file suitable for `rpk cluster config import`. This ensures that dependent configurations "see" their dependents and that the cluster is configured post quorum/bootstrap.

To mitigate a race condition with the post-upgrade job, this commit additionally swaps the hook weights. This ensures that the `rpk cluster config import` call in the post-upgrade job does not wipe any configurations set by the post-install job. This solution is less than ideal and we'll need to consolidate all cluster configuration changes into a single job in the near future.