### PR TITLE
replace chart-testing and helm github actions with nix

### DIFF
--- a/.github/chart-releaser.nix
+++ b/.github/chart-releaser.nix
@@ -1,0 +1,63 @@
+# Pulled from https://github.com/NixOS/nixpkgs/blob/fa9f817df522ac294016af3d40ccff82f5fd3a63/pkgs/applications/networking/cluster/helm/chart-testing/default.nix#L62
+# and adapted to use https://github.com/helm/chart-releaser
+{ buildGoModule
+, coreutils
+, fetchFromGitHub
+, git
+, installShellFiles
+, lib
+, makeWrapper
+}:
+
+buildGoModule rec {
+  pname = "chart-releaser";
+  version = "1.6.0";
+
+  # Don't run tests.
+  doCheck = false;
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "helm";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-rPNGg4nrDFIa1PAw3efFU/pQub33+QD0vNFu8kiU2/E=";
+  };
+
+  vendorHash = "sha256-zBVAER1RJy449GUndvQkG8R84vOuL+IN4exjETVHp9k=";
+
+  postPatch = ''
+    substituteInPlace pkg/config/config.go \
+      --replace "\"/etc/cr\"," "\"$out/etc/cr\","
+  '';
+
+  # https://github.com/helm/chart-releaser/blob/fa01315c4668d4fca627a5afc67409e31b27305c/.goreleaser.yml#L37
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/helm/chart-releaser/cr/cmd.Version=${version}"
+    "-X github.com/helm/chart-releaser/cr/cmd.GitCommit=${src.rev}"
+    "-X github.com/helm/chart-releaser/cr/cmd.BuildDate=19700101-00:00:00"
+  ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  postInstall = ''
+     installShellCompletion --cmd cr \
+       --bash <($out/bin/cr completion bash) \
+       --zsh <($out/bin/cr completion zsh) \
+       --fish <($out/bin/cr completion fish) \
+
+    wrapProgram $out/bin/cr --prefix PATH : ${lib.makeBinPath [
+      coreutils
+      git
+    ]}
+  '';
+
+  meta = with lib; {
+    description = "Hosting Helm Charts via GitHub Pages and Releases";
+    homepage = "https://github.com/helm/chart-releaser";
+    license = licenses.asl20;
+    mainProgram = "cr";
+  };
+}

--- a/.github/chart-testing.nix
+++ b/.github/chart-testing.nix
@@ -1,0 +1,73 @@
+# Pulled from https://github.com/NixOS/nixpkgs/blob/fa9f817df522ac294016af3d40ccff82f5fd3a63/pkgs/applications/networking/cluster/helm/chart-testing/default.nix#L62
+# and adapted to use https://github.com/joejulian/chart-testing
+{ buildGoModule
+, coreutils
+, fetchFromGitHub
+, git
+, installShellFiles
+, kubectl
+, kubernetes-helm
+, lib
+, makeWrapper
+, yamale
+, yamllint
+}:
+
+buildGoModule rec {
+  pname = "chart-testing";
+  version = "3.9.0-4";
+
+  # Don't run tests.
+  doCheck = false;
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "joejulian";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-MvFNOiHt9MiEd8I/qktN6MsN+FRYNu92utYQShqIIgQ=";
+  };
+
+  vendorHash = "sha256-9XdLSTr9FKuatJzpWM8AwrPtYDS+LC14bpz6evvJRuQ=";
+
+  postPatch = ''
+    substituteInPlace pkg/config/config.go \
+      --replace "\"/etc/ct\"," "\"$out/etc/ct\","
+  '';
+
+  ldflags = [
+    "-w"
+    "-s"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.Version=${version}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.GitCommit=${src.rev}"
+    "-X github.com/helm/chart-testing/v3/ct/cmd.BuildDate=19700101-00:00:00"
+  ];
+
+  nativeBuildInputs = [ installShellFiles makeWrapper ];
+
+  postInstall = ''
+    install -Dm644 -t $out/etc/ct etc/chart_schema.yaml
+    install -Dm644 -t $out/etc/ct etc/lintconf.yaml
+
+    installShellCompletion --cmd ct \
+      --bash <($out/bin/ct completion bash) \
+      --zsh <($out/bin/ct completion zsh) \
+      --fish <($out/bin/ct completion fish) \
+
+    wrapProgram $out/bin/ct --prefix PATH : ${lib.makeBinPath [
+      coreutils
+      git
+      kubectl
+      kubernetes-helm
+      yamale
+      yamllint
+    ]}
+  '';
+
+  meta = with lib; {
+    description = "A tool for testing Helm charts";
+    homepage = "https://github.com/helm/chart-testing";
+    license = licenses.asl20;
+    mainProgram = "ct";
+  };
+}

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,6 +16,10 @@
 # This is to test only the Redpanda Chart Nightly
 name: Nightly - Lint/Test Redpanda-Chart
 
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 on:
   schedule:
     - cron: '0 1 * * 1-5'  # 01:00 AM UTC Monday - Friday
