### PR TITLE
actions: add minor workflow caching 

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -20,6 +20,12 @@ on:
     branches:
       - "**"
 
+# Cancel old workflows whenever a PR is updated.
+# Thanks to https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 defaults:
   run:
     shell: nix develop --impure --command bash {0}
@@ -39,33 +45,45 @@ jobs:
     - uses: dorny/paths-filter@v3
       id: chart-changes
       with:
-        predicate-quantifier: 'every'
+        # NOTE: changes to "auxiliary" files such as Taskfile.yaml and
+        # flake.nix won't trigger actions besides lint. This is intentional due
+        # to the long run times of chart-testing. It's possible to accidentally
+        # break the other chart workflows right now. Please ensure that you
+        # exercise changes to those files manually.
         filters: |
           charts-redpanda:
-            - 'charts/redpanda/**'
-            - '!charts/redpanda/**/*.md'
-            - '!charts/redpanda/**/*.golden'
-            - '!charts/redpanda/**/*.md.gotmpl'
+            - '.github/workflows/test_redpanda.yaml'
+            - 'charts/redpanda/ci/*'
+            - 'charts/redpanda/files/*'
+            - 'charts/redpanda/templates/**'
+            - 'charts/redpanda/(.helmignore|values.schema.json|Chart.yaml)'
           charts-console:
-            - 'charts/console/**'
-            - '!charts/console/**/*.md'
-            - '!charts/console/**/*.md.gotmpl'
+            - 'charts/console/ci/*'
+            - 'charts/console/files/*'
+            - 'charts/console/templates/**'
+            - 'charts/console/(.helmignore|values.schema.json|Chart.yaml)'
           charts-connectors:
-            - 'charts/connectors/**'
-            - '!charts/connectors/**/*.md'
-            - '!charts/connectors/**/*.md.gotmpl'
+            - '.github/workflows/test_connectors.yaml'
+            - 'charts/connectors/ci/*'
+            - 'charts/connectors/files/*'
+            - 'charts/connectors/templates/**'
+            - 'charts/connectors/(.helmignore|values.schema.json|Chart.yaml)'
           charts-kminion:
-            - 'charts/kminion/**'
-            - '!charts/kminion/**/*.md'
-            - '!charts/kminion/**/*.md.gotmpl'
+            - '.github/workflows/test_kminion.yaml'
+            - 'charts/kminion/ci/*'
+            - 'charts/kminion/files/*'
+            - 'charts/kminion/templates/**'
+            - 'charts/kminion/(.helmignore|values.schema.json|Chart.yaml)'
           charts-operator:
-            - 'charts/operator/**'
-            - '!charts/operator/**/*.md'
-            - '!charts/operator/**/*.md.gotmpl'
+            - '.github/workflows/test_operator.yaml'
+            - 'charts/operator/ci/*'
+            - 'charts/operator/files/*'
+            - 'charts/operator/templates/**'
+            - 'charts/operator/(.helmignore|values.schema.json|Chart.yaml)'
           go-code:
-            - '**/testdata/*'
-            - '**/*.go'
-            - '*.go'
+            - '.github/workflows/pull_requests.yaml'
+            - '**/testdata/**'
+            - '**.go'
             - 'go.mod'
             - 'go.sum'
 
@@ -75,6 +93,10 @@ jobs:
       - uses: cachix/install-nix-action@v26
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Cache the nix store.
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+
       - uses: actions/checkout@v4
       - run: task ci:lint
 
@@ -86,6 +108,7 @@ jobs:
       - uses: cachix/install-nix-action@v26
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
       - uses: actions/checkout@v4
       - run: go test ./... -short
 

--- a/.github/workflows/test_connectors.yaml
+++ b/.github/workflows/test_connectors.yaml
@@ -35,48 +35,40 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cache the nix store.
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+
+      # Cache helm repositories.
+      - uses: actions/cache@v4
+        with:
+          key: helm-repositories
+          path: |
+            ~/.cache/helm
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - run: |
-          git checkout main
-          git checkout -
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --config .github/ct-connectors.yaml)
-          echo "$changed"
-          if [[ -n "$changed" ]]; then
-            echo changed="true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
-        if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind.yaml
 
       - name: Check kind config worked
-        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl get nodes
 
       - name: install cert-manager
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           task helm:install:cert-manager
 
       - name: install Redpanda
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm dependency build charts/redpanda
           helm install --namespace redpanda --create-namespace redpanda charts/redpanda --wait --wait-for-jobs \
             --set connectors.enabled=false
 
       - name: Copy Redpanda tls cert to connectors chart
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl -n redpanda wait --for=condition=Ready --timeout=10m certificates/redpanda-default-cert
           mkdir -p charts/connectors/templates/hidden-only-for-ci
@@ -85,8 +77,14 @@ jobs:
             sed -e '/resourceVersion/d' | \
             sed -e '/uid/d'  > charts/connectors/templates/hidden-only-for-ci/redpanda-tls.yaml
 
+        # Chart-testing requires there to be a branch on the local repository
+        # for diffing. This will create such a branch without performing a
+        # checkout.
+      - name: Fetch origin/main
+        run: |
+          git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
+
       - name: Run chart-testing (install and upgrade)
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install \
             --github-groups \

