### PR TITLE
gotohelm: add partial support for intstr.IntOrString

### DIFF
--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.go
@@ -7,8 +7,25 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func Pod() corev1.Pod {
-	return corev1.Pod{
+func K8s() map[string]any {
+	return map[string]any{
+		"Objects": []metav1.Object{
+			pod(),
+			pdb(),
+			service(),
+		},
+		// intstr's are special cased because they have an... interesting
+		// JSON/YAML mapping.
+		"intstr": []intstr.IntOrString{
+			intstr.FromInt(10),
+			intstr.FromInt32(11),
+			intstr.FromString("12"),
+		},
+	}
+}
+
+func pod() *corev1.Pod {
+	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
 			Kind:       "Pod",
@@ -20,15 +37,29 @@ func Pod() corev1.Pod {
 	}
 }
 
-func PDB() policyv1.PodDisruptionBudget {
+func pdb() *policyv1.PodDisruptionBudget {
 	minAvail := intstr.FromInt32(3)
-	return policyv1.PodDisruptionBudget{
+	return &policyv1.PodDisruptionBudget{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
+			APIVersion: "policyv1",
 			Kind:       "PodDisruptionBudget",
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvail,
+		},
+	}
+}
+
+func service() *corev1.Service {
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{}, // Include an empty port to test the zero value of intstr.
+			},
 		},
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
@@ -1,16 +1,30 @@
 {{- /* Generated from "k8s.go" */ -}}
 
-{{- define "k8s.Pod" -}}
+{{- define "k8s.K8s" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list 10 11 "12") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "k8s.pod" -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "containers" (coalesce nil) ) "status" (dict ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Pod" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "namespace" "spacename" "name" "eman" )) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 
-{{- define "k8s.PDB" -}}
+{{- define "k8s.pdb" -}}
 {{- range $_ := (list 1) -}}
 {{- $minAvail := 3 -}}
-{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict ) "status" (dict "disruptionsAllowed" 0 "currentHealthy" 0 "desiredHealthy" 0 "expectedPods" 0 ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "PodDisruptionBudget" )) (dict "spec" (mustMergeOverwrite (dict ) (dict "minAvailable" $minAvail )) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict ) "status" (dict "disruptionsAllowed" 0 "currentHealthy" 0 "desiredHealthy" 0 "expectedPods" 0 ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "policyv1" "kind" "PodDisruptionBudget" )) (dict "spec" (mustMergeOverwrite (dict ) (dict "minAvailable" $minAvail )) ))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "k8s.service" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (mustMergeOverwrite (mustMergeOverwrite (dict ) (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict ) "status" (dict "loadBalancer" (dict ) ) )) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Service" )) (dict "spec" (mustMergeOverwrite (dict ) (dict "ports" (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict ))) )) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/main.go
+++ b/pkg/gotohelm/testdata/src/example/main.go
@@ -94,8 +94,7 @@ func runChart(dot *helmette.Dot) (_ map[string]any, err any) {
 
 	case "k8s":
 		return map[string]any{
-			"Pod": k8s.Pod(),
-			"PDB": k8s.PDB(),
+			"K8s": k8s.K8s(),
 		}, nil
 
 	case "flowcontrol":


### PR DESCRIPTION
### This PR is stacked on top of others!

Please consider reviewing those PRs first. This message will be removed once prerequisite PRs are merged and this one is rebased.

* da02911a024de48e5744eb88f0f4f1e099d87455 is from #1181
* a91d4c1d92f10cb9f171bda65f64d1cc229109b7 is from #1182

---

#### 8736301bd34686119bd2511bba555cd77cd550d3 gotohelm: add partial support for intstr.IntOrString

This commit adds partial support for Kubernetes's IntOrString type
within gotohelm. All constructors and zero values of IntOrString _as
struct fields_ are working as expected. Directly constructing
IntOrString is NOT supported as the correct behavior is a bit unclear at
this time.

This commit also heavily refactors some of the plumbing code to
construct zero values. The original intent was to being respecting the
+optional annotation within comments and to outright ban constructing
zero values of `IntOrString`. Doing so ended up being a can of worms but
the resultant code is better documented so I've opted to leave it in.