@@ -24,24 +28,22 @@ jobs:
   lint:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.2
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
-
       - name: Run chart-testing (lint)
         run: ct lint --config .github/ct-redpanda.yaml
+
   test:
     name: Run ct tests for ci values matching ${{ matrix.testvaluespattern }} for Redpanda version ${{ matrix.version }}
     strategy:
@@ -60,10 +62,15 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
@@ -72,14 +79,6 @@ jobs:
         run: |
           echo bash -O extglob -c "rm -v charts/redpanda/ci/!(${{ matrix.testvaluespattern }})"
           bash -O extglob -c "rm -v charts/redpanda/ci/!(${{ matrix.testvaluespattern }})"
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.1
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -20,6 +20,11 @@ on:
   schedule:
     - cron: '0 2 * * 1-5'  # 01:00 AM UTC Monday - Friday
   workflow_dispatch: {}
+
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 jobs:
   test-redpanda-nightly:
     name: Run ct tests for ci values matching ${{ matrix.testvaluespattern }} for Redpanda nightly build
@@ -38,10 +43,15 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
@@ -51,9 +61,6 @@ jobs:
           echo bash -O extglob -c "rm -v charts/redpanda/ci/!(${{ matrix.testvaluespattern }})"
           bash -O extglob -c "rm -v charts/redpanda/ci/!(${{ matrix.testvaluespattern }})"
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version: '>=1.20.4'
       - run: go install github.com/joejulian/docker-tag-list@latest
 
       - name: Get latest nightly tag
@@ -62,14 +69,6 @@ jobs:
           echo "TAG=$(
             docker-tag-list -c '~0.0.0-0' --latest -r redpandadata/redpanda-nightly | sed 's/-a..64$//'
           )" >> $GITHUB_OUTPUT
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.2
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0

--- a/.github/workflows/pull_requests_connectors.yaml
+++ b/.github/workflows/pull_requests_connectors.yaml
@@ -31,19 +31,33 @@ on:
       - '!charts/operator/**'
       - '!charts/redpanda/**'
       - '!**/*.md'
+
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash {0} # Explicit restore the default for jobs not using nix.
     steps:
       - name: Noop
         run: echo noop
+
   version-and-lint:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
@@ -51,32 +65,27 @@ jobs:
       - name: Run CI file name checker
         run: .github/check-ci-files.sh charts/connectors/ci
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.2
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
-
       - name: Connectors lint
         run: ct lint --config .github/ct-connectors.yaml --github-groups
 
   check-values:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
 
-      - name: install dyff
-        run: curl -Ls https://github.com/homeport/dyff/releases/download/v1.5.6/dyff_1.5.6_linux_amd64.tar.gz | tar xzv dyff
       - name: compare connectors values with main
-        run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/connectors/values.yaml') charts/connectors/values.yaml
+        run: dyff --color=off -k between -s <(git show 'origin/main:charts/connectors/values.yaml') charts/connectors/values.yaml
 
   test:
     needs: lint
@@ -85,21 +94,18 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.1
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -31,6 +31,11 @@ on:
       - '!charts/kminion/**'
       - '!charts/operator/**'
       - '!**/*.md'
+
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 jobs:
   test:
     if: ${{ github.event.pull_request.head.repo.full_name == 'redpanda-data/helm-charts' }}
@@ -45,21 +50,18 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.2
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       # we're excluding console from testing until we have a way to test it with Redpanda
       - name: Run chart-testing (list-changed)

--- a/.github/workflows/pull_requests_kminion.yaml
+++ b/.github/workflows/pull_requests_kminion.yaml
@@ -31,19 +31,33 @@ on:
       - '!charts/operator/**'
       - '!charts/redpanda/**'
       - '!**/*.md'
+
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash {0} # Explicit restore the default for jobs not using nix.
     steps:
       - name: Noop
         run: echo noop
+
   version-and-lint:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
@@ -51,32 +65,27 @@ jobs:
       - name: Run CI file name checker
         run: .github/check-ci-files.sh charts/kminion/ci
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.2
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
-
       - name: Kminion lint
         run: ct lint --config .github/ct-kminion.yaml --github-groups
 
   check-values:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
 
-      - name: install dyff
-        run: curl -Ls https://github.com/homeport/dyff/releases/download/v1.5.6/dyff_1.5.6_linux_amd64.tar.gz | tar xzv dyff
       - name: compare kminion values with main
-        run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/kminion/values.yaml') charts/kminion/values.yaml
+        run: dyff --color=off -k between -s <(git show 'origin/main:charts/kminion/values.yaml') charts/kminion/values.yaml
 
   test:
     needs: lint
@@ -85,21 +94,18 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.1
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       - name: Run chart-testing (list-changed)
         id: list-changed

--- a/.github/workflows/pull_requests_operator.yaml
+++ b/.github/workflows/pull_requests_operator.yaml
@@ -32,19 +32,31 @@ on:
       - '!charts/redpanda/**'
       - '!**/*.md'
 
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash {0} # Explicit restore the default for jobs not using nix.
     steps:
       - name: Noop
         run: echo noop
   version-and-lint:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
