### PR TITLE
connectors: Add envFrom configuration option to connectors chart

### DIFF
--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.1.10
+version: 0.1.11
 
 # The app version is the default version of Redpanda Connectors to install.
 appVersion: v1.0.6

--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connectors Helm chart.
 ---
 
-![Version: 0.1.10](https://img.shields.io/badge/Version-0.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.6](https://img.shields.io/badge/AppVersion-v1.0.6-informational?style=flat-square)
+![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.6](https://img.shields.io/badge/AppVersion-v1.0.6-informational?style=flat-square)
 
 This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
@@ -261,6 +261,12 @@ Additional annotations to apply to the Pods of this Deployment.
 ### [deployment.extraEnv](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.extraEnv)
 
 Additional environment variables for the Pods.
+
+**Default:** `[]`
+
+### [deployment.extraEnvFrom](https://artifacthub.io/packages/helm/redpanda-data/connectors?modal=values&path=deployment.extraEnvFrom)
+
+Configure extra environment variables from Secrets and ConfigMaps.
 
 **Default:** `[]`
 

--- a/charts/connectors/templates/deployment.yaml
+++ b/charts/connectors/templates/deployment.yaml
@@ -108,13 +108,14 @@ spec:
                 status.storage.replication.factor={{ .Values.connectors.storage.replicationFactor.status }}
                 producer.linger.ms={{ .Values.connectors.producerLingerMS }}
                 producer.batch.size={{ .Values.connectors.producerBatchSize }}
-                config.providers=file,secretsManager
+                config.providers=file,secretsManager,env
                 config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
                 {{- if .Values.connectors.secretManager.enabled }}
                 config.providers.secretsManager.class=com.github.jcustenborder.kafka.config.aws.SecretsManagerConfigProvider
                 config.providers.secretsManager.param.secret.prefix={{ .Values.connectors.secretManager.consolePrefix }}{{ .Values.connectors.secretManager.connectorsPrefix }}
                 config.providers.secretsManager.param.aws.region={{ .Values.connectors.secretManager.region }}
                 {{- end }}
+                config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider
             - name: CONNECT_ADDITIONAL_CONFIGURATION
               value: {{ .Values.connectors.additionalConfiguration | quote }}
             - name: CONNECT_BOOTSTRAP_SERVERS
@@ -152,6 +153,10 @@ spec:
               value: {{ printf "key/%s" (default "tls.key" .Values.connectors.brokerTLS.key.secretNameOverwrite) }}
             {{- end }}
             {{- with .Values.deployment.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          envFrom:
+            {{- with .Values.deployment.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
           livenessProbe:

--- a/charts/connectors/values.yaml
+++ b/charts/connectors/values.yaml
@@ -208,6 +208,13 @@ deployment:
   # - name: RACK_ID
   #   value: "1"
 
+  # -- Configure extra environment variables from Secrets and ConfigMaps.
+  extraEnvFrom: []
+  # - secretRef: 
+  #     name: my-secret
+  # - configMapRef:
+  #     name: my-configmap
+
   # -- The maximum time in seconds for a deployment to make progress before it is
   # considered to be failed. The deployment controller will continue to process
   # failed deployments and a condition with a ProgressDeadlineExceeded reason


### PR DESCRIPTION
Closes #1165 

- Configures a environment variable configuration provider based on Kafka [EnvVarConfigProvider](https://kafka.apache.org/35/javadoc/org/apache/kafka/common/config/provider/EnvVarConfigProvider.html)
- Adds option to pass `envFrom` to `deployment.yaml` template
- Adds `deployment.extraEnvFrom` to `values.yaml`