### PR TITLE
Add chart-testing and chart-releaser to flake.nix

### DIFF
--- a/.github/chart-releaser.nix
+++ b/.github/chart-releaser.nix
@@ -1,0 +1,63 @@
+# Pulled from https://github.com/NixOS/nixpkgs/blob/fa9f817df522ac294016af3d40ccff82f5fd3a63/pkgs/applications/networking/cluster/helm/chart-testing/default.nix#L62
+# and adapted to use https://github.com/helm/chart-releaser
+{ buildGoModule
+, coreutils
+, fetchFromGitHub
+, git
+, installShellFiles
+, lib
+, makeWrapper
+}:
+
+buildGoModule rec {
+  pname = "chart-releaser";
+  version = "1.6.0";
+
+  # Don't run tests.
+  doCheck = false;
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "helm";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rPNGg4nrDFIa1PAw3efFU/pQub33+QD0vNFu8kiU2/E=";
+  };
+
+  vendorHash = "sha256-zBVAER1RJy449GUndvQkG8R84vOuL+IN4exjETVHp9k=";
+
+  postPatch = ''
+    substituteInPlace pkg/config/config.go \
+      --replace "\"/etc/cr\"," "\"$out/etc/cr\","
+  '';
+
+  # https://github.com/helm/chart-releaser/blob/fa01315c4668d4fca627a5afc67409e31b27305c/.goreleaser.yml#L37
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/helm/chart-releaser/cr/cmd.Version=${version}"
+    "-X github.com/helm/chart-releaser/cr/cmd.GitCommit=${src.rev}"
+    "-X github.com/helm/chart-releaser/cr/cmd.BuildDate=19700101-00:00:00"
+  ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  postInstall = ''
+     installShellCompletion --cmd cr \
+       --bash <($out/bin/cr completion bash) \
+       --zsh <($out/bin/cr completion zsh) \
+       --fish <($out/bin/cr completion fish) \
+
+    wrapProgram $out/bin/cr --prefix PATH : ${lib.makeBinPath [
+      coreutils
+      git
+    ]}
+  '';
+
+  meta = with lib; {
+    description = "Hosting Helm Charts via GitHub Pages and Releases";
+    homepage = "https://github.com/helm/chart-releaser";
+    license = licenses.asl20;
+    mainProgram = "cr";
+  };
+}

--- a/.github/chart-testing.nix
+++ b/.github/chart-testing.nix
@@ -1,0 +1,73 @@
+# Pulled from https://github.com/NixOS/nixpkgs/blob/fa9f817df522ac294016af3d40ccff82f5fd3a63/pkgs/applications/networking/cluster/helm/chart-testing/default.nix#L62
+# and adapted to use https://github.com/joejulian/chart-testing
+{ buildGoModule
+, coreutils
+, fetchFromGitHub
+, git
+, installShellFiles
+, kubectl
+, kubernetes-helm
+, lib
+, makeWrapper
+, yamale
+, yamllint
+}:
+
+buildGoModule rec {
+  pname = "chart-testing";
+  version = "3.9.0-4";
+
+  # Don't run tests.
+  doCheck = false;
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "joejulian";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-MvFNOiHt9MiEd8I/qktN6MsN+FRYNu92utYQShqIIgQ=";
+  };
+
+  vendorHash = "sha256-9XdLSTr9FKuatJzpWM8AwrPtYDS+LC14bpz6evvJRuQ=";
+
+  postPatch = ''
+    substituteInPlace pkg/config/config.go \
+      --replace "\"/etc/ct\"," "\"$out/etc/ct\","
+  '';
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${version}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=${src.rev}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=19700101-00:00:00"
+  ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  postInstall = ''
+    install -Dm644 -t $out/etc/ct etc/chart_schema.yaml
+    install -Dm644 -t $out/etc/ct etc/lintconf.yaml
+
+    installShellCompletion --cmd ct \
+      --bash <($out/bin/ct completion bash) \
+      --zsh <($out/bin/ct completion zsh) \
+      --fish <($out/bin/ct completion fish) \
+
+    wrapProgram $out/bin/ct --prefix PATH : ${lib.makeBinPath [
+      coreutils
+      git
+      kubectl
+      kubernetes-helm
+      yamale
+      yamllint
+    ]}
+  '';
+
+  meta = with lib; {
+    description = "A tool for testing Helm charts";
+    homepage = "https://github.com/helm/chart-testing";
+    license = licenses.asl20;
+    mainProgram = "ct";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -30,6 +30,24 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-unstable": {
@@ -49,24 +67,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },


### PR DESCRIPTION
This commit adds the necessary nix files to install `chart-releaser`,
which is not available in nixpkgs, and joejuilian's fork of
`chart-testing`.

Doing so paves the way towards replacing unnecessary github actions
(anything that could be replaced with nix and a single shell command)
with nix to cut down on the duplication of dependencies.

This work was motivated by the sudden flakiness of installing github
actions. See also #1097.