### PR TITLE
Move git configuration to earlier step

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,6 +58,11 @@ jobs:
         with:
           token: ${{ secrets.ACTIONS_BOT_TOKEN }}
           fetch-depth: 0
+      - name: configure git
+        run: |
+          git config --global user.name 'vbotbuildovich'
+          git config --global user.email 'vbotbuildovich@users.noreply.github.com'
+          git config --global --add --bool push.autoSetupRemote true
 
       - name: Add Repositories for each chart
         run: |
@@ -76,9 +81,6 @@ jobs:
 
       - name: Commit changes for testdata golden files
         run: |
-          git config --global user.name 'vbotbuildovich'
-          git config --global user.email 'vbotbuildovich@users.noreply.github.com'
-          git config --global --add --bool push.autoSetupRemote true
           git add charts/redpanda
           git commit -m "[Auto Commit] Update testdata golden files"
           git push


### PR DESCRIPTION
Due to error in https://github.com/redpanda-data/helm-charts/actions/runs/8708200936/job/23884992632#step:7:109 the git configuration is performed just after checkout.

Reference

```
Author identity unknown

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: empty ident name (for <runner@fv-az1245-596.44uquw3knzoenloncamig1c14h.dx.internal.cloudapp.net>) not allowed
Error: exit status 128
Usage:
  cr index [flags]
```