### PR TITLE
gotohelm: fix nil representation

### DIFF
--- a/pkg/gotohelm/ast.go
+++ b/pkg/gotohelm/ast.go
@@ -32,7 +32,15 @@ func (s *Selector) Write(w io.Writer) {
 type Nil struct{}
 
 func (*Nil) Write(w io.Writer) {
-	w.Write([]byte(`(fromJson "null")`))
+	// nil is strange for some reason, in many cases it's acceptable to just
+	// have `nil` but in others, you'll get `nil is not a command` errors.
+	// {{ $_ := nil }} Doesn't work
+	// {{ $_ := (eq nil nil) }} Works
+	// It's too difficult to inspect all the cases and use nil in some but not
+	// others, instead wrap nil in a function that just returns nil.
+	// (fromJSON "null") doesn't work quite as expected but coalesce seems to
+	// do the trick.
+	w.Write([]byte(`(coalesce nil)`))
 }
 
 type Statement struct {

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
@@ -2,7 +2,7 @@
 
 {{- define "k8s.Pod" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (fromJson "null") ) "spec" (dict "containers" (fromJson "null") ) "status" (dict ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Pod" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (fromJson "null") ) (dict "namespace" "spacename" "name" "eman" )) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "containers" (coalesce nil) ) "status" (dict ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Pod" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "namespace" "spacename" "name" "eman" )) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -10,7 +10,7 @@
 {{- define "k8s.PDB" -}}
 {{- range $_ := (list 1) -}}
 {{- $minAvail := 3 -}}
-{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (fromJson "null") ) "spec" (dict ) "status" (dict "disruptionsAllowed" 0 "currentHealthy" 0 "desiredHealthy" 0 "expectedPods" 0 ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "PodDisruptionBudget" )) (dict "spec" (mustMergeOverwrite (dict ) (dict "minAvailable" $minAvail )) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict ) "status" (dict "disruptionsAllowed" 0 "currentHealthy" 0 "desiredHealthy" 0 "expectedPods" 0 ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "PodDisruptionBudget" )) (dict "spec" (mustMergeOverwrite (dict ) (dict "minAvailable" $minAvail )) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/mutability/mutability.yaml
+++ b/pkg/gotohelm/testdata/src/example/mutability/mutability.yaml
@@ -2,9 +2,9 @@
 
 {{- define "mutability.Mutability" -}}
 {{- range $_ := (list 1) -}}
-{{- $v := (dict "Name" "" "Labels" (fromJson "null") "SubService" (fromJson "null") ) -}}
+{{- $v := (dict "Name" "" "Labels" (coalesce nil) "SubService" (coalesce nil) ) -}}
 {{- $_ := (set $v "Labels" (dict )) -}}
-{{- $_ := (set $v "SubService" (mustMergeOverwrite (dict "Name" "" "Labels" (fromJson "null") ) (dict ))) -}}
+{{- $_ := (set $v "SubService" (mustMergeOverwrite (dict "Name" "" "Labels" (coalesce nil) ) (dict ))) -}}
 {{- $_ := (set $v.SubService "Labels" (dict )) -}}
 {{- $_ := (set $v.SubService "Name" "Hello!") -}}
 {{- $_ := (set $v.SubService.Labels "hello" "world") -}}

--- a/pkg/gotohelm/testdata/src/example/typing/structs.yaml
+++ b/pkg/gotohelm/testdata/src/example/typing/structs.yaml
@@ -10,10 +10,10 @@
 
 {{- define "typing.zeros" -}}
 {{- range $_ := (list 1) -}}
-{{- $number := (fromJson "null") -}}
-{{- $str := (fromJson "null") -}}
-{{- $stru := (fromJson "null") -}}
-{{- (dict "r" (list (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict )) (mustMergeOverwrite (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict "Nilable" (fromJson "null") )) (dict )) $number $str $stru)) | toJson -}}
+{{- $number := (coalesce nil) -}}
+{{- $str := (coalesce nil) -}}
+{{- $stru := (coalesce nil) -}}
+{{- (dict "r" (list (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict )) (mustMergeOverwrite (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict "Nilable" (coalesce nil) )) (dict )) $number $str $stru)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -35,7 +35,7 @@
 
 {{- define "typing.alsoMe" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict "Nilable" (fromJson "null") )) (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict "Key" "Foo" )) (dict ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict "Nilable" (coalesce nil) )) (mustMergeOverwrite (dict "Key" "" "with_tag" 0 ) (dict "Key" "Foo" )) (dict ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
#### da02911a024de48e5744eb88f0f4f1e099d87455 gotohelm: fix nil representation

Previously, `nil` was represented as `(fromJson "null")`. For whatever
reason, that did not appear to work in all cases. I believe that
`(fromJson "null") likely returned an empty dictionary or something of
that nature though it's not 100% clear why this didn't cause more test
failures.

This commit changes the representation to `(coalesce nil)` and includes
some notes about the difficulty of representing `nil` in go templates.