### PR TITLE
redpanda: Add timeouts to curl exec probes

### DIFF
--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -223,7 +223,7 @@ spec:
                 - -c
                 - |
                   set -e
-                  RESULT=$(curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready")
+                  RESULT=$(curl --silent --fail -k -m 5 {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready")
                   echo $RESULT
                   echo $RESULT | grep ready
             initialDelaySeconds: {{ .Values.statefulset.startupProbe.initialDelaySeconds }}
@@ -235,7 +235,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - curl --silent --fail -k {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready"
+                - curl --silent --fail -k -m 5 {{ include "admin-tls-curl-flags" . }} "{{ include "admin-http-protocol" . }}://{{ include "admin-api-urls" . }}/v1/status/ready"
             initialDelaySeconds: {{ .Values.statefulset.livenessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.livenessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.livenessProbe.periodSeconds }}
@@ -252,8 +252,9 @@ spec:
                 - -c
                 - |
                   set -x
-                  rpk cluster health
-                  rpk cluster health | grep 'Healthy:.*true'
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
             initialDelaySeconds: {{ .Values.statefulset.readinessProbe.initialDelaySeconds }}
             failureThreshold: {{ .Values.statefulset.readinessProbe.failureThreshold }}
             periodSeconds: {{ .Values.statefulset.readinessProbe.periodSeconds }}


### PR DESCRIPTION
Thanks to digging from Rafal, we've discovered that exec probes in kubernetes implicitly get an additional 2 minute timeout [1]. This results in abnormally long startup times for redpanda as each Pod's startup probe can hang for up to 2 minutes.

This commit adds a timeout of 5 seconds to each exec using curl via the `-m` flag which prevents the 2 minute hang time.

For posterity, 5 seconds was chosen arbitrarily.

[1]: https://github.com/kubernetes/kubernetes/blob/54f9807e1e84981b2053f4daf779f5ed19962144/pkg/kubelet/cri/remote/remote_runtime.go#L475-L478