### PR TITLE
Adjust and bump kustomize semver for setup-kustomize GH action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install kustomize
         uses: imranismail/setup-kustomize@2ba527d4d055ab63514ba50a99456fc35684947f # v2.1.0
         with:
-          kustomize-version: v5.1.1
+          kustomize-version: 5.3.0
 
       - name: Build dependencies for the operator chart
         run: |


### PR DESCRIPTION
Previously `setup-kustomize` used `getMaxSatisfyingVersion` function to find corresponding kustomize version. In latest release there is new function `getPinnedVersion` that does not work with semver with `v` prefix.

## Reference

Function addition:
https://github.com/imranismail/setup-kustomize/compare/6691bdeb1b0a3286fb7f70fd1423c10e81e5375f...2ba527d4d055ab63514ba50a99456fc35684947f#diff-36a9847d245bd66dd946fe257334eb7bbe0c728d37d53df8b8173c7e3eecd5b2R68-R70

Dependabot commit:
https://github.com/redpanda-data/helm-charts/commit/36b6d34cdd670aeeef278355d43905024c5489f1

Dependabot PR:
https://github.com/redpanda-data/helm-charts/pull/1051

Successful execution from https://github.com/redpanda-data/helm-charts/pull/1065 PR:
https://github.com/redpanda-data/helm-charts/actions/runs/8103477122/job/22148154358?pr=1065#step:8:1