@@ -52,32 +64,28 @@ jobs:
       - name: Run CI file name checker
         run: .github/check-ci-files.sh charts/operator/ci
 
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.12.2
-
-      - name: Set up chart-testing for operator
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
-
       - name: Operator lint
         run: ct lint --config .github/ct-operator.yaml --github-groups
 
   check-values:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
 
-      - name: install dyff
-        run: curl -Ls https://github.com/homeport/dyff/releases/download/v1.5.6/dyff_1.5.6_linux_amd64.tar.gz | tar xzv dyff
       - name: compare operator values with main
-        run: ./dyff --color=off -k between -s <(git show 'origin/main:charts/operator/values.yaml') charts/operator/values.yaml
+        run: dyff --color=off -k between -s <(git show 'origin/main:charts/operator/values.yaml') charts/operator/values.yaml
+
   test:
     needs: lint
     name: Run ct tests for operator chart
@@ -85,27 +93,24 @@ jobs:
       fail-fast: true
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - run: |
           git checkout main
           git checkout -
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.1
 
       - name: Get appVersion
         id: app_version
         uses: mikefarah/yq@master
         with:
           cmd: yq .appVersion charts/operator/Chart.yaml
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       # we're excluding console from testing until we have a way to test it with Redpanda
       - name: Run chart-testing (list-changed)

--- a/.github/workflows/pull_requests_redpanda.yaml
+++ b/.github/workflows/pull_requests_redpanda.yaml
@@ -33,9 +33,16 @@ on:
       - '!charts/operator/**'
       - '!**/*.md'
 
+defaults:
+  run:
+    shell: nix develop --impure --command bash {0}
+
 jobs:
   lint:
     runs-on: ubuntu-22.04
+    defaults:
+      run:
+        shell: bash {0} # Explicit restore the default for jobs not using nix.
     steps:
       - name: Noop
         run: echo noop
@@ -43,30 +50,29 @@ jobs:
   version-and-lint:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: cachix/install-nix-action@v26
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Redpanda lint
         run: task lint:chart:redpanda
-        shell: nix develop --impure --command bash {0}
 
   check-values:
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - uses: cachix/install-nix-action@v26
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
       - run: |
           git checkout main
@@ -74,11 +80,9 @@ jobs:
 
       - name: compare redpanda values with main
         run: dyff --color=off -k between -s <(git show 'origin/main:charts/redpanda/values.yaml') charts/redpanda/values.yaml
-        shell: nix develop --impure --command bash {0}
 
       - name: compare console values with main
         run: dyff --color=off -k between -s <(git show 'origin/main:charts/console/values.yaml') charts/console/values.yaml
-        shell: nix develop --impure --command bash {0}
 
   test:
     name: "${{ matrix.version }}/${{ matrix.testvaluespattern }}: Run ct tests"
@@ -101,6 +105,10 @@ jobs:
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:
+      - uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -108,15 +116,6 @@ jobs:
       - run: |
           git checkout main
           git checkout -
-
-
-      - name: Set up Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.11.1
-
-      - name: Set up chart-testing
-        uses: joejulian/chart-testing-action@9f27771144b6debb69e1f85d5f5a3eae8485d057  # v2.4.0-3
 
       # we're excluding console from testing until we have a way to test it with Redpanda
       - name: Run chart-testing (list-changed)
@@ -211,6 +210,7 @@ jobs:
             --skip-missing-values \
             --chart-dirs=charts/redpanda \
             --target-branch ${{ github.event.repository.default_branch }}
+
   summary:
     if: always()
     needs:

--- a/flake.lock
+++ b/flake.lock
@@ -1,20 +1,20 @@
 {
   "nodes": {
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
+        "lastModified": 1709336216,
+        "narHash": "sha256-Dt/wOWeW6Sqm11Yh+2+t0dfEWxoMxGBvv3JpIocFl9E=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7b3c975cf067e56e7cda6cb098ebe3fb4d74ca2",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -30,6 +30,24 @@
       "original": {
         "id": "nixpkgs",
         "type": "indirect"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1709237383,
+        "narHash": "sha256-cy6ArO4k5qTx+l5o+0mL9f5fa86tYUX3ozE1S+Txlds=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1536926ef5621b09bba54035ae2bb6d806d72ac8",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs-unstable": {
@@ -49,24 +67,9 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,7 @@
 
           devShells.default = pkgs.mkShell {
             buildInputs = [
+              pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               pkgs.chart-releaser
               pkgs.chart-testing
               pkgs.dyff


### PR DESCRIPTION
# Based on PR #1099

This commit removes all references to joejulian/chart-testing-action and
azure/setup-helm in favor of relying on nix to provide these packages.

There are a few side effects to this commit:
- All github actions are now run through `nix develop --impure --command
  bash`. This may interact strangely with the actions that install a
  dependency (ie kind) but would only result in running the version
  that's provided by nix.
- helm has been upgraded to `v3.14.2`

Fixes #1097.