### PR TITLE
Assert that values does not change

### DIFF
--- a/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
@@ -1,0 +1,34 @@
+{{- /* Generated from "" */ -}}
+
+{{- define "_shims.typetest" -}}
+{{- $type := (index .a 0) -}}
+{{- $value := (index .a 1) -}}
+{{- dict "r" (list $value (typeIs $type $value)) | toJson -}}
+{{- end -}}
+
+{{- define "_shims.dicttest" -}}
+{{- $dict := (index .a 0) -}}
+{{- $key := (index .a 1) -}}
+{{- if (hasKey $dict $key) -}}
+{{- (dict "r" (list (index $dict $key) true)) | toJson -}}
+{{- else -}}
+{{- (dict "r" (list "" false)) | toJson -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.typeassertion" -}}
+{{- $type := (index .a 0) -}}
+{{- $value := (index .a 1) -}}
+{{- if (not (typeIs $type $value)) -}}
+{{- (fail "TODO MAKE THIS A NICE MESSAGE") -}}
+{{- end -}}
+{{- (dict "r" $value) | toJson -}}
+{{- end -}}
+
+{{- define "_shims.compact" -}}
+{{- $out := (dict) -}}
+{{- range $i, $e := (index .a 0) }}
+{{- $_ := (set $out (printf "T%d" (add1 $i)) $e) -}}
+{{- end -}}
+{{- (dict "r" $out) | toJson -}}
+{{- end -}}

--- a/pkg/gotohelm/testdata/src/example/changing_inputs/changing_inputs.go
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/changing_inputs.go
@@ -1,0 +1,14 @@
+package changing_inputs
+
+import (
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+)
+
+func ChangingInputs(dot *helmette.Dot) map[string]any {
+	for k, v := range dot.Values {
+		if _, ok := v.(string); ok {
+			dot.Values[k] = "change that"
+		}
+	}
+	return nil
+}

--- a/pkg/gotohelm/testdata/src/example/changing_inputs/changing_inputs.yaml
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/changing_inputs.yaml
@@ -1,0 +1,17 @@
+{{- /* Generated from "changing_inputs.go" */ -}}
+
+{{- define "changing_inputs.ChangingInputs" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- range $k, $v := $dot.Values -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "string" $v) ))) "r")) ))) "r") -}}
+{{- $ok_1 := $tmp_tuple_1.T2 -}}
+{{- if $ok_1 -}}
+{{- $_ := (set $dot.Values $k "change that") -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" nil) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/main.go
+++ b/pkg/gotohelm/testdata/src/example/main.go
@@ -8,6 +8,7 @@ import (
 
 	"example.com/example/a"
 	"example.com/example/b"
+	"example.com/example/changing_inputs"
 	"example.com/example/directives"
 	"example.com/example/flowcontrol"
 	"example.com/example/inputs"
@@ -100,6 +101,11 @@ func runChart(dot *helmette.Dot) (_ map[string]any, err any) {
 	case "inputs":
 		return map[string]any{
 			"Inputs": inputs.Inputs(dot),
+		}, nil
+
+	case "changing_inputs":
+		return map[string]any{
+			"ChangingInputs": changing_inputs.ChangingInputs(dot),
 		}, nil
 
 	default:


### PR DESCRIPTION
Tanspiler test suite can verify that input values has changed. That helps narrowing down badly written functions in any of the helm chart.