### PR TITLE
Fix release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -68,14 +68,16 @@ jobs:
           go test ./charts/redpanda -update -short
 
       # Commit changes must be run before chart-releaser execution, because auto commit would include helm chart tar.gz artifact
-      - name: Commit changes for testdata golden files
-        run: |
-          git config --global user.name 'vbotbuildovich'
-          git config --global user.email 'vbotbuildovich@users.noreply.github.com'
-          git config --global --add --bool push.autoSetupRemote true
-          git add --all
-          git commit -m "[Auto Commit] Update testdata golden files"
-          git push
+      # TODO: Find a solution for protection ruleset that prevents from pushing to main branch any commit that do not pass
+      # require status checks (namely `lint` and `summary`).
+#      - name: Commit changes for testdata golden files
+#        run: |
+#          git config --global user.name 'vbotbuildovich'
+#          git config --global user.email 'vbotbuildovich@users.noreply.github.com'
+#          git config --global --add --bool push.autoSetupRemote true
+#          git add --all
+#          git commit -m "[Auto Commit] Update testdata golden files"
+#          git push
 
       # Chart releaser must be run after auto commit for testdata golder files, because commit could include helm chart tar.gz artifact
       - name: Run chart-releaser

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1204,7 +1204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1259,7 +1259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1283,7 +1283,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1342,7 +1342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1365,7 +1365,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 spec:
   maxUnavailable: 1
@@ -46,7 +46,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -173,7 +173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -221,7 +221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 data: 
   
@@ -355,7 +355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 data:
   profile: | 
@@ -438,7 +438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 spec:
   type: ClusterIP
@@ -482,7 +482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 spec:
   type: NodePort
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
 spec:
   selector:
@@ -633,7 +633,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -649,7 +649,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -683,7 +683,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -801,7 +801,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -917,7 +917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
   annotations:
     # This is what defines this resource as a hook. Without this line, the
@@ -943,7 +943,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -990,7 +990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     testlabel: exercise_common_labels_template
   annotations:
     "helm.sh/hook": post-upgrade
@@ -1015,7 +1015,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -169,7 +169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -216,7 +216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -499,7 +499,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -541,7 +541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -696,7 +696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -725,7 +725,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -745,7 +745,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -783,7 +783,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -905,7 +905,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1008,7 +1008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1034,7 +1034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1134,7 +1134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1150,7 +1150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1167,7 +1167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1183,7 +1183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1246,7 +1246,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1305,7 +1305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1328,7 +1328,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -325,7 +325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -465,7 +465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -547,7 +547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -589,7 +589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -713,7 +713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -742,7 +742,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -761,7 +761,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -798,7 +798,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -919,7 +919,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1038,7 +1038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1062,7 +1062,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1115,7 +1115,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1138,7 +1138,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -278,7 +278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -325,7 +325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -544,7 +544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -628,7 +628,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -670,7 +670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -832,7 +832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -861,7 +861,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -884,7 +884,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -925,7 +925,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1050,7 +1050,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1210,7 +1210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1397,7 +1397,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1462,7 +1462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1485,7 +1485,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 ---
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -181,7 +181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -246,7 +246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -463,7 +463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -527,7 +527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 rules:
   - apiGroups:
     - ""
@@ -547,7 +547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 rules:
   - apiGroups:
     - ""
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -645,7 +645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -687,7 +687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -871,7 +871,7 @@ spec:
       serviceAccountName: redpanda
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -891,7 +891,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -929,7 +929,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1051,7 +1051,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1242,7 +1242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1313,7 +1313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1329,7 +1329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1368,7 +1368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1392,7 +1392,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1451,7 +1451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1474,7 +1474,7 @@ spec:
       serviceAccountName: redpanda
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -279,7 +279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -790,7 +790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -819,7 +819,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -841,7 +841,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -881,7 +881,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1017,7 +1017,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1126,7 +1126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1152,7 +1152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1178,7 +1178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1203,7 +1203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1315,7 +1315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1331,7 +1331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-cert2-root-certificate
@@ -1348,7 +1348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1364,7 +1364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1381,7 +1381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1397,7 +1397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1436,7 +1436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1460,7 +1460,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1525,7 +1525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1548,7 +1548,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1044,7 +1044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1070,7 +1070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1095,7 +1095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1132,7 +1132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1170,7 +1170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1203,7 +1203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1258,7 +1258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1282,7 +1282,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1341,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1364,7 +1364,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -784,7 +784,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -838,7 +838,7 @@ spec:
               echo "Hello World!"
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -962,7 +962,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1122,7 +1122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1197,7 +1197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1213,7 +1213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1309,7 +1309,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1368,7 +1368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1391,7 +1391,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1135,7 +1135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1175,7 +1175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1287,7 +1287,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1346,7 +1346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1369,7 +1369,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   users.txt: |-
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -280,7 +280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -339,7 +339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -568,7 +568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -660,7 +660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -702,7 +702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -864,7 +864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -893,7 +893,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -916,7 +916,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -957,7 +957,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1082,7 +1082,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1242,7 +1242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1279,7 +1279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1350,7 +1350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1366,7 +1366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1405,7 +1405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1429,7 +1429,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1494,7 +1494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1517,7 +1517,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1070,7 +1070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1126,7 +1126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1189,7 +1189,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1271,7 +1271,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -619,7 +619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -660,7 +660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -817,7 +817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -846,7 +846,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -866,7 +866,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -904,7 +904,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1026,7 +1026,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1194,7 +1194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1210,7 +1210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1273,7 +1273,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1355,7 +1355,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -376,7 +376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -466,7 +466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -625,7 +625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -654,7 +654,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -670,7 +670,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -704,7 +704,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -822,7 +822,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -913,7 +913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   endpoints:
   - interval: 30s
