### PR TITLE
Fix task chart lint redpanda target name

### DIFF
--- a/.github/workflows/pull_requests_redpanda.yaml
+++ b/.github/workflows/pull_requests_redpanda.yaml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
 
       - name: Redpanda lint
-        run: task lint:chart:redpanda
+        run: task chart:lint:redpanda
 
   check-values:
     runs-on: ubuntu-22.04

--- a/flake.nix
+++ b/flake.nix
@@ -66,7 +66,7 @@
                 # 2. Run `nix develop`
                 # 3. Copy the output value into vendorHash
                 # TODO: Figure out a better way to update this.
-                vendorHash = "sha256-68iCDOuD/h4BuscIXZPZu+RM3aAPc+tFX3AmEjnCIME=";
+                vendorHash = "sha256-ILhTJL3KBuZNXpCLxbWFGK7+9cUb2imPHjgfTxqnkjM=";
               };
             in
             {

--- a/go.mod
+++ b/go.mod
@@ -78,7 +78,6 @@ require (
 	github.com/texttheater/golang-levenshtein v1.0.1 // indirect
 	github.com/virtuald/go-ordered-json v0.0.0-20170621173500-b18e6e673d74 // indirect
 	golang.org/x/crypto v0.19.0 // indirect
-	golang.org/x/exp v0.0.0-20231006140011-7918f672742d // indirect
 	golang.org/x/mod v0.14.0 // indirect
 	golang.org/x/oauth2 v0.12.0 // indirect
 	golang.org/x/sync v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -193,8 +193,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.3.0/go.mod h1:hebNnKkNXi2UzZN1eVRvBB7co0a+JxK6XbPiWVs/3J4=
 golang.org/x/crypto v0.19.0 h1:ENy+Az/9Y1vSrlrvBSyna3PITt4tiZLf7sgCjZBX7Wo=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d h1:jtJma62tbqLibJ5sFQz8bKtEM8rJBtfilJ2qTU199MI=
-golang.org/x/exp v0.0.0-20231006140011-7918f672742d/go.mod h1:ldy0pHrwJyGW56pPQzzkH36rKxoZW1tw7ZJpeKx+hdo=
+golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
+golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4/go.mod h1:jJ57K6gSWd91VN4djpZkiMVwK6gcyfeH4XE8wZrZaV4=


### PR DESCRIPTION
In https://github.com/redpanda-data/helm-charts/pull/1101 the lint target https://github.com/redpanda-data/helm-charts/pull/1101/files#diff-1552e0a6f970b2191f0e8ef34ac62e41815fc6cdbc213921e915a042e500f03aR54 was renamed. This change correct the missmatch.

Another change is to run go mod tidy as CI is failing.

## Reference

```
task: Task "lint:chart:redpanda" does not exist
* generate:                      [Re]Generate all generated files
* shell:                         Launch a development shell
* chart:generate:redpanda:       Generate files for the redpanda Helm chart
Error: Process completed with exit code 200.
```

https://github.com/redpanda-data/helm-charts/actions/runs/8478776684/job/23231679902?pr=1119#step:4:173

```
error: builder for '/nix/store/cxx8a85k0jfi1ckcjx09zgl200v2733z-genpartial-0.0.0-go-modules.drv' failed with exit code 1;
       last 9 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/d7ahhn8qs0w1w3lmkzz5yb2v3l7aif06-source
       > source root is source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > Running phase: buildPhase
       > go: updates to go.mod needed; to update it:
       >      go mod tidy
```

https://github.com/redpanda-data/helm-charts/actions/runs/8479785383/job/23234405506?pr=1120#step:4:182