### PR TITLE
adding ability to set RPK_CLOUD_STORAGE_AZURE_SHARED_KEY for post upgrade configuration job.

### DIFF
--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -850,7 +850,7 @@ REDPANDA_SASL_USERNAME REDPANDA_SASL_PASSWORD REDPANDA_SASL_MECHANISM
     [
         {{- if and (include "is-licensed" . | fromJson).bool (dig "cloud_storage_enabled" false $config) -}}
             {{include "secret-ref-or-value" (dict
-                "Name" "RPK_CLOUD_STORAGE_SECRET_KEY"
+                "Name" (printf "RPK_%s" (dig "tiered" "credentialsSecretRef" "secretKey" "configurationKey"  nil .Values.storage ) | upper )
                 "Value" (dig "cloud_storage_secret_key" nil $config)
                 "SecretName" (dig "tiered" "credentialsSecretRef" "secretKey" "name" nil .Values.storage)
                 "SecretKey" (dig "tiered" "credentialsSecretRef" "secretKey" "key" nil .Values.storage)


### PR DESCRIPTION
adding ability to set `RPK_CLOUD_STORAGE_AZURE_SHARED_KEY` (`Azure`) currently only `RPK_CLOUD_STORAGE_SECRET_KEY` is set which is for `AWS/GCP`

As per the [docs](https://artifacthub.io/packages/helm/redpanda-data/redpanda/5.7.35?modal=values&path=storage.tiered.credentialsSecretRef.secretKey) we should be able to set both.