### PR TITLE
redpanda: add support for overriding default flags

### DIFF
--- a/.github/check-ci-files.sh
+++ b/.github/check-ci-files.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# CI files to run at all must has the right suffix *-values
+# CI files to run at all must has the right suffix *-{,no}values.yaml{,.tpl}
 # To avoid creating CI cases that will not run in CT we will check using
 # this script if any files added to a folder do not meet the expected suffix
 
@@ -11,7 +11,7 @@ exitCode=0
 for file in ${FILES}/*
 do
  echo verifying file: ${file}
- if [[ $file == *-values.yaml ]] || [[ $file == *-values.yaml.tpl ]] || [[ $file == *-novalues.yaml.tpl ]] ; then
+ if [[ $file == *-values.yaml ]] || [[ $file == *-values.yaml.tpl ]] || [[ $file == *-novalues.yaml.tpl ]] || [[ $file == *-novalues.yaml ]]; then
    continue
  else
    echo "- file does not match neither suffix '-values.yaml' nor -values.yaml.tpl'"

--- a/charts/redpanda/ci/30-additional-flags-override-novalues.yaml
+++ b/charts/redpanda/ci/30-additional-flags-override-novalues.yaml
@@ -1,0 +1,4 @@
+statefulset:
+  additionalRedpandaCmdFlags:
+    - "--smp=99"
+    - "--reserve-memory=9999"

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -1,0 +1,64 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +gotohelm:filename=_configmap.go.tpl
+package redpanda
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+)
+
+// RedpandaAdditionalStartFlags returns a string list of flags suitable for use
+// as `additional_start_flags`. User provided flags will override any of those
+// set by default.
+func RedpandaAdditionalStartFlags(dot *helmette.Dot, smp, memory, reserveMemory string) []string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	// All `additional_start_flags` that are set by the chart.
+	chartFlags := map[string]string{
+		"smp":               smp,
+		"memory":            fmt.Sprintf("%sM", memory),
+		"reserve-memory":    fmt.Sprintf("%sM", reserveMemory),
+		"default-log-level": values.Logging.LogLevel,
+	}
+
+	// If in developer_mode, don't set reserve-memory.
+	if values.Config.Node["developer_mode"] == true {
+		delete(chartFlags, "reserve-memory")
+	}
+
+	// Check to see if there are any flags overriding the defaults set by the
+	// chart.
+	for flag := range chartFlags {
+		for _, userFlag := range values.Statefulset.AdditionalRedpandaCmdFlags {
+			if helmette.RegexMatch(fmt.Sprintf("^--%s", flag), userFlag) {
+				delete(chartFlags, flag)
+			}
+		}
+	}
+
+	// Deterministically order out list and add in values supplied flags.
+	keys := helmette.Keys(chartFlags)
+	helmette.SortAlpha(keys)
+
+	flags := []string{}
+	for _, key := range keys {
+		flags = append(flags, fmt.Sprintf("--%s=%s", key, chartFlags[key]))
+	}
+
+	return append(flags, values.Statefulset.AdditionalRedpandaCmdFlags...)
+}

--- a/charts/redpanda/templates/_configmap.go.tpl
+++ b/charts/redpanda/templates/_configmap.go.tpl
@@ -1,0 +1,31 @@
+{{- /* Generated from "configmap.tpl.go" */ -}}
+
+{{- define "redpanda.RedpandaAdditionalStartFlags" -}}
+{{- $dot := (index .a 0) -}}
+{{- $smp := (index .a 1) -}}
+{{- $memory := (index .a 2) -}}
+{{- $reserveMemory := (index .a 3) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $chartFlags := (dict "smp" $smp "memory" (printf "%sM" $memory) "reserve-memory" (printf "%sM" $reserveMemory) "default-log-level" $values.logging.logLevel ) -}}
+{{- if (eq (index $values.config.node "developer_mode") true) -}}
+{{- $_ := (unset $chartFlags "reserve-memory") -}}
+{{- end -}}
+{{- range $flag, $_ := $chartFlags -}}
+{{- range $_, $userFlag := $values.statefulset.additionalRedpandaCmdFlags -}}
+{{- if (regexMatch (printf "^--%s" $flag) $userFlag) -}}
+{{- $_ := (unset $chartFlags $flag) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- $keys := (keys $chartFlags) -}}
+{{- $_ := (sortAlpha $keys) -}}
+{{- $flags := (list ) -}}
+{{- range $_, $key := $keys -}}
+{{- $flags = (mustAppend $flags (printf "--%s=%s" $key (index $chartFlags $key))) -}}
+{{- end -}}
+{{- (dict "r" (concat $flags $values.statefulset.additionalRedpandaCmdFlags)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/redpanda/templates/_configmap.tpl
+++ b/charts/redpanda/templates/_configmap.tpl
@@ -595,15 +595,7 @@ rpk:
   overprovisioned: {{ dig "cpu" "overprovisioned" false .Values.resources }}
   enable_memory_locking: {{ dig "memory" "enable_memory_locking" false .Values.resources }}
   additional_start_flags:
-    - "--smp={{ include "redpanda-smp" . }}"
-    - "--memory={{ template "redpanda-memory" . }}M"
-    {{- if not .Values.config.node.developer_mode }}
-    - "--reserve-memory={{ template "redpanda-reserve-memory" . }}M"
-    {{- end }}
-    - "--default-log-level={{ .Values.logging.logLevel }}"
-  {{- with .Values.statefulset.additionalRedpandaCmdFlags -}}
-  {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- get ((include "redpanda.RedpandaAdditionalStartFlags" (dict "a" (list . (include "redpanda-smp" .) (include "redpanda-memory" .) (include "redpanda-reserve-memory" .)))) | fromJson) "r" | toYaml | nindent 4 }}
 
   {{- with dig "config" "rpk" dict .Values.AsMap }}
   # config.rpk entries

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1229,7 +1231,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1231,7 +1229,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -25,10 +25,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -326,10 +327,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -375,7 +376,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -405,7 +406,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -517,7 +518,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -533,12 +534,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 63c329ba09b56f1dd83be951ffa92276a4629ad8a718d23cd4e7ac76a51d28e5
+        checksum-redpanda-chart/config: f95b24f953ead12c5fcbc88d8389bce0ad053498a3b052bcab9a28563c2281b4
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -887,7 +889,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -25,11 +25,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -376,7 +375,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -406,7 +405,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -518,7 +517,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -534,13 +533,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: f95b24f953ead12c5fcbc88d8389bce0ad053498a3b052bcab9a28563c2281b4
+        checksum-redpanda-chart/config: 63c329ba09b56f1dd83be951ffa92276a4629ad8a718d23cd4e7ac76a51d28e5
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -889,7 +887,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -437,7 +436,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -467,7 +466,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -575,7 +574,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -591,13 +590,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 81e2c7b7079444623a213600ed7e35f29bb4589ca326d13d6eeb33a2f0fb5ea5
+        checksum-redpanda-chart/config: 11b9b16f1898f78a96cf661b3ff71cbbe2f2af35281ef684edcf163c896c6a6c
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1194,7 +1192,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -384,10 +385,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -436,7 +437,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -466,7 +467,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -574,7 +575,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -590,12 +591,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 11b9b16f1898f78a96cf661b3ff71cbbe2f2af35281ef684edcf163c896c6a6c
+        checksum-redpanda-chart/config: 81e2c7b7079444623a213600ed7e35f29bb4589ca326d13d6eeb33a2f0fb5ea5
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1192,7 +1194,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -485,7 +484,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -515,7 +514,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -623,7 +622,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -639,13 +638,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: d7c9a4b4575b2e6f3a72961ced8bd0718c896f5409cdf7bf2b82cb0ce201fbc7
+        checksum-redpanda-chart/config: 3d078f24945f91d1b25df5c69c81ec92fca04aed1a5c9c06aca9dde2e185acd8
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1010,7 +1008,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -436,10 +437,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -484,7 +485,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -514,7 +515,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -622,7 +623,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -638,12 +639,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 3d078f24945f91d1b25df5c69c81ec92fca04aed1a5c9c06aca9dde2e185acd8
+        checksum-redpanda-chart/config: d7c9a4b4575b2e6f3a72961ced8bd0718c896f5409cdf7bf2b82cb0ce201fbc7
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1008,7 +1010,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -513,10 +514,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -565,7 +566,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -595,7 +596,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -703,7 +704,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -719,12 +720,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 5a9b1e5c0962bac2f65b693f82f9ff0d67d12a3ade7d51b0e03fc6879a1863e1
+        checksum-redpanda-chart/config: 6ad88a2e61bdf4de39a2de55a09a5d0d2570a72fc51587b139ba749925929100
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1343,7 +1345,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -566,7 +565,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -596,7 +595,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -704,7 +703,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -720,13 +719,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 6ad88a2e61bdf4de39a2de55a09a5d0d2570a72fc51587b139ba749925929100
+        checksum-redpanda-chart/config: 5a9b1e5c0962bac2f65b693f82f9ff0d67d12a3ade7d51b0e03fc6879a1863e1
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1345,7 +1343,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -489,7 +488,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -613,7 +612,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -721,7 +720,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -737,13 +736,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1340,7 +1338,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -428,10 +429,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -488,7 +489,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +613,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -720,7 +721,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -736,12 +737,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1338,7 +1340,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -468,10 +469,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -526,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -692,7 +693,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -708,12 +709,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: ade431c30419558a251714518e03badc5fc2c8086132a8143e1451340c4d730c
+        checksum-redpanda-chart/config: 43e388b4043ae0f1ea3c64c03ac63b5bad8a406c2dee57c90ffe6254eb88d967
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1406,7 +1408,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -527,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -561,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -693,7 +692,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -709,13 +708,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 43e388b4043ae0f1ea3c64c03ac63b5bad8a406c2dee57c90ffe6254eb88d967
+        checksum-redpanda-chart/config: ade431c30419558a251714518e03badc5fc2c8086132a8143e1451340c4d730c
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1408,7 +1406,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1230,7 +1228,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1228,7 +1230,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1255,7 +1257,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1257,7 +1255,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1235,7 +1233,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1233,7 +1235,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -594,7 +593,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,7 +627,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -736,7 +735,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -752,13 +751,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 12228d42f8c1e9a30a0e192e9ad02f3413ea17bd3f323309e8b4af2268dec566
+        checksum-redpanda-chart/config: 23a6a57fb6028034d1adf27f61b77ae24d5fa135db8c02c7b86828a1cfba15a4
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1377,7 +1375,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -533,10 +534,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -593,7 +594,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,7 +628,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -735,7 +736,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -751,12 +752,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 23a6a57fb6028034d1adf27f61b77ae24d5fa135db8c02c7b86828a1cfba15a4
+        checksum-redpanda-chart/config: 12228d42f8c1e9a30a0e192e9ad02f3413ea17bd3f323309e8b4af2268dec566
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1375,7 +1377,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1137,7 +1135,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1135,7 +1137,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -696,7 +695,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -712,13 +711,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1221,7 +1219,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -695,7 +696,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -711,12 +712,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1219,7 +1221,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -400,7 +399,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -434,7 +433,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -542,7 +541,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -558,13 +557,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 43e388b4043ae0f1ea3c64c03ac63b5bad8a406c2dee57c90ffe6254eb88d967
+        checksum-redpanda-chart/config: ade431c30419558a251714518e03badc5fc2c8086132a8143e1451340c4d730c
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -931,7 +929,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -343,10 +344,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -399,7 +400,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -433,7 +434,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -541,7 +542,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -557,12 +558,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: ade431c30419558a251714518e03badc5fc2c8086132a8143e1451340c4d730c
+        checksum-redpanda-chart/config: 43e388b4043ae0f1ea3c64c03ac63b5bad8a406c2dee57c90ffe6254eb88d967
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -929,7 +931,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1258,7 +1256,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1256,7 +1258,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -715,7 +716,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -823,7 +824,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -839,12 +840,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1454,7 +1456,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -716,7 +715,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -824,7 +823,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -840,13 +839,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1456,7 +1454,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1234,7 +1232,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2000M"
-        - "--reserve-memory=0M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2000M
+        - --reserve-memory=0M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1232,7 +1234,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1235,7 +1233,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1233,7 +1235,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -527,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -561,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -669,7 +668,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -685,13 +684,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1322,7 +1320,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -466,10 +467,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -526,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -668,7 +669,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -684,12 +685,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1320,7 +1322,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -528,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -562,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -670,7 +669,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -686,13 +685,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1323,7 +1321,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -526,7 +525,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +559,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -668,7 +667,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -684,13 +683,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1322,7 +1320,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -465,10 +466,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -525,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -559,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -667,7 +668,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -683,12 +684,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1320,7 +1322,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -419,10 +419,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -466,10 +467,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -526,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -668,7 +669,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -684,12 +685,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1328,7 +1330,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -527,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -561,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -669,7 +668,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -685,13 +684,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1330,7 +1328,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -467,10 +468,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -527,7 +528,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -561,7 +562,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -669,7 +670,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -685,12 +686,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1329,7 +1331,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -528,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -562,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -670,7 +669,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -686,13 +685,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1331,7 +1329,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -526,7 +525,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +559,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -668,7 +667,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -684,13 +683,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1331,7 +1329,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -465,10 +466,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -525,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -559,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -667,7 +668,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -683,12 +684,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1329,7 +1331,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -419,10 +419,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -466,10 +467,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -526,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -668,7 +669,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -684,12 +685,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1328,7 +1330,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -527,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -561,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -669,7 +668,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -685,13 +684,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1330,7 +1328,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -467,10 +468,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -527,7 +528,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -561,7 +562,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -669,7 +670,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -685,12 +686,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1329,7 +1331,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -528,7 +527,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -562,7 +561,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -670,7 +669,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -686,13 +685,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1331,7 +1329,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -526,7 +525,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -560,7 +559,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -668,7 +667,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -684,13 +683,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1331,7 +1329,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -465,10 +466,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -525,7 +526,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -559,7 +560,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -667,7 +668,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -683,12 +684,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1329,7 +1331,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -419,10 +419,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=1024M"
-        - "--reserve-memory=100M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=1024M
+        - --reserve-memory=100M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -33,53 +33,6 @@ metadata:
     app.kubernetes.io/version: "v2.4.5"
     app.kubernetes.io/managed-by: Helm
 ---
-# Source: redpanda/templates/console/configmap-and-deployment.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: redpanda-console
-  labels:
-    helm.sh/chart: console-0.7.25
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
-    app.kubernetes.io/managed-by: Helm
-    
-type: Opaque
-data:
-  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
-  # For this reason we can't use `with` to change the scope.
-  # Kafka
-  kafka-sasl-password: ""
-  kafka-protobuf-git-basicauth-password: ""
-  kafka-sasl-aws-msk-iam-secret-key: ""
-  kafka-tls-ca: ""
-  kafka-tls-cert: ""
-  kafka-tls-key: ""
-  kafka-schema-registry-password: ""
-  kafka-schemaregistry-tls-ca: ""
-  kafka-schemaregistry-tls-cert: ""
-  kafka-schemaregistry-tls-key: ""
-
-  # Login
-  login-jwt-secret: "U0VDUkVUS0VZ"
-  login-google-oauth-client-secret: ""
-  login-google-groups-service-account.json: ""
-  login-github-oauth-client-secret: ""
-  login-github-personal-access-token: ""
-  login-okta-client-secret: ""
-  login-okta-directory-api-token: ""
-  login-oidc-client-secret: ""
-
-  # Enterprise
-  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
-
-  # Redpanda
-  redpanda-admin-api-password: ""
-  redpanda-admin-api-tls-ca: ""
-  redpanda-admin-api-tls-cert: ""
-  redpanda-admin-api-tls-key: ""
----
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
 kind: Secret
@@ -378,17 +331,6 @@ data:
         - host:
             address: redpanda-2.redpanda.default.svc.cluster.local.
             port: 33145
-    cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
-    cloud_storage_api_endpoint: storage.googleapis.com
-    cloud_storage_bucket: ${TEST_BUCKET}
-    cloud_storage_cache_size: "5368709120"
-    cloud_storage_credentials_source: config_file
-    cloud_storage_enable_remote_read: true
-    cloud_storage_enable_remote_write: true
-    cloud_storage_enabled: true
-    cloud_storage_region: US-WEST1
-    cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
-    cloud_storage_segment_max_upload_interval_sec: 1
   
     schema_registry_client:
       brokers:
@@ -469,9 +411,9 @@ data:
       enable_memory_locking: false
       additional_start_flags:
         - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
+        - --memory=2048M
+        - --smp=99
+        - --reserve-memory=9999
       # rpk tune entries
       tune_aio_events: true
     
@@ -700,9 +642,6 @@ spec:
         - name: configs
           configMap:
             name: redpanda-console
-        - name: secrets
-          secret:
-            secretName: redpanda-console
         - name: kafka-default-cert
           secret:
             defaultMode: 272
@@ -730,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: redpandadata/console-unstable:master-8a51854
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -739,9 +678,6 @@ spec:
           volumeMounts:
             - name: configs
               mountPath: /etc/console/configs
-              readOnly: true
-            - name: secrets
-              mountPath: /etc/console/secrets
               readOnly: true
             - mountPath: /mnt/cert/kafka/default
               name: kafka-default-cert
@@ -785,16 +721,6 @@ spec:
               value: "true"
             - name: REDPANDA_ADMINAPI_URLS
               value: https://redpanda.default.svc.cluster.local.:9644
-            - name: LOGIN_JWTSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: redpanda-console
-                  key: login-jwt-secret
-            - name: LICENSE
-              valueFrom:
-                secretKeyRef:
-                  name: redpanda-console
-                  key: enterprise-license
       priorityClassName:
 ---
 # Source: redpanda/templates/statefulset.yaml
@@ -827,7 +753,7 @@ spec:
         app.kubernetes.io/name: redpanda
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -855,19 +781,6 @@ spec:
               mountPath: /etc/tls/certs/external
             - name: redpanda
               mountPath: /etc/redpanda
-        - name: set-tiered-storage-cache-dir-ownership
-          image: busybox:latest
-          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
-          volumeMounts: 
-            
-            - name: redpanda-default-cert
-              mountPath: /etc/tls/certs/default
-            - name: redpanda-external-cert
-              mountPath: /etc/tls/certs/external
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
-            - name: tiered-storage-dir
-              mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
           command:
@@ -1024,12 +937,10 @@ spec:
               mountPath: /var/lifecycle
             - name: datadir
               mountPath: /var/lib/redpanda/data
-            - name: tiered-storage-dir
-              mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
             limits:
-              cpu: 400m
-              memory: 2.0Gi
+              cpu: 1
+              memory: 2.5Gi
         - name: config-watcher
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
           command:
@@ -1064,9 +975,6 @@ spec:
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: tiered-storage-dir
-          emptyDir:
-            sizeLimit: 5.36870912e+09
         - name: redpanda
           configMap:
             name: redpanda
@@ -1377,31 +1285,7 @@ spec:
       - name: redpanda-post-install
         image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
         
-        env:
-        - name: REDPANDA_LICENSE
-          value: ${REDPANDA_SAMPLE_LICENSE}
-        - name: RPK_CLOUD_STORAGE_SECRET_KEY
-          value: ${GCP_SECRET_ACCESS_KEY}
-        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
-          value: ${GCP_ACCESS_KEY_ID}
-        - name: RPK_CLOUD_STORAGE_API_ENDPOINT
-          value: '"storage.googleapis.com"'
-        - name: RPK_CLOUD_STORAGE_BUCKET
-          value: '"${TEST_BUCKET}"'
-        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
-          value: "5368709120"
-        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
-          value: '"config_file"'
-        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
-          value: "true"
-        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
-          value: "true"
-        - name: RPK_CLOUD_STORAGE_ENABLED
-          value: "true"
-        - name: RPK_CLOUD_STORAGE_REGION
-          value: '"US-WEST1"'
-        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
-          value: "1"
+        env: []
         command: ["bash","-c"]
         args:
           - |

--- a/charts/redpanda/testdata/30-additional-flags-override-values.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-values.yaml.golden
@@ -15,70 +15,22 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels: 
-      app.kubernetes.io/component: redpanda-statefulset
-      app.kubernetes.io/instance: redpanda
       app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
       redpanda.com/poddisruptionbudget: redpanda
 ---
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
     app.kubernetes.io/managed-by: Helm
----
-# Source: redpanda/templates/console/configmap-and-deployment.yaml
-apiVersion: v1
-kind: Secret
-metadata:
-  name: redpanda-console
-  labels:
-    helm.sh/chart: console-0.7.25
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
-    app.kubernetes.io/managed-by: Helm
-    
-type: Opaque
-data:
-  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
-  # For this reason we can't use `with` to change the scope.
-  # Kafka
-  kafka-sasl-password: ""
-  kafka-protobuf-git-basicauth-password: ""
-  kafka-sasl-aws-msk-iam-secret-key: ""
-  kafka-tls-ca: ""
-  kafka-tls-cert: ""
-  kafka-tls-key: ""
-  kafka-schema-registry-password: ""
-  kafka-schemaregistry-tls-ca: ""
-  kafka-schemaregistry-tls-cert: ""
-  kafka-schemaregistry-tls-key: ""
-
-  # Login
-  login-jwt-secret: "U0VDUkVUS0VZ"
-  login-google-oauth-client-secret: ""
-  login-google-groups-service-account.json: ""
-  login-github-oauth-client-secret: ""
-  login-github-personal-access-token: ""
-  login-okta-client-secret: ""
-  login-okta-directory-api-token: ""
-  login-oidc-client-secret: ""
-
-  # Enterprise
-  enterprise-license: "JHtSRURQQU5EQV9TQU1QTEVfTElDRU5TRX0="
-
-  # Redpanda
-  redpanda-admin-api-password: ""
-  redpanda-admin-api-tls-ca: ""
-  redpanda-admin-api-tls-cert: ""
-  redpanda-admin-api-tls-key: ""
 ---
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
@@ -378,17 +330,6 @@ data:
         - host:
             address: redpanda-2.redpanda.default.svc.cluster.local.
             port: 33145
-    cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
-    cloud_storage_api_endpoint: storage.googleapis.com
-    cloud_storage_bucket: ${TEST_BUCKET}
-    cloud_storage_cache_size: "5368709120"
-    cloud_storage_credentials_source: config_file
-    cloud_storage_enable_remote_read: true
-    cloud_storage_enable_remote_write: true
-    cloud_storage_enabled: true
-    cloud_storage_region: US-WEST1
-    cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
-    cloud_storage_segment_max_upload_interval_sec: 1
   
     schema_registry_client:
       brokers:
@@ -469,9 +410,9 @@ data:
       enable_memory_locking: false
       additional_start_flags:
         - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
+        - --memory=2048M
+        - --smp=99
+        - --reserve-memory=9999
       # rpk tune entries
       tune_aio_events: true
     
@@ -528,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -562,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -600,9 +541,9 @@ spec:
   publishNotReadyAddresses: true
   clusterIP: None
   selector: 
-    app.kubernetes.io/component: redpanda-statefulset
-    app.kubernetes.io/instance: redpanda
     app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
   ports:
     - name: admin
       protocol: TCP
@@ -660,9 +601,9 @@ spec:
       port: 8084
       nodePort: 30081
   selector: 
-    app.kubernetes.io/component: redpanda-statefulset
-    app.kubernetes.io/instance: redpanda
     app.kubernetes.io/name: redpanda
+    app.kubernetes.io/instance: "redpanda"
+    app.kubernetes.io/component: redpanda-statefulset
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 apiVersion: apps/v1
@@ -670,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -686,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -700,9 +640,6 @@ spec:
         - name: configs
           configMap:
             name: redpanda-console
-        - name: secrets
-          secret:
-            secretName: redpanda-console
         - name: kafka-default-cert
           secret:
             defaultMode: 272
@@ -730,7 +667,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: redpandadata/console-unstable:master-8a51854
+          image: docker.redpanda.com/redpandadata/console:v2.4.5
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -739,9 +676,6 @@ spec:
           volumeMounts:
             - name: configs
               mountPath: /etc/console/configs
-              readOnly: true
-            - name: secrets
-              mountPath: /etc/console/secrets
               readOnly: true
             - mountPath: /mnt/cert/kafka/default
               name: kafka-default-cert
@@ -785,16 +719,6 @@ spec:
               value: "true"
             - name: REDPANDA_ADMINAPI_URLS
               value: https://redpanda.default.svc.cluster.local.:9644
-            - name: LOGIN_JWTSECRET
-              valueFrom:
-                secretKeyRef:
-                  name: redpanda-console
-                  key: login-jwt-secret
-            - name: LICENSE
-              valueFrom:
-                secretKeyRef:
-                  name: redpanda-console
-                  key: enterprise-license
       priorityClassName:
 ---
 # Source: redpanda/templates/statefulset.yaml
@@ -811,9 +735,9 @@ metadata:
 spec:
   selector:
     matchLabels: 
-      app.kubernetes.io/component: redpanda-statefulset
-      app.kubernetes.io/instance: redpanda
       app.kubernetes.io/name: redpanda
+      app.kubernetes.io/instance: "redpanda"
+      app.kubernetes.io/component: redpanda-statefulset
   serviceName: redpanda
   replicas: 3
   updateStrategy:
@@ -822,12 +746,12 @@ spec:
   template:
     metadata:
       labels: 
-        app.kubernetes.io/component: redpanda-statefulset
-        app.kubernetes.io/instance: redpanda
         app.kubernetes.io/name: redpanda
+        app.kubernetes.io/instance: "redpanda"
+        app.kubernetes.io/component: redpanda-statefulset
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
+        config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -855,19 +779,6 @@ spec:
               mountPath: /etc/tls/certs/external
             - name: redpanda
               mountPath: /etc/redpanda
-        - name: set-tiered-storage-cache-dir-ownership
-          image: busybox:latest
-          command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']
-          volumeMounts: 
-            
-            - name: redpanda-default-cert
-              mountPath: /etc/tls/certs/default
-            - name: redpanda-external-cert
-              mountPath: /etc/tls/certs/external
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
-            - name: tiered-storage-dir
-              mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
           command:
@@ -1024,12 +935,10 @@ spec:
               mountPath: /var/lifecycle
             - name: datadir
               mountPath: /var/lib/redpanda/data
-            - name: tiered-storage-dir
-              mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
             limits:
-              cpu: 400m
-              memory: 2.0Gi
+              cpu: 1
+              memory: 2.5Gi
         - name: config-watcher
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
           command:
@@ -1064,9 +973,6 @@ spec:
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: tiered-storage-dir
-          emptyDir:
-            sizeLimit: 5.36870912e+09
         - name: redpanda
           configMap:
             name: redpanda
@@ -1090,9 +996,9 @@ spec:
           whenUnsatisfiable: ScheduleAnyway
           labelSelector:
             matchLabels: 
-              app.kubernetes.io/component: redpanda-statefulset
-              app.kubernetes.io/instance: redpanda
               app.kubernetes.io/name: redpanda
+              app.kubernetes.io/instance: "redpanda"
+              app.kubernetes.io/component: redpanda-statefulset
       nodeSelector:
         {}
       affinity:
@@ -1102,9 +1008,9 @@ spec:
           - topologyKey: kubernetes.io/hostname
             labelSelector:
               matchLabels: 
-                app.kubernetes.io/component: redpanda-statefulset
-                app.kubernetes.io/instance: redpanda
                 app.kubernetes.io/name: redpanda
+                app.kubernetes.io/instance: "redpanda"
+                app.kubernetes.io/component: redpanda-statefulset
       tolerations:
         []
   volumeClaimTemplates:
@@ -1323,7 +1229,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -1377,31 +1283,7 @@ spec:
       - name: redpanda-post-install
         image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
         
-        env:
-        - name: REDPANDA_LICENSE
-          value: ${REDPANDA_SAMPLE_LICENSE}
-        - name: RPK_CLOUD_STORAGE_SECRET_KEY
-          value: ${GCP_SECRET_ACCESS_KEY}
-        - name: RPK_CLOUD_STORAGE_ACCESS_KEY
-          value: ${GCP_ACCESS_KEY_ID}
-        - name: RPK_CLOUD_STORAGE_API_ENDPOINT
-          value: '"storage.googleapis.com"'
-        - name: RPK_CLOUD_STORAGE_BUCKET
-          value: '"${TEST_BUCKET}"'
-        - name: RPK_CLOUD_STORAGE_CACHE_SIZE
-          value: "5368709120"
-        - name: RPK_CLOUD_STORAGE_CREDENTIALS_SOURCE
-          value: '"config_file"'
-        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_READ
-          value: "true"
-        - name: RPK_CLOUD_STORAGE_ENABLE_REMOTE_WRITE
-          value: "true"
-        - name: RPK_CLOUD_STORAGE_ENABLED
-          value: "true"
-        - name: RPK_CLOUD_STORAGE_REGION
-          value: '"US-WEST1"'
-        - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
-          value: "1"
+        env: []
         command: ["bash","-c"]
         args:
           - |

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -410,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -649,7 +648,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -683,7 +682,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -791,7 +790,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -807,13 +806,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 12228d42f8c1e9a30a0e192e9ad02f3413ea17bd3f323309e8b4af2268dec566
+        checksum-redpanda-chart/config: 23a6a57fb6028034d1adf27f61b77ae24d5fa135db8c02c7b86828a1cfba15a4
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1448,7 +1446,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -588,10 +589,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -648,7 +649,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -682,7 +683,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -790,7 +791,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -806,12 +807,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 23a6a57fb6028034d1adf27f61b77ae24d5fa135db8c02c7b86828a1cfba15a4
+        checksum-redpanda-chart/config: 12228d42f8c1e9a30a0e192e9ad02f3413ea17bd3f323309e8b4af2268dec566
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1446,7 +1448,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -38,7 +39,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -456,10 +457,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -516,7 +517,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -550,7 +551,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -658,7 +659,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -674,12 +675,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1292,7 +1294,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -39,7 +38,7 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -517,7 +516,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -551,7 +550,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -659,7 +658,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -675,13 +674,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1294,7 +1292,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -409,10 +410,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -469,7 +470,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -503,7 +504,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -611,7 +612,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -627,12 +628,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1234,7 +1236,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -470,7 +469,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -504,7 +503,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -612,7 +611,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -628,13 +627,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1236,7 +1234,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -23,11 +23,10 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
-automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -481,7 +480,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -515,7 +514,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -623,7 +622,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -639,13 +638,12 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1274,7 +1272,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.24
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -23,10 +23,11 @@ spec:
 # Source: redpanda/charts/console/templates/serviceaccount.yaml
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -420,10 +421,10 @@ data:
       overprovisioned: false
       enable_memory_locking: false
       additional_start_flags:
-        - "--smp=1"
-        - "--memory=2048M"
-        - "--reserve-memory=205M"
-        - "--default-log-level=info"
+        - --default-log-level=info
+        - --memory=2048M
+        - --reserve-memory=205M
+        - --smp=1
       # rpk tune entries
       tune_aio_events: true
     
@@ -480,7 +481,7 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -514,7 +515,7 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -622,7 +623,7 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"
@@ -638,12 +639,13 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 0cdf5c9a3fcc3216498da65ba291ff41f592b3b0da48d5925916e547d0dbd066
+        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
     spec:
       serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
       securityContext:
         fsGroup: 99
         runAsUser: 99
@@ -1272,7 +1274,7 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.24
+    helm.sh/chart: console-0.7.25
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/version: "v2.4.5"

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -10,6 +10,7 @@ import (
 	"text/template"
 
 	"github.com/imdario/mergo"
+	"golang.org/x/exp/maps"
 )
 
 var (
@@ -35,7 +36,7 @@ func KindIs(kind string, v any) bool {
 
 // Keys is the go equivalent of sprig's `keys`.
 func Keys[K comparable, V any](m map[K]V) []K {
-	return nil
+	return maps.Keys(m)
 }
 
 // Merge is a go equivalent of sprig's `merge`.

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -179,3 +179,12 @@ func Upper(in string) string {
 func Unset[K comparable, V any](d map[K]V, key K) {
 	delete(d, key)
 }
+
+// Concat is the go equivalent of sprig's `concat`.
+func Concat[T any](lists ...[]T) []T {
+	var out []T
+	for _, l := range lists {
+		out = append(out, l...)
+	}
+	return out
+}

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -173,3 +173,8 @@ func Lower(in string) string {
 func Upper(in string) string {
 	return strings.ToUpper(in)
 }
+
+// Unset is the go equivalent of sprig's `unset`.
+func Unset[K comparable, V any](d map[K]V, key K) {
+	delete(d, key)
+}

--- a/pkg/gotohelm/testdata/src/example/main.go
+++ b/pkg/gotohelm/testdata/src/example/main.go
@@ -40,6 +40,10 @@ func main() {
 			out = map[string]any{}
 		}
 
+		if err != nil {
+			err = fmt.Sprintf("%+v", err)
+		}
+
 		if err := enc.Encode(map[string]any{
 			"result": out,
 			"err":    err,

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -16,6 +16,7 @@ type AStruct struct {
 func Sprig() map[string]any {
 	return map[string]any{
 		"default": default_(),
+		"keys":    keys(),
 		"empty":   empty(),
 		"strings": stringsFunctions(),
 		"unset":   unset(),
@@ -28,6 +29,17 @@ func stringsFunctions() []string {
 		helmette.Upper("hello WORLD"),
 		strings.ToLower("hello WORLD"),
 		strings.ToUpper("hello WORLD"),
+	}
+}
+
+func keys() [][]string {
+	// .Keys is non-deterministic, must sort to ensure tests always pass.
+	keys := helmette.Keys(map[string]int{"0": 0, "1": 1})
+	helmette.SortAlpha(keys)
+
+	return [][]string{
+		keys,
+		helmette.Keys(map[string]int{}),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -15,6 +15,7 @@ type AStruct struct {
 // in helmette return the same values as the transpiled versions.
 func Sprig() map[string]any {
 	return map[string]any{
+		"concat":  concat(),
 		"default": default_(),
 		"keys":    keys(),
 		"empty":   empty(),
@@ -40,6 +41,15 @@ func keys() [][]string {
 	return [][]string{
 		keys,
 		helmette.Keys(map[string]int{}),
+	}
+}
+
+func concat() [][]int {
+	return [][]int{
+		helmette.Concat([]int{1, 2}, []int{3, 4}),
+		helmette.Concat([]int{1, 2}, []int{3, 4}, []int{5, 6}),
+		append([]int{1, 2}, []int{3, 4}...),
+		append([]int{1, 2}, 3, 4),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -15,9 +15,10 @@ type AStruct struct {
 // in helmette return the same values as the transpiled versions.
 func Sprig() map[string]any {
 	return map[string]any{
-		"empty":   empty(),
 		"default": default_(),
+		"empty":   empty(),
 		"strings": stringsFunctions(),
+		"unset":   unset(),
 	}
 }
 
@@ -28,6 +29,22 @@ func stringsFunctions() []string {
 		strings.ToLower("hello WORLD"),
 		strings.ToUpper("hello WORLD"),
 	}
+}
+
+func unset() []map[string]int {
+	m1 := map[string]int{"0": 0, "1": 1, "2": 2}
+	m2 := map[string]int{"0": 0, "1": 1, "2": 2}
+	m3 := map[string]int{"0": 0, "1": 1, "2": 2}
+	m4 := map[string]int{"0": 0, "1": 1, "2": 2}
+
+	delete(m2, "0")
+
+	helmette.Unset(m3, "2")
+
+	delete(m3, "1")
+	helmette.Unset(m3, "2")
+
+	return []map[string]int{m1, m2, m3, m4}
 }
 
 func default_() []any {

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,7 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -19,6 +19,13 @@
 {{- $keys := (keys (dict "0" 0 "1" 1 )) -}}
 {{- $_ := (sortAlpha $keys) -}}
 {{- (dict "r" (list $keys (keys (dict )))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.concat" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (list (concat (list 1 2) (list 3 4)) (concat (list 1 2) (list 3 4) (list 5 6)) (concat (list 1 2) (list 3 4)) (concat (list 1 2) (list 3 4)))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,7 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -10,6 +10,21 @@
 {{- define "sprig.stringsFunctions" -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (list (lower "hello WORLD") (upper "hello WORLD") (lower "hello WORLD") (upper "hello WORLD"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.unset" -}}
+{{- range $_ := (list 1) -}}
+{{- $m1 := (dict "0" 0 "1" 1 "2" 2 ) -}}
+{{- $m2 := (dict "0" 0 "1" 1 "2" 2 ) -}}
+{{- $m3 := (dict "0" 0 "1" 1 "2" 2 ) -}}
+{{- $m4 := (dict "0" 0 "1" 1 "2" 2 ) -}}
+{{- $_ := (unset $m2 "0") -}}
+{{- $_ := (unset $m3 "2") -}}
+{{- $_ := (unset $m3 "1") -}}
+{{- $_ := (unset $m3 "2") -}}
+{{- (dict "r" (list $m1 $m2 $m3 $m4)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,7 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -10,6 +10,15 @@
 {{- define "sprig.stringsFunctions" -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (list (lower "hello WORLD") (upper "hello WORLD") (lower "hello WORLD") (upper "hello WORLD"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.keys" -}}
+{{- range $_ := (list 1) -}}
+{{- $keys := (keys (dict "0" 0 "1" 1 )) -}}
+{{- $_ := (sortAlpha $keys) -}}
+{{- (dict "r" (list $keys (keys (dict )))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -624,6 +624,8 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 			return &BuiltInCall{FuncName: "toString", Arguments: args}
 		case "len":
 			return &BuiltInCall{FuncName: "len", Arguments: args}
+		case "delete":
+			return &BuiltInCall{FuncName: "unset", Arguments: args}
 		default:
 			panic(fmt.Sprintf("unsupport golang builtin %q", n.Fun.(*ast.Ident).Name))
 		}
@@ -663,6 +665,7 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 		"helmette.ToJSON":         "toJson",
 		"helmette.Tpl":            "tpl",
 		"helmette.Trunc":          "trunc",
+		"helmette.Unset":          "unset",
 		"helmette.Upper":          "upper",
 		"maps.Keys":               "keys",
 		"math.Floor":              "floor",

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -662,6 +662,7 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 		"helmette.MustRegexMatch": "mustRegexMatch",
 		"helmette.MustToJSON":     "mustToJson",
 		"helmette.RegexMatch":     "regexMatch",
+		"helmette.SortAlpha":      "sortAlpha",
 		"helmette.ToJSON":         "toJson",
 		"helmette.Tpl":            "tpl",
 		"helmette.Trunc":          "trunc",

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -257,7 +257,7 @@ func (g *GoRunner) Render(ctx context.Context, dot *helmette.Dot) (map[string]an
 	select {
 	case res := <-g.outputCh:
 		if err, ok := res["err"]; ok && err != nil {
-			return nil, fmt.Errorf("%#v", err)
+			return nil, fmt.Errorf("error from go code: %s", err)
 		}
 		if m, ok := res["result"].(map[string]any); ok {
 			return m, nil

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -124,7 +124,7 @@ func AssertGolden(t *testing.T, assertionType GoldenAssertion, path string, actu
 		)
 		require.NoError(t, err)
 
-		if len(report.Diffs) > 1 {
+		if len(report.Diffs) > 0 {
 			hr := dyff.HumanReport{Report: report, OmitHeader: true}
 
 			var buf bytes.Buffer


### PR DESCRIPTION
#### 0c6068618df4a1b4bdacb6191df9d2f0bcd1a50f gotohelm: support delete and unset

This commits add support for transpiling the golang builtin `delete` and
sprig's `unset` helper.


#### 04d408e063cf91c5131edb28164d073bd1c79b01 Fix buggy check in AssertGolden



#### 75d5a7848465aebe5f563acab856b47e026dc422 gotohelm: add support for concat and append

This commit adds support for sprig's `concat` helper and additionally
makes the golang builtin `append` work in all cases. Prior to this
commit `append` was limited to appending a single element, it now
supports multiple elements and spreading.


#### 690129a25d0f6eea86630e49e706fd0439ffea3e redpanda: add support for overriding default flags

Prior to this commit, users could not _directly_ control the value of
`--smp`, `--memory`, or `--reserve-memory`. This commit adds support for
overriding the defaults by specifying said flag in
`.statefulset.additionalRedpandaCmdFlags`.

For example, if a user passes `--smp=123` in, the chart's value for smp
will be ignored.

Fixes #1134