@@ -959,7 +959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -983,7 +983,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1030,7 +1030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1053,7 +1053,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1204,7 +1204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1237,7 +1237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   endpoints:
   - interval: 30s
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1310,7 +1310,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1392,7 +1392,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 rules:
   - apiGroups:
     - ""
@@ -528,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 rules:
   - apiGroups:
     - ""
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 rules:
   - apiGroups:
       - ""
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -630,7 +630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -650,7 +650,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 rules:
   - apiGroups:
       - apps
@@ -700,7 +700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -790,7 +790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -945,7 +945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -974,7 +974,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -994,7 +994,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -1032,7 +1032,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1154,7 +1154,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1270,7 +1270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1358,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1396,7 +1396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1412,7 +1412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1429,7 +1429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1445,7 +1445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1484,7 +1484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1508,7 +1508,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1567,7 +1567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1590,7 +1590,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -945,7 +945,7 @@ spec:
               cpu: 1
               memory: 2500Mi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1048,7 +1048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1074,7 +1074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1099,7 +1099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1136,7 +1136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1174,7 +1174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1286,7 +1286,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1345,7 +1345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1368,7 +1368,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1135,7 +1135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1175,7 +1175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1287,7 +1287,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1346,7 +1346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1369,7 +1369,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -501,7 +501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -835,7 +835,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -868,7 +868,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -906,7 +906,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1030,7 +1030,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1136,7 +1136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1162,7 +1162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1350,7 +1350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1374,7 +1374,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1455,7 +1455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1478,7 +1478,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -836,7 +836,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -869,7 +869,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -907,7 +907,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1031,7 +1031,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1137,7 +1137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1163,7 +1163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1188,7 +1188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1279,7 +1279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1312,7 +1312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1351,7 +1351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1375,7 +1375,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1458,7 +1458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1481,7 +1481,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -500,7 +500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -805,7 +805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -834,7 +834,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -867,7 +867,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -905,7 +905,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1029,7 +1029,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1136,7 +1136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1162,7 +1162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1350,7 +1350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1374,7 +1374,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1453,7 +1453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1476,7 +1476,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -453,7 +453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -545,7 +545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -742,7 +742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -771,7 +771,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -804,7 +804,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -842,7 +842,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -966,7 +966,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1073,7 +1073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1099,7 +1099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1124,7 +1124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1161,7 +1161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1199,7 +1199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1311,7 +1311,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: RPK_CLOUD_STORAGE_AZURE_CONTAINER
