### PR TITLE
gotohelm: add support for referencing constants

### DIFF
--- a/charts/redpanda/Chart.lock
+++ b/charts/redpanda/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: console
   repository: https://charts.redpanda.com
-  version: 0.7.25
+  version: 0.7.26
 - name: connectors
   repository: https://charts.redpanda.com
   version: 0.1.11
-digest: sha256:0ee4b5138de2f3bfa7bde4509c236cb420fb76e96c47bcf0414d4dcb5062f8dc
-generated: "2024-04-11T19:10:13.080851042Z"
+digest: sha256:52ec651b909af2461cc7d69da8786e1047b96fb32a692ce949d36789c9f60e36
+generated: "2024-04-11T23:19:16.151449+02:00"

--- a/charts/redpanda/templates/_helpers.go.tpl
+++ b/charts/redpanda/templates/_helpers.go.tpl
@@ -43,7 +43,7 @@
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $labels := (dict ) -}}
-{{- if (ne $values.commonLabels nil) -}}
+{{- if (ne $values.commonLabels (coalesce nil)) -}}
 {{- $labels = $values.commonLabels -}}
 {{- end -}}
 {{- $defaults := (dict "helm.sh/chart" (get (fromJson (include "redpanda.Chart" (dict "a" (list $dot) ))) "r") "app.kubernetes.io/name" (get (fromJson (include "redpanda.Name" (dict "a" (list $dot) ))) "r") "app.kubernetes.io/instance" $dot.Release.Name "app.kubernetes.io/managed-by" $dot.Release.Service "app.kubernetes.io/component" (get (fromJson (include "redpanda.Name" (dict "a" (list $dot) ))) "r") ) -}}
