### PR TITLE
redpanda: implement snapshot testing

### DIFF
--- a/charts/redpanda/.helmignore
+++ b/charts/redpanda/.helmignore
@@ -24,3 +24,5 @@ README.md.gotmpl
 .vscode/
 
 *.go
+testdata/
+ci/

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -663,7 +663,7 @@ rpk:
 {{- define "rpk-config-external" -}}
   {{- $brokers := list -}}
   {{- $admin := list -}}
-  {{- $profile := keys .Values.listeners.kafka.external | first -}}
+  {{- $profile := keys .Values.listeners.kafka.external | sortAlpha | first -}}
   {{- $kafkaListener := get .Values.listeners.kafka.external $profile -}}
   {{- $adminListener := dict -}}
   {{- if .Values.listeners.admin.external -}}

--- a/charts/redpanda/templates/values.yaml
+++ b/charts/redpanda/templates/values.yaml
@@ -1,0 +1,2 @@
+{{- /* Generated from "values.go" */ -}}
+

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -1,0 +1,1402 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -1,0 +1,1041 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      testlabel: exercise_common_labels_template
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="http://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail  ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent  ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    touch /tmp/preStopHookFinished
+    echo "Not enough replicas or in recovery mode, cannot put a broker into maintenance mode."
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 1
+    retention_local_target_ms_default: 21600000
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 161061273
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      retention_local_target_ms_default: 21600000
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 161061273
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls:
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls:
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+      tls:
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+      tls:
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: false
+        urls:
+        - http://redpanda-0.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: false
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+    testlabel: exercise_common_labels_template
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+    testlabel: exercise_common_labels_template
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 63c329ba09b56f1dd83be951ffa92276a4629ad8a718d23cd4e7ac76a51d28e5
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: http://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      testlabel: exercise_common_labels_template
+  serviceName: redpanda
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        testlabel: exercise_common_labels_template
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: c25c6cf5baf4214ae98067f0a26d62a97fd24d0d059b10724cbaadd0e8097d82
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+              testlabel: exercise_common_labels_template
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+                testlabel: exercise_common_labels_template
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+          testlabel: exercise_common_labels_template
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "3Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+        testlabel: exercise_common_labels_template
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    testlabel: exercise_common_labels_template
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+        testlabel: exercise_common_labels_template
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 1
+            rpk cluster config set retention_local_target_ms_default 21600000
+            rpk cluster config set storage_min_free_bytes 161061273
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -1,0 +1,1365 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    touch /tmp/preStopHookFinished
+    echo "Not enough replicas or in recovery mode, cannot put a broker into maintenance mode."
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 1
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 161061273
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 161061273
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 11b9b16f1898f78a96cf661b3ff71cbbe2f2af35281ef684edcf163c896c6a6c
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 4719797cc24da807a3e7ee94bfe7ef592cc5f2d8f86cda636ceba64a04dcd0b0
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "3Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 1
+            rpk cluster config set storage_min_free_bytes 161061273
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -1,0 +1,1169 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="http://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail  ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent  ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+      # Setup and export SASL bootstrap-user
+      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+      MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+      rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    touch /tmp/preStopHookFinished
+    echo "Not enough replicas or in recovery mode, cannot put a broker into maintenance mode."
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "redpanda-users"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  users.txt: |-
+    admin:hunter2:SCRAM-SHA-256
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    while true; do
+      echo "RUNNING: Monitoring and Updating SASL users"
+      USERS_DIR="/etc/secrets/users"
+
+      new_users_list(){
+        LIST=$1
+        NEW_USER=$2
+        if [[ -n "${LIST}" ]]; then
+          LIST="${NEW_USER},${LIST}"
+        else
+          LIST="${NEW_USER}"
+        fi
+
+        echo "${LIST}"
+      }
+
+      process_users() {
+        USERS_DIR=${1-"/etc/secrets/users"}
+        USERS_FILE=$(find ${USERS_DIR}/* -print)
+        USERS_LIST=""
+        READ_LIST_SUCCESS=0
+        # Read line by line, handle a missing EOL at the end of file
+        while read p || [ -n "$p" ] ; do
+          IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+          # Do not process empty lines
+          if [ -z "$USER_NAME" ]; then
+            continue
+          fi
+          if [[ "${USER_NAME// /}" != "$USER_NAME" ]]; then
+            continue
+          fi
+          echo "Creating user ${USER_NAME}..."
+          MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          if [[ $creation_result_exit_code -ne 0 ]]; then
+            # Check if the stderr contains "User already exists"
+            # this error occurs when password has changed
+            if [[ $creation_result == *"User already exists"* ]]; then
+              echo "Update user ${USER_NAME}"
+              # we will try to update by first deleting
+              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              if [[ $deletion_result_exit_code -ne 0 ]]; then
+                echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
+                READ_LIST_SUCCESS=1
+                break
+              fi
+              # Now we update the user
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              if [[ $update_result_exit_code -ne 0 ]]; then
+                echo "updating user ${USER_NAME} failed: ${update_result}"
+                READ_LIST_SUCCESS=1
+                break
+              else
+                echo "Updated user ${USER_NAME}..."
+                USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+              fi
+            else
+              # Another error occurred, so output the original message and exit code
+              echo "error creating user ${USER_NAME}: ${creation_result}"
+              READ_LIST_SUCCESS=1
+              break
+            fi
+          # On a success, the user was created so output that
+          else
+            echo "Created user ${USER_NAME}..."
+            USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+          fi
+        done < $USERS_FILE
+
+        if [[ -n "${USERS_LIST}" && ${READ_LIST_SUCCESS} ]]; then
+          echo "Setting superusers configurations with users [${USERS_LIST}]"
+          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
+          if [[ $superuser_result_exit_code -ne 0 ]]; then
+              echo "Setting superusers configurations failed: ${superuser_result}"
+          else
+              echo "Completed setting superusers configurations"
+          fi
+        fi
+      }
+
+      # first time processing
+      process_users $USERS_DIR
+
+      # subsequent changes detected here
+      # watching delete_self as documented in https://ahmet.im/blog/kubernetes-inotify/
+      USERS_FILE=$(find ${USERS_DIR}/* -print)
+      while RES=$(inotifywait -q -e delete_self ${USERS_FILE}); do
+        process_users $USERS_DIR
+      done
+    done
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: true
+    enable_sasl: true
+    enable_rack_awareness: false
+    superusers: 
+      - admin
+          
+    default_topic_replications: 1
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 161061273
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: true
+      enable_sasl: true
+      superusers: ["admin"]
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 161061273
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+          authentication_method: sasl
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+          authentication_method: sasl
+      kafka_api_tls:
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+          authentication_method: http_basic
+      schema_registry_api_tls:
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+          authentication_method: http_basic
+      pandaproxy_api_tls:
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls:
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls:
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+      tls:
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+      tls:
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: true
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: false
+        urls:
+        - http://redpanda-0.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: false
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 3d078f24945f91d1b25df5c69c81ec92fca04aed1a5c9c06aca9dde2e185acd8
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: redpanda-users
+          secret:
+            secretName: redpanda-users
+      containers:
+        - name: console
+          command: ["sh","-c","set -e; IFS=':' read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM \u003c \u003c(grep \"\" $(find /mnt/users/* -print)); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-SCRAM-SHA-512}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;  export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;  export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;  /app/console $@","--"]
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/users
+              name: redpanda-users
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: http://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 8ced03362a6eafe39caebb461f35eeb3f1abcd221a362da127a2d11c0f679274
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: users
+          secret:
+            secretName: redpanda-users
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "3Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: users
+          secret:
+            secretName: redpanda-users
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 1
+            rpk cluster config set storage_min_free_bytes 161061273
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: users
+          secret:
+            secretName: redpanda-users

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -1,0 +1,1529 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+      # Setup and export SASL bootstrap-user
+      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+      MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+      rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    touch /tmp/preStopHookFinished
+    echo "Not enough replicas or in recovery mode, cannot put a broker into maintenance mode."
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "redpanda-users"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  users.txt: |-
+    admins:change-me:SCRAM-SHA-256
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    while true; do
+      echo "RUNNING: Monitoring and Updating SASL users"
+      USERS_DIR="/etc/secrets/users"
+
+      new_users_list(){
+        LIST=$1
+        NEW_USER=$2
+        if [[ -n "${LIST}" ]]; then
+          LIST="${NEW_USER},${LIST}"
+        else
+          LIST="${NEW_USER}"
+        fi
+
+        echo "${LIST}"
+      }
+
+      process_users() {
+        USERS_DIR=${1-"/etc/secrets/users"}
+        USERS_FILE=$(find ${USERS_DIR}/* -print)
+        USERS_LIST=""
+        READ_LIST_SUCCESS=0
+        # Read line by line, handle a missing EOL at the end of file
+        while read p || [ -n "$p" ] ; do
+          IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+          # Do not process empty lines
+          if [ -z "$USER_NAME" ]; then
+            continue
+          fi
+          if [[ "${USER_NAME// /}" != "$USER_NAME" ]]; then
+            continue
+          fi
+          echo "Creating user ${USER_NAME}..."
+          MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          if [[ $creation_result_exit_code -ne 0 ]]; then
+            # Check if the stderr contains "User already exists"
+            # this error occurs when password has changed
+            if [[ $creation_result == *"User already exists"* ]]; then
+              echo "Update user ${USER_NAME}"
+              # we will try to update by first deleting
+              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              if [[ $deletion_result_exit_code -ne 0 ]]; then
+                echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
+                READ_LIST_SUCCESS=1
+                break
+              fi
+              # Now we update the user
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              if [[ $update_result_exit_code -ne 0 ]]; then
+                echo "updating user ${USER_NAME} failed: ${update_result}"
+                READ_LIST_SUCCESS=1
+                break
+              else
+                echo "Updated user ${USER_NAME}..."
+                USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+              fi
+            else
+              # Another error occurred, so output the original message and exit code
+              echo "error creating user ${USER_NAME}: ${creation_result}"
+              READ_LIST_SUCCESS=1
+              break
+            fi
+          # On a success, the user was created so output that
+          else
+            echo "Created user ${USER_NAME}..."
+            USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+          fi
+        done < $USERS_FILE
+
+        if [[ -n "${USERS_LIST}" && ${READ_LIST_SUCCESS} ]]; then
+          echo "Setting superusers configurations with users [${USERS_LIST}]"
+          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
+          if [[ $superuser_result_exit_code -ne 0 ]]; then
+              echo "Setting superusers configurations failed: ${superuser_result}"
+          else
+              echo "Completed setting superusers configurations"
+          fi
+        fi
+      }
+
+      # first time processing
+      process_users $USERS_DIR
+
+      # subsequent changes detected here
+      # watching delete_self as documented in https://ahmet.im/blog/kubernetes-inotify/
+      USERS_FILE=$(find ${USERS_DIR}/* -print)
+      while RES=$(inotifywait -q -e delete_self ${USERS_FILE}); do
+        process_users $USERS_DIR
+      done
+    done
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: true
+    enable_sasl: true
+    enable_rack_awareness: false
+    superusers: 
+      - admins
+          
+    default_topic_replications: 1
+        
+    kafka_nodelete_topics:
+    - audit
+    - consumer_offsets
+    - _schemas
+    - my_sample_topic
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 161061273
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: true
+      enable_sasl: true
+      superusers: ["admins"]
+      default_topic_replications: 3
+      kafka_nodelete_topics: 
+      - audit
+      - consumer_offsets
+      - _schemas
+      - my_sample_topic
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 161061273
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+          authentication_method: sasl
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+          authentication_method: sasl
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+          authentication_method: http_basic
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+          authentication_method: http_basic
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: true
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 5a9b1e5c0962bac2f65b693f82f9ff0d67d12a3ade7d51b0e03fc6879a1863e1
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: redpanda-users
+          secret:
+            secretName: redpanda-users
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          command: ["sh","-c","set -e; IFS=':' read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM \u003c \u003c(grep \"\" $(find /mnt/users/* -print)); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-SCRAM-SHA-512}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;  export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;  export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;  /app/console $@","--"]
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/users
+              name: redpanda-users
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 1
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 22bc8864df0791c86464075939b736c569776459cbf9c1bb2aff400ed23c9efc
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: redpanda-users
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "3Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: redpanda-users
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 1
+            rpk cluster config set kafka_nodelete_topics "[ audit,consumer_offsets,_schemas,my_sample_topic ]"
+            rpk cluster config set storage_min_free_bytes 161061273
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: redpanda-users

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -1,0 +1,1511 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+
+    # Configure Rack Awareness
+    set +x
+    RACK=$(curl --silent --cacert /run/secrets/kubernetes.io/serviceaccount/ca.crt --fail -H 'Authorization: Bearer '$(cat /run/secrets/kubernetes.io/serviceaccount/token) "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT_HTTPS}/api/v1/nodes/${KUBERNETES_NODE_NAME}?pretty=true" | grep '"topology.kubernetes.io/zone"' | grep -v '\"key\":' | sed 's/.*": "\([^"]\+\).*/\1/')
+    set -x
+    rpk --config "$CONFIG" redpanda config set redpanda.rack "${RACK}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: true
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda-rpk-bundle
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - persistentvolumeclaims
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda
+subjects:
+  - kind: ServiceAccount
+    name: redpanda
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda-rpk-bundle
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda-rpk-bundle
+subjects:
+  - kind: ServiceAccount
+    name: redpanda
+    namespace: "default"
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: ca166991d3d04e5ce4d1b783b16e9c719c3a4d6477618bfe37bc5f3db9d268a9
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: redpanda
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: redpanda
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: redpanda
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -1,0 +1,1591 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext2\",\"port\":31292}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext2\",\"port\":31292}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext2\",\"port\":31292}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[2] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext3\",\"port\":31392}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext3\",\"port\":31392}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext3\",\"port\":31392}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[3] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext2\",\"port\":30183}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext2\",\"port\":30183}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext2\",\"port\":30183}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[2] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext3\",\"port\":30283}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext3\",\"port\":30283}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"ext3\",\"port\":30283}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[3] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+        - name: ext2
+          address: 0.0.0.0
+          port: 19094
+        - name: ext3
+          address: 0.0.0.0
+          port: 29094
+      kafka_api_tls:
+        - name: ext2
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: ext3
+          enabled: true
+          cert_file: /etc/tls/certs/cert2/tls.crt
+          key_file: /etc/tls/certs/cert2/tls.key
+          require_client_auth: true
+          
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+        - name: ext2
+          address: 0.0.0.0
+          port: 18081
+        - name: ext3
+          address: 0.0.0.0
+          port: 28081
+      schema_registry_api_tls:
+        - name: ext2
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: ext3
+          enabled: true
+          cert_file: /etc/tls/certs/cert2/tls.crt
+          key_file: /etc/tls/certs/cert2/tls.key
+          require_client_auth: true
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+        - name: ext2
+          address: 0.0.0.0
+          port: 18083
+        - name: ext3
+          address: 0.0.0.0
+          port: 28083
+      pandaproxy_api_tls:
+        - name: ext2
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: ext3
+          enabled: true
+          cert_file: /etc/tls/certs/cert2/tls.crt
+          key_file: /etc/tls/certs/cert2/tls.key
+          require_client_auth: true
+          truststore_file: /etc/ssl/certs/ca-certificates.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: false
+        urls:
+        - http://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - http://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - http://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: false
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: kafka-ext2
+      protocol: TCP
+      port: 19094
+      nodePort: 31292
+    - name: kafka-ext3
+      protocol: TCP
+      port: 29094
+      nodePort: 31392
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: http-ext2
+      protocol: TCP
+      port: 18083
+      nodePort: 30183
+    - name: http-ext3
+      protocol: TCP
+      port: 28083
+      nodePort: 30283
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+    - name: schema-ext2
+      protocol: TCP
+      port: 18081
+      nodePort: 30181
+    - name: schema-ext3
+      protocol: TCP
+      port: 28081
+      nodePort: 30281
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: ade431c30419558a251714518e03badc5fc2c8086132a8143e1451340c4d730c
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 3be4f208b870d3b1c3c16fcf853f431264a96fefe3709940890462a08e505619
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-cert2-cert
+              mountPath: /etc/tls/certs/cert2
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-cert2-cert
+              mountPath: /etc/tls/certs/cert2
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: http-ext2
+              containerPort: 18083
+            - name: http-ext3
+              containerPort: 28083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: kafka-ext2
+              containerPort: 19094
+            - name: kafka-ext3
+              containerPort: 29094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+            - name: schema-ext2
+              containerPort: 18081
+            - name: schema-ext3
+              containerPort: 28081
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-cert2-cert
+              mountPath: /etc/tls/certs/cert2
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-cert2-cert
+              mountPath: /etc/tls/certs/cert2
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-cert2-cert
+          secret:
+            secretName: redpanda-cert2-cert
+            defaultMode: 0o440
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-cert2-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-cert2-root-certificate
+  secretName: redpanda-cert2-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-cert2-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-cert2-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-cert2-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-cert2-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-cert2-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-cert2-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-cert2-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-cert2-cert
+            mountPath: /etc/tls/certs/cert2
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-cert2-cert
+          secret:
+            secretName: redpanda-cert2-cert
+            defaultMode: 0o440
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-cert2-cert
+            mountPath: /etc/tls/certs/cert2
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-cert2-cert
+          secret:
+            secretName: redpanda-cert2-cert
+            defaultMode: 0o440
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -1,0 +1,1401 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/instance: redpanda
+                app.kubernetes.io/name: redpanda
+            topologyKey: kubernetes.io/hostname
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -1,0 +1,1428 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: test-extra-volume
+              mountPath: /fake/lifecycle
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: test-extra-volume
+              mountPath: /fake/lifecycle
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+          resources:
+            limits:
+              cpu: 200m
+              memory: 60Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+        - name: "test-init-container"
+          image: "mintel/docker-alpine-bash-curl-jq:latest"
+          command: [ "/bin/bash", "-c" ]
+          args:
+            - |
+              set -xe
+              echo "Hello World!"
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: test-extra-volume
+              mountPath: /fake/lifecycle
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+            - name: test-extra-volume
+              mountPath: /fake/lifecycle
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: test-extra-volume
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0774
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -1,0 +1,1406 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"redpanda-1.my-domain\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"127.0.0.1.my-domain\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"192.168.0.1.my-domain\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"redpanda-1.my-domain\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"127.0.0.1.my-domain\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"192.168.0.1.my-domain\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-1.my-domain:31092
+          - 127.0.0.1.my-domain:31092
+          - 192.168.0.1.my-domain:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-1.my-domain:31644
+          - 127.0.0.1.my-domain:31644
+          - 192.168.0.1.my-domain:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: f76995dbcf55dfd8ebf788b6ea899e0afa77c0be59923885237d1469c7dd8fa2
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+    - "my-domain"
+    - "*.my-domain"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+    - "my-domain"
+    - "*.my-domain"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -1,0 +1,1560 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+      # Setup and export SASL bootstrap-user
+      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+      MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+      rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "some-users"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  users.txt: |-
+    admin:badpassword:SCRAM-SHA-256
+    user1:pass1word:SCRAM-SHA-512
+    someuser:ABC123r:SCRAM-SHA-512
+    anotherme:blah2784a:SCRAM-SHA-512
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    while true; do
+      echo "RUNNING: Monitoring and Updating SASL users"
+      USERS_DIR="/etc/secrets/users"
+
+      new_users_list(){
+        LIST=$1
+        NEW_USER=$2
+        if [[ -n "${LIST}" ]]; then
+          LIST="${NEW_USER},${LIST}"
+        else
+          LIST="${NEW_USER}"
+        fi
+
+        echo "${LIST}"
+      }
+
+      process_users() {
+        USERS_DIR=${1-"/etc/secrets/users"}
+        USERS_FILE=$(find ${USERS_DIR}/* -print)
+        USERS_LIST=""
+        READ_LIST_SUCCESS=0
+        # Read line by line, handle a missing EOL at the end of file
+        while read p || [ -n "$p" ] ; do
+          IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+          # Do not process empty lines
+          if [ -z "$USER_NAME" ]; then
+            continue
+          fi
+          if [[ "${USER_NAME// /}" != "$USER_NAME" ]]; then
+            continue
+          fi
+          echo "Creating user ${USER_NAME}..."
+          MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          if [[ $creation_result_exit_code -ne 0 ]]; then
+            # Check if the stderr contains "User already exists"
+            # this error occurs when password has changed
+            if [[ $creation_result == *"User already exists"* ]]; then
+              echo "Update user ${USER_NAME}"
+              # we will try to update by first deleting
+              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              if [[ $deletion_result_exit_code -ne 0 ]]; then
+                echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
+                READ_LIST_SUCCESS=1
+                break
+              fi
+              # Now we update the user
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              if [[ $update_result_exit_code -ne 0 ]]; then
+                echo "updating user ${USER_NAME} failed: ${update_result}"
+                READ_LIST_SUCCESS=1
+                break
+              else
+                echo "Updated user ${USER_NAME}..."
+                USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+              fi
+            else
+              # Another error occurred, so output the original message and exit code
+              echo "error creating user ${USER_NAME}: ${creation_result}"
+              READ_LIST_SUCCESS=1
+              break
+            fi
+          # On a success, the user was created so output that
+          else
+            echo "Created user ${USER_NAME}..."
+            USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+          fi
+        done < $USERS_FILE
+
+        if [[ -n "${USERS_LIST}" && ${READ_LIST_SUCCESS} ]]; then
+          echo "Setting superusers configurations with users [${USERS_LIST}]"
+          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
+          if [[ $superuser_result_exit_code -ne 0 ]]; then
+              echo "Setting superusers configurations failed: ${superuser_result}"
+          else
+              echo "Completed setting superusers configurations"
+          fi
+        fi
+      }
+
+      # first time processing
+      process_users $USERS_DIR
+
+      # subsequent changes detected here
+      # watching delete_self as documented in https://ahmet.im/blog/kubernetes-inotify/
+      USERS_FILE=$(find ${USERS_DIR}/* -print)
+      while RES=$(inotifywait -q -e delete_self ${USERS_FILE}); do
+        process_users $USERS_DIR
+      done
+    done
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: true
+    enable_sasl: true
+    enable_rack_awareness: false
+    superusers: 
+      - admin
+      - user1
+      - someuser
+      - anotherme
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: true
+      enable_sasl: true
+      superusers: ["admin","user1","someuser","anotherme"]
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+          authentication_method: sasl
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+          authentication_method: sasl
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+          authentication_method: http_basic
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+          authentication_method: http_basic
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: true
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 23a6a57fb6028034d1adf27f61b77ae24d5fa135db8c02c7b86828a1cfba15a4
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: redpanda-users
+          secret:
+            secretName: some-users
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          command: ["sh","-c","set -e; IFS=':' read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM \u003c \u003c(grep \"\" $(find /mnt/users/* -print)); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-SCRAM-SHA-512}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;  export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;  export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;  /app/console $@","--"]
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/users
+              name: redpanda-users
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 0766591fed04355f3be5edcbf374f613c0e290ec9a6a9a70c5747b8b6b94c0cb
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: some-users
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: some-users
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: some-users

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -1,0 +1,1308 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30090}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30090}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30090}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30070}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30070}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30070}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0.random-domain:30090
+          - redpanda-1.random-domain:30090
+          - redpanda-2.random-domain:30090
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0.random-domain:31644
+          - redpanda-1.random-domain:31644
+          - redpanda-2.random-domain:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 30090
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30070
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30080
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 0fb743a9bdf50317a9bd224403c52c992691819f7c107e176628a03e65f3a4ff
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: external-tls-secret
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+    - "random-domain"
+    - "*.random-domain"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: external-tls-secret
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: external-tls-secret
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -1,0 +1,1392 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}.random-domain\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0.random-domain:31092
+          - redpanda-1.random-domain:31092
+          - redpanda-2.random-domain:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0.random-domain:31644
+          - redpanda-1.random-domain:31644
+          - redpanda-2.random-domain:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/service.loadbalancer.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-redpanda-0
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    repdanda.com/type: "loadbalancer"
+spec:
+  type: LoadBalancer
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      targetPort: 9644
+      port: 31644
+    - name: kafka-default
+      protocol: TCP
+      targetPort: 9094
+      port: 31092
+    - name: http-default
+      protocol: TCP
+      targetPort: 8083
+      port: 30082
+    - name: schema-default
+      protocol: TCP
+      targetPort: 8084
+      port: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+    statefulset.kubernetes.io/pod-name: redpanda-0
+---
+# Source: redpanda/templates/service.loadbalancer.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-redpanda-1
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    repdanda.com/type: "loadbalancer"
+spec:
+  type: LoadBalancer
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      targetPort: 9644
+      port: 31644
+    - name: kafka-default
+      protocol: TCP
+      targetPort: 9094
+      port: 31092
+    - name: http-default
+      protocol: TCP
+      targetPort: 8083
+      port: 30082
+    - name: schema-default
+      protocol: TCP
+      targetPort: 8084
+      port: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+    statefulset.kubernetes.io/pod-name: redpanda-1
+---
+# Source: redpanda/templates/service.loadbalancer.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: lb-redpanda-2
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+    repdanda.com/type: "loadbalancer"
+spec:
+  type: LoadBalancer
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      targetPort: 9644
+      port: 31644
+    - name: kafka-default
+      protocol: TCP
+      targetPort: 9094
+      port: 31092
+    - name: http-default
+      protocol: TCP
+      targetPort: 8083
+      port: 30082
+    - name: schema-default
+      protocol: TCP
+      targetPort: 8084
+      port: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+    statefulset.kubernetes.io/pod-name: redpanda-2
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 0fb743a9bdf50317a9bd224403c52c992691819f7c107e176628a03e65f3a4ff
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: external-tls-secret
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+    - "random-domain"
+    - "*.random-domain"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: external-tls-secret
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: external-tls-secret
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -1,0 +1,1078 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="http://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail  ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent  ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX}  ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: false
+        urls:
+        - http://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - http://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - http://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: false
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "true"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: ade431c30419558a251714518e03badc5fc2c8086132a8143e1451340c4d730c
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: http://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 8df4a4e02a9691a55c354a2adc8da664140f1cb694d105b8def29e91000d67fc
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5  "http://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/servicemonitor.yaml
+# This servicemonitor is used by Prometheus Operator to scrape the metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  endpoints:
+  - interval: 30s
+    path: /public_metrics
+    port: admin
+  selector:
+    matchLabels:
+      monitoring.redpanda.com/enabled: "true"
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -1,0 +1,1429 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "true"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/templates/servicemonitor.yaml
+# This servicemonitor is used by Prometheus Operator to scrape the metrics
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  endpoints:
+  - interval: 30s
+    path: /public_metrics
+    port: admin
+    scheme: https
+    tlsConfig:
+      insecureSkipVerify: true
+  selector:
+    matchLabels:
+      monitoring.redpanda.com/enabled: "true"
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -1,0 +1,1627 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda-rpk-bundle
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - persistentvolumeclaims
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda-rpk-bundle
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda-rpk-bundle
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda-sidecar-controllers
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: redpanda-sidecar-controllers
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+        - name: redpanda-controllers
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.10-23.2.18
+          command:
+            - /manager
+          args:
+            - --operator-mode=false
+            - --namespace=default
+            - --health-probe-bind-address=:8085
+            - --metrics-bind-address=:9082
+            - --additional-controllers=all
+          env:
+            - name: REDPANDA_HELM_RELEASE_NAME
+              value: redpanda
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -1,0 +1,1405 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2000M"
+        - "--reserve-memory=0M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            requests:
+              cpu: 1
+              memory: 2500Mi
+            limits:
+              cpu: 1
+              memory: 2500Mi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -1,0 +1,1406 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE="$POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum | head -c 7)"
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"$PREFIX_TEMPLATE.my-domain\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE="$POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum | head -c 7)"
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"$PREFIX_TEMPLATE.my-domain\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE="$POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum | head -c 7)"
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"$PREFIX_TEMPLATE.my-domain\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE="$POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum | head -c 7)"
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"$PREFIX_TEMPLATE.my-domain\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE="$POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum | head -c 7)"
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"$PREFIX_TEMPLATE.my-domain\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE="$POD_ORDINAL-XYZ-$(echo -n $HOST_IP_ADDRESS | sha256sum | head -c 7)"
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"$PREFIX_TEMPLATE.my-domain\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - $PREFIX_TEMPLATE.my-domain:31092
+          - $PREFIX_TEMPLATE.my-domain:31092
+          - $PREFIX_TEMPLATE.my-domain:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - $PREFIX_TEMPLATE.my-domain:31644
+          - $PREFIX_TEMPLATE.my-domain:31644
+          - $PREFIX_TEMPLATE.my-domain:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 198e81db02d47b8d780f95a4f6f464ea68c47337efcc683bf633a3ca55f271f6
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+    - "my-domain"
+    - "*.my-domain"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+    - "my-domain"
+    - "*.my-domain"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env: []
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1515 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: ${AWS_ACCESS_KEY_ID}
+    cloud_storage_bucket: ${TEST_BUCKET}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: ${AWS_REGION}
+    cloud_storage_secret_key: ${AWS_SECRET_ACCESS_KEY}
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: tiered-storage-dir
+          emptyDir:
+            sizeLimit: 5.36870912e+09
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: ${AWS_SECRET_ACCESS_KEY}
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: ${AWS_ACCESS_KEY_ID}
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"${TEST_BUCKET}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"${AWS_REGION}"'
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1518 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
+    cloud_storage_api_endpoint: storage.googleapis.com
+    cloud_storage_bucket: ${TEST_BUCKET}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: US-WEST1
+    cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=1024M"
+        - "--reserve-memory=100M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 400m
+              memory: 2.0Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: tiered-storage-dir
+          emptyDir:
+            sizeLimit: 5.36870912e+09
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: ${GCP_SECRET_ACCESS_KEY}
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: ${GCP_ACCESS_KEY_ID}
+        - name: RPK_CLOUD_STORAGE_API_ENDPOINT
+          value: '"storage.googleapis.com"'
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"${TEST_BUCKET}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"US-WEST1"'
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1513 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
+    cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
+    cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=1024M"
+        - "--reserve-memory=100M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 400m
+              memory: 2.0Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: tiered-storage-dir
+          emptyDir:
+            sizeLimit: 5.36870912e+09
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: "managed-csi"
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_AZURE_CONTAINER
+          value: '"${TEST_STORAGE_CONTAINER}"'
+        - name: RPK_CLOUD_STORAGE_AZURE_SHARED_KEY
+          value: '"${TEST_AZURE_SHARED_KEY}"'
+        - name: RPK_CLOUD_STORAGE_AZURE_STORAGE_ACCOUNT
+          value: '"${TEST_STORAGE_ACCOUNT}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1523 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: ${AWS_ACCESS_KEY_ID}
+    cloud_storage_bucket: ${TEST_BUCKET}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: ${AWS_REGION}
+    cloud_storage_secret_key: ${AWS_SECRET_ACCESS_KEY}
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+    - metadata:
+        name: tiered-storage-dir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5.36870912e+09
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: ${AWS_SECRET_ACCESS_KEY}
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: ${AWS_ACCESS_KEY_ID}
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"${TEST_BUCKET}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"${AWS_REGION}"'
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1526 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
+    cloud_storage_api_endpoint: storage.googleapis.com
+    cloud_storage_bucket: ${TEST_BUCKET}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: US-WEST1
+    cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=1024M"
+        - "--reserve-memory=100M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 400m
+              memory: 2.0Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+    - metadata:
+        name: tiered-storage-dir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5.36870912e+09
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: ${GCP_SECRET_ACCESS_KEY}
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: ${GCP_ACCESS_KEY_ID}
+        - name: RPK_CLOUD_STORAGE_API_ENDPOINT
+          value: '"storage.googleapis.com"'
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"${TEST_BUCKET}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"US-WEST1"'
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1522 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
+    cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
+    cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=1024M"
+        - "--reserve-memory=100M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 400m
+              memory: 2.0Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: "managed-csi"
+        resources:
+          requests:
+            storage: "20Gi"
+    - metadata:
+        name: tiered-storage-dir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: managed-csi
+        resources:
+          requests:
+            storage: 5.36870912e+09
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_AZURE_CONTAINER
+          value: '"${TEST_STORAGE_CONTAINER}"'
+        - name: RPK_CLOUD_STORAGE_AZURE_SHARED_KEY
+          value: '"${TEST_AZURE_SHARED_KEY}"'
+        - name: RPK_CLOUD_STORAGE_AZURE_STORAGE_ACCOUNT
+          value: '"${TEST_STORAGE_ACCOUNT}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1523 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: ${AWS_ACCESS_KEY_ID}
+    cloud_storage_bucket: ${TEST_BUCKET}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: ${AWS_REGION}
+    cloud_storage_secret_key: ${AWS_SECRET_ACCESS_KEY}
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: shadow-index-cache
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: shadow-index-cache
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+    - metadata:
+        name: shadow-index-cache
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5.36870912e+09
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: ${AWS_SECRET_ACCESS_KEY}
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: ${AWS_ACCESS_KEY_ID}
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"${TEST_BUCKET}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"${AWS_REGION}"'
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1526 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
+    cloud_storage_api_endpoint: storage.googleapis.com
+    cloud_storage_bucket: ${TEST_BUCKET}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: US-WEST1
+    cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=1024M"
+        - "--reserve-memory=100M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: shadow-index-cache
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: shadow-index-cache
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 400m
+              memory: 2.0Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+    - metadata:
+        name: shadow-index-cache
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5.36870912e+09
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: ${GCP_SECRET_ACCESS_KEY}
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: ${GCP_ACCESS_KEY_ID}
+        - name: RPK_CLOUD_STORAGE_API_ENDPOINT
+          value: '"storage.googleapis.com"'
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"${TEST_BUCKET}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"US-WEST1"'
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -1,0 +1,1522 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
+    cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
+    cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
+    cloud_storage_cache_size: "5368709120"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_segment_max_upload_interval_sec: 1
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=1024M"
+        - "--reserve-memory=100M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: shadow-index-cache
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: shadow-index-cache
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 400m
+              memory: 2.0Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: "managed-csi"
+        resources:
+          requests:
+            storage: "20Gi"
+    - metadata:
+        name: shadow-index-cache
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: managed-csi
+        resources:
+          requests:
+            storage: 5.36870912e+09
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_SAMPLE_LICENSE}
+        - name: RPK_CLOUD_STORAGE_AZURE_CONTAINER
+          value: '"${TEST_STORAGE_CONTAINER}"'
+        - name: RPK_CLOUD_STORAGE_AZURE_SHARED_KEY
+          value: '"${TEST_AZURE_SHARED_KEY}"'
+        - name: RPK_CLOUD_STORAGE_AZURE_STORAGE_ACCOUNT
+          value: '"${TEST_STORAGE_ACCOUNT}"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "5368709120"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
+          value: "1"
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -1,0 +1,1633 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9MSUNFTlNFfQ=="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+      # Setup and export SASL bootstrap-user
+      IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+      MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+      rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} || true
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: "redpanda-users"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  users.txt: |-
+    admin:change-me:SCRAM-SHA-512
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    while true; do
+      echo "RUNNING: Monitoring and Updating SASL users"
+      USERS_DIR="/etc/secrets/users"
+
+      new_users_list(){
+        LIST=$1
+        NEW_USER=$2
+        if [[ -n "${LIST}" ]]; then
+          LIST="${NEW_USER},${LIST}"
+        else
+          LIST="${NEW_USER}"
+        fi
+
+        echo "${LIST}"
+      }
+
+      process_users() {
+        USERS_DIR=${1-"/etc/secrets/users"}
+        USERS_FILE=$(find ${USERS_DIR}/* -print)
+        USERS_LIST=""
+        READ_LIST_SUCCESS=0
+        # Read line by line, handle a missing EOL at the end of file
+        while read p || [ -n "$p" ] ; do
+          IFS=":" read -r USER_NAME PASSWORD MECHANISM <<< $p
+          # Do not process empty lines
+          if [ -z "$USER_NAME" ]; then
+            continue
+          fi
+          if [[ "${USER_NAME// /}" != "$USER_NAME" ]]; then
+            continue
+          fi
+          echo "Creating user ${USER_NAME}..."
+          MECHANISM=${MECHANISM:-SCRAM-SHA-512}
+          creation_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code
+          if [[ $creation_result_exit_code -ne 0 ]]; then
+            # Check if the stderr contains "User already exists"
+            # this error occurs when password has changed
+            if [[ $creation_result == *"User already exists"* ]]; then
+              echo "Update user ${USER_NAME}"
+              # we will try to update by first deleting
+              deletion_result=$(rpk acl user delete ${USER_NAME} 2>&1) && deletion_result_exit_code=$? || deletion_result_exit_code=$?
+              if [[ $deletion_result_exit_code -ne 0 ]]; then
+                echo "deletion of user ${USER_NAME} failed: ${deletion_result}"
+                READ_LIST_SUCCESS=1
+                break
+              fi
+              # Now we update the user
+              update_result=$(rpk acl user create ${USER_NAME} --password=${PASSWORD} --mechanism ${MECHANISM} 2>&1) && update_result_exit_code=$? || update_result_exit_code=$?  # On a non-success exit code
+              if [[ $update_result_exit_code -ne 0 ]]; then
+                echo "updating user ${USER_NAME} failed: ${update_result}"
+                READ_LIST_SUCCESS=1
+                break
+              else
+                echo "Updated user ${USER_NAME}..."
+                USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+              fi
+            else
+              # Another error occurred, so output the original message and exit code
+              echo "error creating user ${USER_NAME}: ${creation_result}"
+              READ_LIST_SUCCESS=1
+              break
+            fi
+          # On a success, the user was created so output that
+          else
+            echo "Created user ${USER_NAME}..."
+            USERS_LIST=$(new_users_list "${USERS_LIST}" "${USER_NAME}")
+          fi
+        done < $USERS_FILE
+
+        if [[ -n "${USERS_LIST}" && ${READ_LIST_SUCCESS} ]]; then
+          echo "Setting superusers configurations with users [${USERS_LIST}]"
+          superuser_result=$(rpk cluster config set superusers [${USERS_LIST}] 2>&1) && superuser_result_exit_code=$? || superuser_result_exit_code=$?
+          if [[ $superuser_result_exit_code -ne 0 ]]; then
+              echo "Setting superusers configurations failed: ${superuser_result}"
+          else
+              echo "Completed setting superusers configurations"
+          fi
+        fi
+      }
+
+      # first time processing
+      process_users $USERS_DIR
+
+      # subsequent changes detected here
+      # watching delete_self as documented in https://ahmet.im/blog/kubernetes-inotify/
+      USERS_FILE=$(find ${USERS_DIR}/* -print)
+      while RES=$(inotifywait -q -e delete_self ${USERS_FILE}); do
+        process_users $USERS_DIR
+      done
+    done
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: true
+    enable_sasl: true
+    enable_rack_awareness: false
+    superusers: 
+      - admin
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: true
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: true
+      enable_sasl: true
+      superusers: ["admin"]
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: true
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+          authentication_method: sasl
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+          authentication_method: sasl
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+          authentication_method: http_basic
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+    audit_log_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+          authentication_method: http_basic
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+          authentication_method: http_basic
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: true
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 23a6a57fb6028034d1adf27f61b77ae24d5fa135db8c02c7b86828a1cfba15a4
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: redpanda-users
+          secret:
+            secretName: redpanda-users
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          command: ["sh","-c","set -e; IFS=':' read -r KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM \u003c \u003c(grep \"\" $(find /mnt/users/* -print)); KAFKA_SASL_MECHANISM=${KAFKA_SASL_MECHANISM:-SCRAM-SHA-512}; export KAFKA_SASL_USERNAME KAFKA_SASL_PASSWORD KAFKA_SASL_MECHANISM;  export KAFKA_SCHEMAREGISTRY_USERNAME=$KAFKA_SASL_USERNAME;  export KAFKA_SCHEMAREGISTRY_PASSWORD=$KAFKA_SASL_PASSWORD;  /app/console $@","--"]
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/users
+              name: redpanda-users
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 3237c5214a7b800f207eb24759710c562761cc4eb64568b79c2bdc70010e6576
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: users
+              mountPath: /etc/secrets/users
+              readOnly: true
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: redpanda-users
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_LICENSE}
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: redpanda-users
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: users
+            mountPath: /etc/secrets/users
+            readOnly: true
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: users
+          secret:
+            secretName: redpanda-users

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -1,0 +1,1467 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: "JHtSRURQQU5EQV9MSUNFTlNFfQ=="
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: secrets
+          secret:
+            secretName: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: login-jwt-secret
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-console
+                  key: enterprise-license
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          value: ${REDPANDA_LICENSE}
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -1,0 +1,1412 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-license
+                  key: license-key
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license-key
+              name: redpanda-license
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -1,0 +1,1468 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: redpanda
+  namespace: default
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-sts-lifecycle
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/maintenance"
+
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/tls.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-config-watcher
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    echo "Waiting for cluster to be ready"
+    rpk cluster health --watch --exit-when-healthy
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-configurator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+type: Opaque
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data: 
+  
+  bootstrap.yaml: |
+    kafka_enable_authorization: false
+    enable_sasl: false
+    enable_rack_awareness: false
+          
+    default_topic_replications: 3
+    enable_idempotence: false
+    
+    compacted_log_segment_size: 67108864
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    topic_partitions_per_shard: 1000
+    storage_min_free_bytes: 1073741824
+  
+    audit_enabled: false
+  
+  redpanda.yaml: |
+    config_file: /etc/redpanda/redpanda.yaml
+    redpanda:
+      empty_seed_starts_cluster: false
+      kafka_enable_authorization: false
+      enable_sasl: false
+      default_topic_replications: 3
+      enable_idempotence: false
+      compacted_log_segment_size: 67108864
+      group_topic_partitions: 16
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      topic_partitions_per_shard: 1000
+      storage_min_free_bytes: 1073741824
+        
+      crash_loop_limit: "5"
+      audit_enabled: false
+  
+  
+      admin:
+        - name: internal
+          address: 0.0.0.0
+          port: 9644
+        - name: default
+          address: 0.0.0.0
+          port: 9645
+      admin_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 9093
+        - name: default
+          address: 0.0.0.0
+          port: 9094
+      kafka_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        enabled: true
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers: 
+        - host:
+            address: redpanda-0.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-1.redpanda.default.svc.cluster.local.
+            port: 33145
+        - host:
+            address: redpanda-2.redpanda.default.svc.cluster.local.
+            port: 33145
+    cloud_storage_access_key: test
+    cloud_storage_bucket: test
+    cloud_storage_cache_size: "11000000000"
+    cloud_storage_credentials_source: config_file
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: true
+    cloud_storage_region: test
+    cloud_storage_secret_key: test
+  
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    schema_registry:
+      schema_registry_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8081
+        - name: default
+          address: 0.0.0.0
+          port: 8084
+      schema_registry_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    pandaproxy_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        cert_file: /etc/tls/certs/default/tls.crt
+        key_file: /etc/tls/certs/default/tls.key
+        truststore_file: /etc/tls/certs/default/ca.crt
+    pandaproxy:
+      pandaproxy_api:
+        - name: internal
+          address: 0.0.0.0
+          port: 8082
+        - name: default
+          address: 0.0.0.0
+          port: 8083
+      pandaproxy_api_tls:
+        - name: internal
+          enabled: true
+          cert_file: /etc/tls/certs/default/tls.crt
+          key_file: /etc/tls/certs/default/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/default/ca.crt
+        - name: default
+          enabled: true
+          cert_file: /etc/tls/certs/external/tls.crt
+          key_file: /etc/tls/certs/external/tls.key
+          require_client_auth: false
+          truststore_file: /etc/tls/certs/external/ca.crt
+  
+    
+    rpk:
+      # redpanda server configuration
+      overprovisioned: false
+      enable_memory_locking: false
+      additional_start_flags:
+        - "--smp=1"
+        - "--memory=2048M"
+        - "--reserve-memory=205M"
+        - "--default-log-level=info"
+      # rpk tune entries
+      tune_aio_events: true
+    
+      # kafka connection configuration
+      kafka_api:
+        brokers: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9093
+          - redpanda-1.redpanda.default.svc.cluster.local.:9093
+          - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      admin_api:
+        addresses: 
+          - redpanda-0.redpanda.default.svc.cluster.local.:9644
+          - redpanda-1.redpanda.default.svc.cluster.local.:9644
+          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-rpk
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+data:
+  profile: | 
+    name: default
+    kafka_api:
+      brokers: 
+          - redpanda-0:31092
+          - redpanda-1:31092
+          - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    admin_api:
+      addresses: 
+          - redpanda-0:31644
+          - redpanda-1:31644
+          - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect: {}
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          enabled: true
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        enabled: true
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+# This service is only used to create the DNS enteries for each pod in
+# the stateful set and allow the serviceMonitor to target the pods.
+# This service should not be used by any client application
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda
+  namespace: "default"
+  labels:
+    monitoring.redpanda.com/enabled: "false"
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: ClusterIP
+  publishNotReadyAddresses: true
+  clusterIP: None
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+  ports:
+    - name: admin
+      protocol: TCP
+      port: 9644
+      targetPort: 9644
+    - name: http
+      protocol: TCP
+      port: 8082
+      targetPort: 8082
+    - name: kafka
+      protocol: TCP
+      port: 9093
+      targetPort: 9093
+    - name: rpc
+      protocol: TCP
+      port: 33145
+      targetPort: 33145
+    - name: schemaregistry
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+---
+# Source: redpanda/templates/services.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-external
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  type: NodePort
+  publishNotReadyAddresses: true
+  externalTrafficPolicy: Local
+  sessionAffinity: None
+  ports:
+    - name: admin-default
+      protocol: TCP
+      port: 9645
+      nodePort: 31644
+    - name: kafka-default
+      protocol: TCP
+      port: 9094
+      nodePort: 31092
+    - name: http-default
+      protocol: TCP
+      port: 8083
+      nodePort: 30082
+    - name: schema-default
+      protocol: TCP
+      port: 8084
+      nodePort: 30081
+  selector: 
+    app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            items:
+            - key: ca.crt
+              path: ca.crt
+            secretName: redpanda-default-cert
+        - name: redpanda-license
+          secret:
+            defaultMode: 272
+            secretName: redpanda-license
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: redpandadata/console-unstable:master-8a51854
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+            - mountPath: /mnt/test
+              name: redpanda-license
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+            - name: REDPANDA_ADMINAPI_TLS_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_TLS_CAFILEPATH
+              value: /mnt/cert/adminapi/default/ca.crt
+            - name: REDPANDA_ADMINAPI_ENABLED
+              value: "true"
+            - name: REDPANDA_ADMINAPI_URLS
+              value: https://redpanda.default.svc.cluster.local.:9644
+            - name: TEST
+              value: test
+            - name: LICENSE
+              valueFrom:
+                secretKeyRef:
+                  name: redpanda-license
+                  key: license-key
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selector:
+    matchLabels: 
+      app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
+  serviceName: redpanda
+  replicas: 3
+  updateStrategy:
+    type: RollingUpdate
+  podManagementPolicy: "Parallel"
+  template:
+    metadata:
+      labels: 
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
+        redpanda.com/poddisruptionbudget: redpanda
+      annotations:
+        config.redpanda.com/checksum: 1a37359565ee5aa39f2265200feb5613c0bb27495adde5a6e1cae726a786a953
+    spec:
+      terminationGracePeriodSeconds: 90
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      initContainers:
+        - name: tuning
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - rpk redpanda tune all
+          securityContext:
+            capabilities:
+              add: ["SYS_RESOURCE"]
+            privileged: true
+            runAsUser: 0
+            runAsGroup: 0
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda
+              mountPath: /etc/redpanda
+        - name: set-tiered-storage-cache-dir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+        - name: redpanda-configurator
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/bash
+            - -c
+            - 'trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}" & wait $!'
+          env:
+            - name: CONFIGURATOR_SCRIPT
+              value: /etc/secrets/configurator/scripts/configurator.sh
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: KUBERNETES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: HOST_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.hostIP
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: redpanda-configurator
+              mountPath: /etc/secrets/configurator/scripts/
+      containers:
+        - name: redpanda
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          env:
+            - name: SERVICE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+          # finish the lifecycle scripts with "true" to prevent them from terminating the pod prematurely
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                    true
+            preStop:
+              exec:
+                command:
+                  - /bin/bash
+                  - -c
+                  - |
+                    timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                    true # do not fail and cause the pod to terminate
+          # the startupProbe checks to see that the admin api is listening and that the broker has a node_id assigned. This
+          # check is only used to delay the start of the liveness and readiness probes until it passes.
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+                  echo $RESULT
+                  echo $RESULT | grep ready
+            initialDelaySeconds: 1
+            failureThreshold: 120
+            periodSeconds: 10
+          # the livenessProbe just checks to see that the admin api is listening and returning 200s.
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/tls.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+            initialDelaySeconds: 10
+            failureThreshold: 3
+            periodSeconds: 10
+          # the readiness probe just checks that the cluster is healthy according to rpk cluster health.
+          # It's ok that this cluster-wide check affects all the pods as it's only used for the
+          # PodDisruptionBudget and we don't want to roll any pods if the Redpanda cluster isn't healthy.
+          # https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets
+          # All services set `publishNotReadyAddresses:true` to prevent this from affecting cluster access
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -x
+                  RESULT=$(rpk cluster health)
+                  echo $RESULT
+                  echo $RESULT | grep 'Healthy:.*true'
+            initialDelaySeconds: 1
+            failureThreshold: 3
+            periodSeconds: 10
+            successThreshold: 1
+          command:
+            - rpk
+            - redpanda
+            - start
+            - "--advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145"
+          ports:
+            - name: admin
+              containerPort: 9644
+            - name: admin-default
+              containerPort: 9645
+            - name: http
+              containerPort: 8082
+            - name: http-default
+              containerPort: 8083
+            - name: kafka
+              containerPort: 9093
+            - name: kafka-default
+              containerPort: 9094
+            - name: rpc
+              containerPort: 33145
+            - name: schemaregistry
+              containerPort: 8081
+            - name: schema-default
+              containerPort: 8084
+          securityContext: 
+            runAsUser: 101
+            runAsGroup: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda
+              mountPath: /tmp/base-config
+            - name: lifecycle-scripts
+              mountPath: /var/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+            - name: tiered-storage-dir
+              mountPath: /var/lib/redpanda/data/cloud_storage_cache
+          resources:
+            limits:
+              cpu: 1
+              memory: 2.5Gi
+        - name: config-watcher
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: config
+              mountPath: /etc/redpanda
+            - name: redpanda-config-watcher
+              mountPath: /etc/secrets/config-watcher/scripts
+      volumes: 
+        
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+        - name: lifecycle-scripts
+          secret:
+            secretName: redpanda-sts-lifecycle
+            defaultMode: 0o775
+        - name: datadir
+          persistentVolumeClaim:
+            claimName: datadir
+        - name: tiered-storage-dir
+          emptyDir:
+            sizeLimit: 11G
+        - name: redpanda
+          configMap:
+            name: redpanda
+        - name: config
+          emptyDir: {}
+        - name: redpanda-configurator
+          secret:
+            secretName: redpanda-configurator
+            defaultMode: 0o775
+        - name: redpanda-config-watcher
+          secret:
+            secretName: redpanda-config-watcher
+            defaultMode: 0o775
+        - name: redpanda-fs-validator
+          secret:
+            secretName: redpanda-fs-validator
+            defaultMode: 0o775
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels: 
+              app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
+      nodeSelector:
+        {}
+      affinity:
+        
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: kubernetes.io/hostname
+            labelSelector:
+              matchLabels: 
+                app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
+      tolerations:
+        []
+  volumeClaimTemplates:
+    - metadata:
+        name: datadir
+        labels:
+          app.kubernetes.io/name: redpanda
+          app.kubernetes.io/instance: "redpanda"
+          app.kubernetes.io/component: redpanda
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: "20Gi"
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-default-root-certificate
+  secretName: redpanda-default-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the root CA certificate
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-root-certificate
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  duration: 43800h
+  isCA: true
+  commonName: redpanda-external-root-certificate
+  secretName: redpanda-external-root-certificate
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-default-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-default-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-default-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: redpanda-external-cert
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  dnsNames:
+    - redpanda-cluster.redpanda.default.svc.cluster.local
+    - redpanda-cluster.redpanda.default.svc
+    - redpanda-cluster.redpanda.default
+    - "*.redpanda-cluster.redpanda.default.svc.cluster.local"
+    - "*.redpanda-cluster.redpanda.default.svc"
+    - "*.redpanda-cluster.redpanda.default"
+    - redpanda.default.svc.cluster.local
+    - redpanda.default.svc
+    - redpanda.default
+    - "*.redpanda.default.svc.cluster.local"
+    - "*.redpanda.default.svc"
+    - "*.redpanda.default"
+  duration: 43800h
+  isCA: false
+  secretName: redpanda-external-cert
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  issuerRef:
+    name: redpanda-external-root-issuer
+    kind: Issuer
+    group: cert-manager.io
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-default-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# The self-signed issuer is used to create the self-signed CA
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-selfsigned-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+# This is the self-signed CA used to issue certs
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: redpanda-external-root-issuer
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.24
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-configuration
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-5"
+spec:
+  template:
+    metadata:
+      generateName: "redpanda-post-"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-install
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      containers:
+      - name: redpanda-post-install
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        
+        env:
+        - name: REDPANDA_LICENSE
+          valueFrom:
+            secretKeyRef:
+              key: license-key
+              name: redpanda-license
+        - name: RPK_CLOUD_STORAGE_SECRET_KEY
+          value: test
+        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
+          value: test
+        - name: RPK_CLOUD_STORAGE_BUCKET
+          value: '"test"'
+        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
+          value: "11000000000"
+        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
+          value: '"config_file"'
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_ENABLED
+          value: "true"
+        - name: RPK_CLOUD_STORAGE_REGION
+          value: '"test"'
+        command: ["bash","-c"]
+        args:
+          - |
+            set -e
+            if [[ -n "$REDPANDA_LICENSE" ]] then
+              rpk cluster license set "$REDPANDA_LICENSE"
+            fi
+
+            
+
+            
+            rpk cluster config export -f /tmp/cfg.yml
+
+            
+            for KEY in "${!RPK_@}"; do
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            done
+
+            
+            rpk cluster config import -f /tmp/cfg.yml
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440
+      serviceAccountName: default
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: redpanda-post-upgrade
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.7.34
+  annotations:
+    "helm.sh/hook": post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/hook-weight": "-10"
+spec:
+  template:
+    metadata:
+      name: "redpanda"
+      labels:
+        app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-post-upgrade
+    spec:
+      affinity:
+        {}
+      restartPolicy: Never
+      securityContext: 
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      containers:
+      - name: redpanda-post-upgrade
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
+        command: ["/bin/bash", "-c"]
+        args:
+          - |
+            set -e
+    
+            rpk cluster config set default_topic_replications 3
+            rpk cluster config set storage_min_free_bytes 1073741824
+            if [ -d "/etc/secrets/users/" ]; then
+                IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+                curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+                --cacert /etc/tls/certs/default/ca.crt \
+                -X PUT -u ${USER_NAME}:${PASSWORD} \
+                https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+            fi
+        securityContext: 
+          runAsUser: 101
+          runAsGroup: 101
+        volumeMounts:
+          - name: config
+            mountPath: /etc/redpanda
+          - name: redpanda-default-cert
+            mountPath: /etc/tls/certs/default
+          - name: redpanda-external-cert
+            mountPath: /etc/tls/certs/external
+      volumes: 
+        - name: config
+          configMap:
+            name: redpanda
+        - name: redpanda-default-cert
+          secret:
+            secretName: redpanda-default-cert
+            defaultMode: 0o440
+        - name: redpanda-external-cert
+          secret:
+            secretName: redpanda-external-cert
+            defaultMode: 0o440

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -14,7 +14,10 @@ type Enterprise struct {
 
 type Config struct {
 	Cluster ClusterConfig `json:"cluster,omitempty"`
+	Node    NodeConfig    `json:"node,omitempty"`
 }
+
+type NodeConfig map[string]any
 
 type ClusterConfig map[string]any
 

--- a/pkg/helm/flags.go
+++ b/pkg/helm/flags.go
@@ -31,6 +31,13 @@ func ToFlags(flagsStruct any) []string {
 			continue
 		}
 
+		if field.Type.Kind() == reflect.Slice {
+			for j := 0; j < v.Field(i).Len(); j++ {
+				flags = append(flags, fmt.Sprintf("--%s=%v", flag, v.Field(i).Index(j)))
+			}
+			continue
+		}
+
 		flags = append(flags, fmt.Sprintf("--%s=%v", flag, value))
 	}
 

--- a/pkg/helm/flags_test.go
+++ b/pkg/helm/flags_test.go
@@ -11,7 +11,8 @@ type Flags struct {
 	NoWait        bool `flag:"wait"`
 	NoWaitForJobs bool `flag:"no-wait-for-jobs"`
 	NotAFlag      string
-	StringFlag    string `flag:"string-flag"`
+	StringFlag    string   `flag:"string-flag"`
+	StringArray   []string `flag:"string-array"`
 }
 
 func TestToFlags(t *testing.T) {
@@ -41,6 +42,20 @@ func TestToFlags(t *testing.T) {
 				"--wait=true",
 				"--no-wait-for-jobs=false",
 				"--string-flag=something",
+			},
+		},
+		{
+			in: Flags{
+				StringFlag:  "something",
+				StringArray: []string{"1", "2", "3"},
+			},
+			out: []string{
+				"--wait=true",
+				"--no-wait-for-jobs=false",
+				"--string-flag=something",
+				"--string-array=1",
+				"--string-array=2",
+				"--string-array=3",
 			},
 		},
 	}

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -137,15 +137,16 @@ func (c *Client) GetValues(ctx context.Context, release *Release, values any) er
 }
 
 type InstallOptions struct {
-	CreateNamespace bool   `flag:"create-namespace"`
-	Name            string `flag:"-"`
-	Namespace       string `flag:"namespace"`
-	Values          any    `flag:"-"`
-	Version         string `flag:"version"`
-	NoWait          bool   `flag:"wait"`
-	NoWaitForJobs   bool   `flag:"wait-for-jobs"`
-	GenerateName    bool   `flag:"generate-name"`
-	ValuesFile      string `flag:"values"`
+	CreateNamespace bool     `flag:"create-namespace"`
+	Name            string   `flag:"-"`
+	Namespace       string   `flag:"namespace"`
+	Values          any      `flag:"-"`
+	Version         string   `flag:"version"`
+	NoWait          bool     `flag:"wait"`
+	NoWaitForJobs   bool     `flag:"wait-for-jobs"`
+	GenerateName    bool     `flag:"generate-name"`
+	ValuesFile      string   `flag:"values"`
+	Set             []string `flag:"set"`
 }
 
 func (c *Client) Install(ctx context.Context, chart string, opts InstallOptions) (Release, error) {
@@ -186,7 +187,17 @@ func (c *Client) Install(ctx context.Context, chart string, opts InstallOptions)
 	return c.Get(ctx, opts.Namespace, result["name"].(string))
 }
 
-func (c *Client) Template(ctx context.Context, chart string, opts InstallOptions) ([]byte, error) {
+type TemplateOptions struct {
+	Name         string   `flag:"-"`
+	Namespace    string   `flag:"namespace"`
+	Values       any      `flag:"-"`
+	Version      string   `flag:"version"`
+	GenerateName bool     `flag:"generate-name"`
+	ValuesFile   string   `flag:"values"`
+	Set          []string `flag:"set"`
+}
+
+func (c *Client) Template(ctx context.Context, chart string, opts TemplateOptions) ([]byte, error) {
 	if opts.Name == "" {
 		opts.GenerateName = true
 	}
@@ -200,7 +211,7 @@ func (c *Client) Template(ctx context.Context, chart string, opts InstallOptions
 	}
 
 	// TODO figure out how to remove kube-version.
-	args := []string{"template", chart, "--dry-run=client", "--kube-version=v1.21.0"}
+	args := []string{"template", chart, "--dry-run=client", "--kube-version=v1.21.0", "--debug"}
 	args = append(args, ToFlags(opts)...)
 
 	if opts.Name != "" {
@@ -216,15 +227,16 @@ func (c *Client) Template(ctx context.Context, chart string, opts InstallOptions
 }
 
 type UpgradeOptions struct {
-	CreateNamespace bool   `flag:"create-namespace"`
-	Install         bool   `flag:"install"`
-	Namespace       string `flag:"namespace"`
-	Version         string `flag:"version"`
-	NoWait          bool   `flag:"wait"`
-	NoWaitForJobs   bool   `flag:"wait-for-jobs"`
-	ReuseValues     bool   `flag:"reuse-values"`
-	Values          any    `flag:"-"`
-	ValuesFile      string `flag:"values"`
+	CreateNamespace bool     `flag:"create-namespace"`
+	Install         bool     `flag:"install"`
+	Namespace       string   `flag:"namespace"`
+	Version         string   `flag:"version"`
+	NoWait          bool     `flag:"wait"`
+	NoWaitForJobs   bool     `flag:"wait-for-jobs"`
+	ReuseValues     bool     `flag:"reuse-values"`
+	Values          any      `flag:"-"`
+	ValuesFile      string   `flag:"values"`
+	Set             []string `flag:"set"`
 }
 
 func (c *Client) Upgrade(ctx context.Context, release, chart string, opts UpgradeOptions) (Release, error) {


### PR DESCRIPTION
This commit implements golden/snapshot based testing for the redpanda chart by leveraging all the test files in `ci` and placing the resultant YAML into `testdata`.

It includes a minor fix to `_configmap.tpl` that caused some non-determinism. For other sources, `--set` flags are specified to work around them.