### PR TITLE
Fixing issue 925 by separating container port from target port

### DIFF
--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.7.22
+version: 0.7.23
 
 # The app version is the version of the Chart application
 appVersion: v2.4.4

--- a/charts/console/templates/_helpers.tpl
+++ b/charts/console/templates/_helpers.tpl
@@ -77,15 +77,19 @@ Create the name of the service account to use
 
 {{/*
 Console's HTTP server Port.
-The port is defined from the service targetPort bu can be overridden
-in the provided config and if that is missing defaults to 8080.
+The port is defined from the provided config but can be overridden
+by setting service.targetPort and if that is missing defaults to 8080.
 */}}
 {{- define "console.containerPort" -}}
 {{- $listenPort := 8080 -}}
-{{- if .Values.console.config.server -}}
-{{- $listenPort = .Values.console.config.server.listenPort -}}
+{{- if .Values.service.targetPort -}}
+{{- $listenPort = .Values.service.targetPort -}}
 {{- end -}}
-{{- .Values.service.targetPort | default $listenPort -}}
+{{- if and .Values.console .Values.console.config .Values.console.config.server -}}
+  {{- .Values.console.config.server.listenPort | default $listenPort -}}
+{{- else -}}
+  {{- $listenPort -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -27,7 +27,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: {{ include "console.containerPort" . }}
+      targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
       {{- if and (contains "NodePort" .Values.service.type) .Values.service.nodePort }}


### PR DESCRIPTION
Hello,

Here is my PR to solve issue [925](https://github.com/redpanda-data/helm-charts/issues/925).

Within the service.yaml the targetPort was set back to .Values.service.targetPort. This allows to differentiate between container port of console container and the service, which allows the usage of an oauth proxy.

Within the _helpers.tpl containerPort port is set to:

1. (if set) .Values.console.config.server.listenPort -> required to be set in case an oauth proxy is used
2. (if set) .Values.service.targetPort -> if .Values.console.config.server.listenPort is not set the targetPort = containerPort 
3. 8080 -> default if both values above are not set

I have successfully tested the change within our kubernetes cluster.

Do not hesitate to ask, comment or adapt.