### PR TITLE
Change execution command log statement

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path"
 	"slices"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/errors"
@@ -309,7 +310,7 @@ func (c *Client) runHelm(ctx context.Context, args ...string) ([]byte, []byte, e
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
-	log.Printf("Executing: %#v", append([]string{"helm"}, args...))
+	log.Printf("Executing: %#v", strings.Join(append([]string{"helm"}, args...), " "))
 	cmd := exec.CommandContext(ctx, "helm", args...)
 
 	cmd.Env = c.env


### PR DESCRIPTION
This change helps to copy command that was generated in the test case.

Previously
```
2024/03/29 17:49:58 Executing: []string{"helm", "template", "redpanda", ".", "--dry-run=client", "--kube-version=v1.21.0", "--debug", "--generate-name=false", "--values=./ci/03-one-node-cluster-tls-no-sasl-values.yaml", "--set=tests.enabled=false", "--set=console.secret.login.jwtSecret=SECRETKEY"}
```

Now
```
2024/03/29 17:40:56 Executing: "helm template redpanda . --dry-run=client --kube-version=v1.21.0 --debug --generate-name=false --values=./ci/16-controller-sidecar-values.yaml --set=tests.enabled=false --set=console.secret.login.jwtSecret=SECRETKEY"
```