--- a/.github/workflows/test_kminion.yaml
+++ b/.github/workflows/test_kminion.yaml
@@ -35,47 +35,39 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cache the nix store.
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+
+      # Cache helm repositories.
+      - uses: actions/cache@v4
+        with:
+          key: helm-repositories
+          path: |
+            ~/.cache/helm
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - run: |
-          git checkout main
-          git checkout -
-
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --config .github/ct-kminion.yaml)
-          echo "$changed"
-          if [[ -n "$changed" ]]; then
-            echo changed="true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
-        if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind.yaml
 
       - name: Check kind config worked
-        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl get nodes
 
       - name: install cert-manager
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           task helm:install:cert-manager
 
       - name: install Redpanda
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           helm dependency build charts/redpanda
           helm install --namespace redpanda --create-namespace redpanda charts/redpanda --wait --wait-for-jobs
 
       - name: Copy Redpanda tls cert to kminion chart
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl -n redpanda wait --for=condition=Ready --timeout=10m certificates/redpanda-default-cert
           kubectl -n redpanda get secret -o yaml redpanda-default-cert | \
@@ -83,8 +75,14 @@ jobs:
             sed -e '/resourceVersion/d' | \
             sed -e '/uid/d'  > charts/kminion/templates/redpanda-tls.yaml
 
+        # Chart-testing requires there to be a branch on the local repository
+        # for diffing. This will create such a branch without performing a
+        # checkout.
+      - name: Fetch origin/main
+        run: |
+          git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
+
       - name: Run chart-testing (install and upgrade)
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install \
             --github-groups \

--- a/.github/workflows/test_operator.yaml
+++ b/.github/workflows/test_operator.yaml
@@ -35,51 +35,48 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cache the nix store.
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+
+      # Cache helm repositories.
+      - uses: actions/cache@v4
+        with:
+          key: helm-repositories
+          path: |
+            ~/.cache/helm
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - run: |
-          git checkout main
-          git checkout -
-
-      # we're excluding console from testing until we have a way to test it with Redpanda
-      - name: Run chart-testing (list-changed)
-        id: list-changed
-        run: |
-          changed=$(ct list-changed --target-branch ${{ github.event.repository.default_branch }} --config .github/ct-operator.yaml)
-          echo "$changed"
-          if [[ -n "$changed" ]]; then
-            echo changed="true" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Create kind cluster
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0
-        if: steps.list-changed.outputs.changed == 'true'
         with:
           config: .github/kind.yaml
 
       - name: Check kind config worked
-        if: steps.list-changed.outputs.changed == 'true'
         run: kubectl get nodes
 
       - name: Annotate nodes for rack awareness
-        if: steps.list-changed.outputs.changed == 'true'
         run: .github/annotate_kind_nodes.sh chart-testing
 
       - name: install cert-manager
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           task helm:install:cert-manager
 
       - name: Install CRDs
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           kubectl kustomize https://github.com/redpanda-data/redpanda-operator//src/go/k8s/config/crd?ref="$(yq -r .appVersion charts/operator/Chart.yaml)" | kubectl apply -f -
 
+        # Chart-testing requires there to be a branch on the local repository
+        # for diffing. This will create such a branch without performing a
+        # checkout.
+      - name: Fetch origin/main
+        run: |
+          git fetch origin ${{ github.event.repository.default_branch }}:${{ github.event.repository.default_branch }}
+
       - name: Run chart-testing (install and upgrade)
-        if: steps.list-changed.outputs.changed == 'true'
         run: |
           ct install \
             --github-groups \

--- a/.github/workflows/test_redpanda.yaml
+++ b/.github/workflows/test_redpanda.yaml
@@ -35,6 +35,16 @@ jobs:
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Cache the nix store.
+      - uses: DeterminateSystems/magic-nix-cache-action@v4
+
+      # Cache helm repositories.
+      - uses: actions/cache@v4
+        with:
+          key: helm-repositories
+          path: |
+            ~/.cache/helm
+
       - name: Checkout
         uses: actions/checkout@v4
         with:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -63,8 +63,7 @@ tasks:
       # Fail on any generated diffs.
       - git diff --exit-code
       # Actually run linters.
-      # Need to ignore an error on predicate-quantifier until https://github.com/dorny/paths-filter/pull/226 is merged.
-      - actionlint -ignore 'input "predicate-quantifier"'
+      - actionlint
       - ct lint --chart-dirs ./charts --check-version-increment=false --github-groups --all
       - .github/check-ci-files.sh charts/connectors/ci
       - .github/check-ci-files.sh charts/kminion/ci


### PR DESCRIPTION
This commit integrates github's cache action and DeterminateSystem's
magic nix cache action into our various workflows. These will cache helm
repositories, which helps reduce flakiness and the nix store which can
shave a couple minutes off all tasks.

Additionally this commit re-works the file filters of the pull_request
github action. Requiring that all paths match resulted in some
inconsistent rule sets. The matching is now back to "one or more" and
relies on being very specific rather than being broad with negations.