### PR TITLE
Fix release process with omitting Chart.lock unrelated updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ admin.conf
 # templated ci values
 charts/redpanda/ci/21-eks-tiered-storage-with-creds-values.yaml
 
+# Dep Chart Lock file
+Chart.lock
+
 charts/redpanda/templates/redpanda-license.yaml
 charts/redpanda/templates/external-service.yaml
 charts/redpanda/templates/external-tls-secret.yaml

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -95,10 +95,26 @@ func TestTemplate(t *testing.T) {
 	client, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
 	require.NoError(t, err)
 
+	lock, err := helm.GetChartLock("Chart.lock")
+	require.NoError(t, err)
+
 	// Chart deps are kept within ./charts as a tgz archive. Helm dep build
 	// will ensure that ./charts is in sync with Chart.lock.
 	_, err = exec.CommandContext(ctx, "helm", "dep", "build").CombinedOutput()
 	require.NoError(t, err, "failed to refresh helm dependencies")
+
+	newLock, err := helm.GetChartLock("Chart.lock")
+	require.NoError(t, err)
+
+	// Comparison between Chart.lock before and after `helm dep build` execution is required to prevent
+	// circular dependency between Chart.lock update, which is included in release [Auto commit], and
+	// next unnecessary release pipeline execution due to change in `generated` field. Allowed change
+	// in Chart.lock is only when dependencies are different. Dependencies might change only when
+	// Redpanda chart dependencies got new release.
+	if lock.Digest == newLock.Digest {
+		err = helm.UpdateChartLock(lock, "Chart.lock")
+		require.NoError(t, err)
+	}
 
 	values, err := os.ReadDir("./ci")
 	require.NoError(t, err)


### PR DESCRIPTION
Comparison between Chart.lock before and after `helm dep build` execution is required to prevent
circular dependency between Chart.lock update, which is included in release [Auto commit], and
next unnecessary release pipeline execution due to change in `generated` field. Allowed change
in Chart.lock is only when dependencies are different. Dependencies might change only when
Redpanda chart dependencies got new release.


Fixes #1185 