### PR TITLE
Change the helmette merge behavior to not mutate parameters

### DIFF
--- a/charts/redpanda/templates/_helpers.go.tpl
+++ b/charts/redpanda/templates/_helpers.go.tpl
@@ -47,7 +47,7 @@
 {{- $labels = $values.commonLabels -}}
 {{- end -}}
 {{- $defaults := (dict "helm.sh/chart" (get (fromJson (include "redpanda.Chart" (dict "a" (list $dot) ))) "r") "app.kubernetes.io/name" (get (fromJson (include "redpanda.Name" (dict "a" (list $dot) ))) "r") "app.kubernetes.io/instance" $dot.Release.Name "app.kubernetes.io/managed-by" $dot.Release.Service "app.kubernetes.io/component" (get (fromJson (include "redpanda.Name" (dict "a" (list $dot) ))) "r") ) -}}
-{{- (dict "r" (merge $defaults $labels)) | toJson -}}
+{{- (dict "r" (merge (dict ) $defaults $labels)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -39,7 +39,8 @@ func Keys[K comparable, V any](m map[K]V) []K {
 }
 
 // Merge is a go equivalent of sprig's `merge`.
-func Merge[K comparable, V any](dst map[K]V, sources ...map[K]V) map[K]V {
+func Merge[K comparable, V any](sources ...map[K]V) map[K]V {
+	dst := map[K]V{}
 	for _, src := range sources {
 		if err := mergo.Merge(&dst, src); err != nil {
 			return nil

--- a/pkg/gotohelm/helmette/sprig_test.go
+++ b/pkg/gotohelm/helmette/sprig_test.go
@@ -84,8 +84,7 @@ func TestMerge(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.Name, func(t *testing.T) {
-			require.Equal(t, tc.Output, helmette.Merge(tc.Inputs[0], tc.Inputs[1:]...))
-			require.Equal(t, tc.Output, tc.Inputs[0])
+			require.Equal(t, tc.Output, helmette.Merge(tc.Inputs...))
 		})
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/labels/labels.go
+++ b/pkg/gotohelm/testdata/src/example/labels/labels.go
@@ -26,5 +26,5 @@ func FullLabels(dot *helmette.Dot) map[string]string {
 	// the empty map is provided to not mutate user provided commonLabels
 	//
 	// https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/docs/dicts.md?plain=1#L125-L182
-	return helmette.Merge(map[string]string{}, commonLabels, defaults)
+	return helmette.Merge(commonLabels, defaults)
 }

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -591,7 +591,6 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 		"helmette.Keys":         "keys",
 		"helmette.KindIs":       "kindIs",
 		"helmette.KindOf":       "kindOf",
-		"helmette.Merge":        "merge",
 		"helmette.MustFromJSON": "mustFromJson",
 		"helmette.MustToJSON":   "mustToJson",
 		"helmette.RegexMatch":   "regexMatch",
@@ -653,6 +652,9 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 			},
 		}, args...)
 		return &Call{FuncName: "_shims.typeassertion", Arguments: args}
+	case "helmette.Merge":
+		dict := DictLiteral{}
+		return &BuiltInCall{FuncName: "merge", Arguments: append([]Node{&dict}, args...)}
 	default:
 		panic(fmt.Sprintf("unsupported function %s", name))
 	}


### PR DESCRIPTION
As the mergo library and helm chart mutates first dictionary (map) the transpiler and the spring wrapper changes that behavior. The first argument to merge function is created inline inside the wrapper function, so none of the arguments are changed.