### PR TITLE
chart lock file committed and added to helmignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ admin.conf
 # templated ci values
 charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml
 
-# Dep Chart Lock file
-Chart.lock
-
 charts/redpanda/templates/redpanda-license.yaml
 charts/redpanda/templates/external-service.yaml
 charts/redpanda/templates/external-tls-secret.yaml

--- a/charts/redpanda/.helmignore
+++ b/charts/redpanda/.helmignore
@@ -26,3 +26,6 @@ README.md.gotmpl
 *.go
 testdata/
 ci/
+
+# include chart lock file
+Chart.lock

--- a/charts/redpanda/Chart.lock
+++ b/charts/redpanda/Chart.lock
@@ -1,0 +1,9 @@
+dependencies:
+- name: console
+  repository: https://charts.redpanda.com
+  version: 0.7.25
+- name: connectors
+  repository: https://charts.redpanda.com
+  version: 0.1.10
+digest: sha256:589f88297dff6c2009bdbd43ea3348ff4f9e34c291bfe21c6a56040d452ca711
+generated: "2024-04-09T14:37:38.514639-04:00"


### PR DESCRIPTION
As per prescription from @chrisseto we are now committing the chart.lock file to help remove issues with golden tests. 