@@ -1388,7 +1388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1411,7 +1411,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -501,7 +501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -835,7 +835,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -868,7 +868,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -906,7 +906,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1030,7 +1030,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1170,7 +1170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1270,7 +1270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1358,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1382,7 +1382,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1463,7 +1463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1486,7 +1486,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -836,7 +836,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -869,7 +869,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -907,7 +907,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1031,7 +1031,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1359,7 +1359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1383,7 +1383,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1466,7 +1466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1489,7 +1489,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -500,7 +500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -805,7 +805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -834,7 +834,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -867,7 +867,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -905,7 +905,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1029,7 +1029,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1359,7 +1359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1383,7 +1383,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1462,7 +1462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1485,7 +1485,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -453,7 +453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -545,7 +545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -742,7 +742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -771,7 +771,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -804,7 +804,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -842,7 +842,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -966,7 +966,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1170,7 +1170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1320,7 +1320,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: RPK_CLOUD_STORAGE_AZURE_CONTAINER
@@ -1397,7 +1397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1420,7 +1420,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -501,7 +501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -593,7 +593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -835,7 +835,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -868,7 +868,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -906,7 +906,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1030,7 +1030,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1170,7 +1170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1270,7 +1270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1358,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1382,7 +1382,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1463,7 +1463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1486,7 +1486,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -502,7 +502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -807,7 +807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -836,7 +836,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -869,7 +869,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -907,7 +907,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1031,7 +1031,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1359,7 +1359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1383,7 +1383,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1466,7 +1466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1489,7 +1489,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -500,7 +500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -805,7 +805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -834,7 +834,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -867,7 +867,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -905,7 +905,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1029,7 +1029,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1359,7 +1359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1383,7 +1383,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1462,7 +1462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1485,7 +1485,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -453,7 +453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -545,7 +545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -742,7 +742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -771,7 +771,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -804,7 +804,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -842,7 +842,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -966,7 +966,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1170,7 +1170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1320,7 +1320,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: RPK_CLOUD_STORAGE_AZURE_CONTAINER
@@ -1397,7 +1397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1420,7 +1420,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -762,7 +762,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -782,7 +782,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -942,7 +942,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1204,7 +1204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1259,7 +1259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1283,7 +1283,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1342,7 +1342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1365,7 +1365,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -733,7 +733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -763,7 +763,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -783,7 +783,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -821,7 +821,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -943,7 +943,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1046,7 +1046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1072,7 +1072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1134,7 +1134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1172,7 +1172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1188,7 +1188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1221,7 +1221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1260,7 +1260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1284,7 +1284,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env: []
         command: ["bash","-c"]
@@ -1343,7 +1343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1366,7 +1366,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   users.txt: |-
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -324,7 +324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -623,7 +623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -715,7 +715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -935,7 +935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -964,7 +964,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -987,7 +987,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -1028,7 +1028,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1153,7 +1153,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1313,7 +1313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1350,7 +1350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1388,7 +1388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1404,7 +1404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1421,7 +1421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1437,7 +1437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1476,7 +1476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1500,7 +1500,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1567,7 +1567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1590,7 +1590,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -215,7 +215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -274,7 +274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -491,7 +491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -583,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -625,7 +625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -796,7 +796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -825,7 +825,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -845,7 +845,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -883,7 +883,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -1005,7 +1005,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1134,7 +1134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1234,7 +1234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1250,7 +1250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1267,7 +1267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1322,7 +1322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1346,7 +1346,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1407,7 +1407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1430,7 +1430,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -578,7 +578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -738,7 +738,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -787,7 +787,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -825,7 +825,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -947,7 +947,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1050,7 +1050,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1101,7 +1101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1138,7 +1138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1176,7 +1176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1209,7 +1209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1264,7 +1264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1288,7 +1288,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1352,7 +1352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1375,7 +1375,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -168,7 +168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data: 
   
   bootstrap.yaml: |
@@ -455,7 +455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 data:
   profile: | 
     name: default
@@ -547,7 +547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -589,7 +589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   type: NodePort
   publishNotReadyAddresses: true
@@ -758,7 +758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selector:
     matchLabels: 
@@ -787,7 +787,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -820,7 +820,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/bash
             - -c
@@ -858,7 +858,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           env:
             - name: SERVICE_NAME
               valueFrom:
@@ -982,7 +982,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
           command:
             - /bin/sh
           args:
@@ -1088,7 +1088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1114,7 +1114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   duration: 43800h
   isCA: true
@@ -1139,7 +1139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1176,7 +1176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1214,7 +1214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   selfSigned: {}
 ---
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1326,7 +1326,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         
         env:
         - name: REDPANDA_LICENSE
@@ -1408,7 +1408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.7.37
+    helm.sh/chart: redpanda-5.7.38
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1431,7 +1431,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.10
+        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
         command: ["/bin/bash", "-c"]
         args:
           - |


### PR DESCRIPTION
https://github.com/redpanda-data/helm-charts/commit/5bf24c47b9b4a0564fbba56f0e11a30ec3bf3b07

#### Remove auto-commit step from helm chart release process

The redpanda-data organization ruleset prevents from pushing commit to main branch until they pass CI.

https://github.com/redpanda-data/helm-charts/commit/88aab0d1d8d4e7c4890ee608d19a002456acf841

#### Bump golden files after Redpanda chart release