### PR TITLE
Upgrade `pkg/helm`

### DIFF
--- a/pkg/helm/flags.go
+++ b/pkg/helm/flags.go
@@ -1,0 +1,38 @@
+package helm
+
+import (
+	"fmt"
+	"reflect"
+)
+
+// ToFlags is a reflect based helper that translates a go struct with `flag`
+// tags into a string slice of command line arguments.
+// If flagsStruct is not a struct, ToFlags panics.
+func ToFlags(flagsStruct any) []string {
+	v := reflect.ValueOf(flagsStruct)
+	t := v.Type()
+
+	var flags []string
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		flag := field.Tag.Get("flag")
+		if flag == "" || flag == "-" {
+			continue
+		}
+
+		value := v.Field(i).Interface()
+
+		if field.Type.Kind() == reflect.Bool && field.Name[:2] == "No" && flag[:3] != "no-" {
+			value = !value.(bool)
+		}
+
+		if field.Type.Kind() == reflect.String && reflect.ValueOf(value).IsZero() {
+			continue
+		}
+
+		flags = append(flags, fmt.Sprintf("--%s=%v", flag, value))
+	}
+
+	return flags
+}

--- a/pkg/helm/flags_test.go
+++ b/pkg/helm/flags_test.go
@@ -1,0 +1,51 @@
+package helm_test
+
+import (
+	"testing"
+
+	"github.com/redpanda-data/helm-charts/pkg/helm"
+	"github.com/stretchr/testify/require"
+)
+
+type Flags struct {
+	NoWait        bool `flag:"wait"`
+	NoWaitForJobs bool `flag:"no-wait-for-jobs"`
+	NotAFlag      string
+	StringFlag    string `flag:"string-flag"`
+}
+
+func TestToFlags(t *testing.T) {
+	testCases := []struct {
+		in  Flags
+		out []string
+	}{
+		{
+			in: Flags{},
+			out: []string{
+				"--wait=true",
+				"--no-wait-for-jobs=false",
+			},
+		},
+		{
+			in: Flags{},
+			out: []string{
+				"--wait=true",
+				"--no-wait-for-jobs=false",
+			},
+		},
+		{
+			in: Flags{
+				StringFlag: "something",
+			},
+			out: []string{
+				"--wait=true",
+				"--no-wait-for-jobs=false",
+				"--string-flag=something",
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		require.Equal(t, tc.out, helm.ToFlags(tc.in))
+	}
+}


### PR DESCRIPTION
### This PR is stacked on top of others!

Please consider reviewing those PRs first. This message will be removed once prerequisite PRs are merged and this one is rebased.

* f126545423ce018f4821d3b7570d3f34f5a524a9 is from #1054
* 8798ce0f5cd72ee07b70f28ebe574207c2ae0a15 is from #1055

---

#### 63533ad5a94a070c019c65efb425a44969cbdae8 Upgrade `pkg/helm`

This commit upgrades to use a more standardized way of converting
structs into CLI flags ala `ToFlags`. It also implements a few more helm
function.