### PR TITLE
redpanda: include Chart.lock in released chart

### DIFF
--- a/charts/redpanda/.helmignore
+++ b/charts/redpanda/.helmignore
@@ -26,6 +26,3 @@ README.md.gotmpl
 *.go
 testdata/
 ci/
-
-# include chart lock file
-Chart.lock


### PR DESCRIPTION
#### de30dc5305c2000f65cd38d1f90394e7ace075f6 redpanda: include Chart.lock in released chart

Prior to this commit we struggled to correctly managed `Chart.lock` as
it was believed that excluding it from the released chart tgz would
allow users to utilize their own version of console or connectors.

This is not the case. `Chart.lock` is merely the output of the version
negotiation done by `helm dep update` which is then used by `helm dep
build` to place the correct chart archives in to `charts/`. `charts/` is
then included within the released helm chart and is the only source for
subcharts[^1].

The attempt to helmignore `Chart.lock` resulted in `helm dep build`
constantly regenerating `Chart.lock` as helm would stop loading the
`Chart.lock` file[^2].

This commit removes `Chart.lock` from helm ignore and some code that
attempted to manage its accidental regeneration. Otherwise it serves as
documention for these choices.

[^1]: https://github.com/helm/helm/blob/14d0c13e9eefff5b4a1b511cf50643529692ec94/cmd/helm/install.go#L261-L290
[^2]: https://github.com/helm/helm/blob/14d0c13e9eefff5b4a1b511cf50643529692ec94/pkg/downloader/manager.go#L86