@@ -56,16 +56,16 @@
 {{- $dot := (index .a 0) -}}
 {{- $statefulSet := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
-{{- if (and $dot.Release.IsUpgrade (ne $statefulSet nil)) -}}
-{{- $existingStatefulSetLabelSelector := (dig "spec" "selector" "matchLabels" nil $statefulSet) -}}
-{{- if (ne $existingStatefulSetLabelSelector nil) -}}
+{{- if (and $dot.Release.IsUpgrade (ne $statefulSet (coalesce nil))) -}}
+{{- $existingStatefulSetLabelSelector := (dig "spec" "selector" "matchLabels" (coalesce nil) $statefulSet) -}}
+{{- if (ne $existingStatefulSetLabelSelector (coalesce nil)) -}}
 {{- (dict "r" $existingStatefulSetLabelSelector) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $commonLabels := (dict ) -}}
-{{- if (ne $values.commonLabels nil) -}}
+{{- if (ne $values.commonLabels (coalesce nil)) -}}
 {{- $commonLabels = $values.commonLabels -}}
 {{- end -}}
 {{- $component := (printf "%s-statefulset" (trimSuffix "-" (trunc 51 (get (fromJson (include "redpanda.Name" (dict "a" (list $dot) ))) "r")))) -}}
@@ -79,20 +79,20 @@
 {{- $dot := (index .a 0) -}}
 {{- $statefulSet := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
-{{- if (and $dot.Release.IsUpgrade (ne $statefulSet nil)) -}}
-{{- $existingStatefulSetPodTemplateLabels := (dig "spec" "template" "metadata" "labels" nil $statefulSet) -}}
-{{- if (ne $existingStatefulSetPodTemplateLabels nil) -}}
+{{- if (and $dot.Release.IsUpgrade (ne $statefulSet (coalesce nil))) -}}
+{{- $existingStatefulSetPodTemplateLabels := (dig "spec" "template" "metadata" "labels" (coalesce nil) $statefulSet) -}}
+{{- if (ne $existingStatefulSetPodTemplateLabels (coalesce nil)) -}}
 {{- (dict "r" $existingStatefulSetPodTemplateLabels) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $statefulSetLabels := (dict ) -}}
-{{- if (ne $values.statefulset.podTemplate.labels nil) -}}
+{{- if (ne $values.statefulset.podTemplate.labels (coalesce nil)) -}}
 {{- $statefulSetLabels = $values.statefulset.podTemplate.labels -}}
 {{- end -}}
 {{- $defults := (dict "redpanda.com/poddisruptionbudget" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") ) -}}
-{{- (dict "r" (merge (dict ) $statefulSetLabels (get (fromJson (include "redpanda.StatefulSetPodLabelsSelector" (dict "a" (list $dot nil) ))) "r") $defults)) | toJson -}}
+{{- (dict "r" (merge (dict ) $statefulSetLabels (get (fromJson (include "redpanda.StatefulSetPodLabelsSelector" (dict "a" (list $dot (coalesce nil)) ))) "r") $defults)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -103,7 +103,7 @@
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $configMapChecksumAnnotation := (dict "config.redpanda.com/checksum" $configMapChecksum ) -}}
-{{- if (ne $values.statefulset.podTemplate.annotations nil) -}}
+{{- if (ne $values.statefulset.podTemplate.annotations (coalesce nil)) -}}
 {{- (dict "r" (merge (dict ) $values.statefulset.podTemplate.annotations $configMapChecksumAnnotation)) | toJson -}}
 {{- break -}}
 {{- end -}}
@@ -155,7 +155,7 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- if (and (ne $values.service nil) (ne $values.service.name nil)) -}}
+{{- if (and (ne $values.service (coalesce nil)) (ne $values.service.name (coalesce nil))) -}}
 {{- (dict "r" (get (fromJson (include "redpanda.cleanForK8s" (dict "a" (list $values.service.name) ))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}
@@ -180,7 +180,7 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- if (and (ne $values.tls.enabled nil) $values.tls.enabled) -}}
+{{- if (and (ne $values.tls.enabled (coalesce nil)) $values.tls.enabled) -}}
 {{- (dict "r" true) | toJson -}}
 {{- break -}}
 {{- end -}}

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1231,10 +1231,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -29,10 +29,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -376,10 +376,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -406,10 +406,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -518,10 +518,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -534,7 +534,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: f95b24f953ead12c5fcbc88d8389bce0ad053498a3b052bcab9a28563c2281b4
+        checksum-redpanda-chart/config: 4636a43ba7f19845dafb63c50d046582b8605eb99db7a02f58148c904ada0e54
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -554,7 +554,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -889,10 +889,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -437,10 +437,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -467,10 +467,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -575,10 +575,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -591,7 +591,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 81e2c7b7079444623a213600ed7e35f29bb4589ca326d13d6eeb33a2f0fb5ea5
+        checksum-redpanda-chart/config: 31e1b0b6331d856866503179ce2b5bad4199ccb720739dfd9e5c2e08cecaa35b
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -632,7 +632,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1194,10 +1194,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -485,10 +485,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -515,10 +515,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -623,10 +623,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -639,7 +639,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: d7c9a4b4575b2e6f3a72961ced8bd0718c896f5409cdf7bf2b82cb0ce201fbc7
+        checksum-redpanda-chart/config: 4d53802ea43e49d3a6ab82e11cc89ceaaa513760ff6c2c01d15fde89700cb18d
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -663,7 +663,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1010,10 +1010,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -566,10 +566,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -596,10 +596,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -704,10 +704,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -720,7 +720,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 6ad88a2e61bdf4de39a2de55a09a5d0d2570a72fc51587b139ba749925929100
+        checksum-redpanda-chart/config: c55d3f3e9ffe058c02970d1dcbc5500b52c4770004cd8ca0fad7b1b089936d9e
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -765,7 +765,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1345,10 +1345,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/serviceaccount.yaml
@@ -489,10 +489,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -613,10 +613,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -721,10 +721,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -737,7 +737,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -778,7 +778,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1340,10 +1340,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -527,10 +527,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -561,10 +561,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -693,10 +693,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -709,7 +709,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 43e388b4043ae0f1ea3c64c03ac63b5bad8a406c2dee57c90ffe6254eb88d967
+        checksum-redpanda-chart/config: 735ac4002aeaa4b3107ba9a41b59cfa1cbe1bebad061ae71d689ce3f70c89047
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -736,7 +736,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1408,10 +1408,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1230,10 +1230,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1257,10 +1257,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1235,10 +1235,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -594,10 +594,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -628,10 +628,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -736,10 +736,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -752,7 +752,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 12228d42f8c1e9a30a0e192e9ad02f3413ea17bd3f323309e8b4af2268dec566
+        checksum-redpanda-chart/config: c5f6c4185763af51a4a493220baec02b1299de425010cfba663ead5c8d35fa50
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -797,7 +797,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1377,10 +1377,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1137,10 +1137,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -696,10 +696,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -712,7 +712,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -753,7 +753,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1221,10 +1221,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -400,10 +400,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -434,10 +434,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -542,10 +542,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -558,7 +558,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 43e388b4043ae0f1ea3c64c03ac63b5bad8a406c2dee57c90ffe6254eb88d967
+        checksum-redpanda-chart/config: 735ac4002aeaa4b3107ba9a41b59cfa1cbe1bebad061ae71d689ce3f70c89047
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -578,7 +578,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -931,10 +931,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1258,10 +1258,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -716,10 +716,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -824,10 +824,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -840,7 +840,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -881,7 +881,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1456,10 +1456,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1234,10 +1234,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1235,10 +1235,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -527,10 +527,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -561,10 +561,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -669,10 +669,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -685,7 +685,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1322,10 +1322,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -528,10 +528,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -562,10 +562,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -670,10 +670,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -686,7 +686,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1323,10 +1323,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -526,10 +526,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -560,10 +560,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -668,10 +668,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -684,7 +684,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1322,10 +1322,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -479,10 +479,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -513,10 +513,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -621,10 +621,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -637,7 +637,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1259,10 +1259,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -527,10 +527,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -561,10 +561,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -669,10 +669,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -685,7 +685,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1330,10 +1330,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -528,10 +528,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -562,10 +562,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -670,10 +670,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -686,7 +686,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1331,10 +1331,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -526,10 +526,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -560,10 +560,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -668,10 +668,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -684,7 +684,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1331,10 +1331,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -479,10 +479,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -513,10 +513,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -621,10 +621,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -637,7 +637,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1268,10 +1268,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -527,10 +527,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -561,10 +561,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -669,10 +669,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -685,7 +685,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1330,10 +1330,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -528,10 +528,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -562,10 +562,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -670,10 +670,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -686,7 +686,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1331,10 +1331,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -526,10 +526,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -560,10 +560,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -668,10 +668,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -684,7 +684,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1331,10 +1331,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -479,10 +479,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -513,10 +513,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -621,10 +621,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -637,7 +637,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1268,10 +1268,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1231,10 +1231,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -669,7 +669,7 @@ spec:
             - "--config.filepath=/etc/console/configs/config.yaml"
           securityContext:
             runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.5
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1232,10 +1232,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -649,10 +649,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -683,10 +683,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -791,10 +791,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -807,7 +807,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 12228d42f8c1e9a30a0e192e9ad02f3413ea17bd3f323309e8b4af2268dec566
+        checksum-redpanda-chart/config: c5f6c4185763af51a4a493220baec02b1299de425010cfba663ead5c8d35fa50
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1448,10 +1448,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
@@ -39,10 +39,10 @@ kind: Secret
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 type: Opaque
@@ -517,10 +517,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -551,10 +551,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -659,10 +659,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -675,7 +675,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1294,10 +1294,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -470,10 +470,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -504,10 +504,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -612,10 +612,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -628,7 +628,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1236,10 +1236,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -27,10 +27,10 @@ automountServiceAccountToken: true
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
 ---
 # Source: redpanda/templates/secrets.yaml
@@ -481,10 +481,10 @@ kind: ConfigMap
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 data:
@@ -515,10 +515,10 @@ kind: Service
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -623,10 +623,10 @@ kind: Deployment
 metadata:
   name: redpanda-console
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
 spec:
@@ -639,7 +639,7 @@ spec:
     metadata:
       annotations:
         checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 61914d7be7a38bb843855250c431b5d33f79bf73a42be380a03e8ffd3170564a
+        checksum-redpanda-chart/config: 64f2cd1f30a71442b56a635c16aab05bd3d59037c9d3ad6b1e6a23b39c65c686
       labels:
         app.kubernetes.io/name: console
         app.kubernetes.io/instance: redpanda
@@ -1274,10 +1274,10 @@ kind: Pod
 metadata:
   name: "redpanda-console-test-connection"
   labels:
-    helm.sh/chart: console-0.7.25
+    helm.sh/chart: console-0.7.26
     app.kubernetes.io/name: console
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.5"
+    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
     
   annotations:

--- a/pkg/gotohelm/testdata/src/example/changing_inputs/changing_inputs.yaml
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/changing_inputs.yaml
@@ -10,7 +10,7 @@
 {{- $_ := (set $dot.Values $k "change that") -}}
 {{- end -}}
 {{- end -}}
-{{- (dict "r" nil) | toJson -}}
+{{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/labels/labels.yaml
+++ b/pkg/gotohelm/testdata/src/example/labels/labels.yaml
@@ -5,7 +5,7 @@
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $commonLabels := (dict ) -}}
-{{- if (ne $values.commonLabels nil) -}}
+{{- if (ne $values.commonLabels (coalesce nil)) -}}
 {{- $commonLabels = $values.commonLabels -}}
 {{- end -}}
 {{- $defaults := (dict "helm.sh/chart" "chart" "app.kubernetes.io/name" "name" "app.kubernetes.io/instance" $dot.Release.Name "app.kubernetes.io/managed-by" $dot.Release.Service "app.kubernetes.io/component" "component" ) -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -50,14 +50,14 @@
 {{- $defaultStr := "DEFAULT" -}}
 {{- $defaultInt := 1234 -}}
 {{- $defaultStrSlice := (list $defaultStr) -}}
-{{- (dict "r" (list (default "" $defaultStr) (default "value" $defaultStr) (default nil $defaultStrSlice) (default (list ) $defaultStrSlice) (default 0 $defaultInt) (default 1 $defaultInt))) | toJson -}}
+{{- (dict "r" (list (default "" $defaultStr) (default "value" $defaultStr) (default (coalesce nil) $defaultStrSlice) (default (list ) $defaultStrSlice) (default 0 $defaultInt) (default 1 $defaultInt))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "sprig.empty" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (list (empty nil) (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" nil )) (empty 1) (empty 0) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict "Value" 0 ) (dict ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" 0 ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" 1 ))))) | toJson -}}
+{{- (dict "r" (list (empty (coalesce nil)) (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" (coalesce nil) )) (empty 1) (empty 0) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict "Value" 0 ) (dict ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" 0 ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" 1 ))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -1,5 +1,14 @@
 package syntax
 
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	AStrConst  = "1234"
+	AnIntConst = 1234
+)
+
 // Syntax only returns an empty map but it contains a variety of go syntax to
 // assert that the transpiler doesn't crash upon seeing it.
 // Notably: Syntax DOES NOT check for correctness.
@@ -34,6 +43,13 @@ func Syntax() map[string]any {
 	_ = "1234"[1:]
 	_ = "1234"[:2]
 	_ = "1234"[1:2]
+
+	// Ident
+	_ = AStrConst  // A reference to a string constant
+	_ = AnIntConst // A reference to an int constant
+
+	// SelectorExpr
+	_ = corev1.IPv4Protocol // A reference to an imported constant
 
 	return map[string]any{}
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -23,6 +23,9 @@
 {{- $_ = (substr 1 -1 "1234") -}}
 {{- $_ = (substr 0 2 "1234") -}}
 {{- $_ = (substr 1 2 "1234") -}}
+{{- $_ = "1234" -}}
+{{- $_ = 1234 -}}
+{{- $_ = "IPv4" -}}
 {{- (dict "r" (dict )) | toJson -}}
 {{- break -}}
 {{- end -}}
@@ -54,8 +57,8 @@
 {{- $_ = (div (int64 1) (int64 1)) -}}
 {{- $_ = (eq (int64 1) (int64 1)) -}}
 {{- $_ = (ne (int64 1) (int64 1)) -}}
-{{- $_ = (eq (dict ) nil) -}}
-{{- $_ = (ne (dict ) nil) -}}
+{{- $_ = (eq (dict ) (coalesce nil)) -}}
+{{- $_ = (ne (dict ) (coalesce nil)) -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### This PR is stacked on top of others!

Please consider reviewing those PRs first. This message will be removed once prerequisite PRs are merged and this one is rebased.

* da02911a024de48e5744eb88f0f4f1e099d87455 is from #1181

---

#### a91d4c1d92f10cb9f171bda65f64d1cc229109b7 gotohelm: add support for referencing constants

This commit adds support for referencing `const` values both within the
same package or within an external package. It additionally includes
some mild changes to the handling of selector expressions which results
in the `Nil` ast Node being used in places that `nil` was pass through
directly.

Notably, gotohelm gocode may now leverage constants defined within
Kubernetes packages.