### PR TITLE
add kube-linter to task

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,10 @@
+
+# Details on checks can be found on this page and the like: https://docs.kubelinter.io/#/generated/checks
+checks:
+  addAllBuiltIn: true
+  exclude:
+    - "unset-cpu-requirements" # Not every pod requires this, for example hooks, we can change opinion later
+    - "unset-memory-requirements" # Not every pod requires this, for example hooks, we can change opinion later
+    - "no-read-only-root-fs" # Some volume mounts require writes
+    - "required-annotation-email" # Not a requirement for out deployments
+    - "no-node-affinity" # Not every pod requires this

--- a/flake.nix
+++ b/flake.nix
@@ -90,6 +90,7 @@
               pkgs.kubectl
               pkgs.kubernetes-helm
               pkgs.kustomize
+              pkgs.kube-linter
               pkgs.yq # jq but for YAML
             ];
           };


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/helm-charts/issues/1061

adding task file, will look to add action in next PR but first we should get an idea of what things to exclude, what things need to be fixed. Please run

task ci:kube-lint-template

this is preliminary and it justs tests the redpanda chart, we can add more templates later if we wish. For now i included hooks, but we can add the `--no-hooks` flag.  