### PR TITLE
operator: bump to latest release

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.19
+version: 0.4.20
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
-appVersion: v2.1.14-23.3.4
+appVersion: v2.1.15-23.3.7
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,11 +34,11 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.14-23.3.4
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.15-23.3.7
     - name: configurator
-      image: docker.redpanda.com/redpandadata/configurator:v2.1.14-23.3.4
+      image: docker.redpanda.com/redpandadata/configurator:v2.1.15-23.3.7
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.3.4
+      image: docker.redpanda.com/redpandadata/redpanda:v23.3.7
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   artifacthub.io/crds: |

--- a/charts/operator/templates/_helpers.tpl
+++ b/charts/operator/templates/_helpers.tpl
@@ -53,7 +53,7 @@ app.kubernetes.io/name: {{ include "redpanda-operator.name" . }}
 helm.sh/chart: {{ include "redpanda-operator.chart" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ include "operator.tag" . | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ with .Values.commonLabels }}


### PR DESCRIPTION
The automation for version bump is broken due to different versioning scheme. Community member rightfully commented that common label should adjust when container tag overwrite is set. 

### Reference

https://redpandacommunity.slack.com/archives/C048589SBEZ/p1711542050048489