### PR TITLE
Narrow the auto-commit path

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Commit changes for testdata golden files
         run: |
-          git add charts/redpanda
+          git add charts/redpanda/testdata
           git commit -m "[Auto Commit] Update testdata golden files"
           git push
 


### PR DESCRIPTION
For release process auto commit initially added whole repo. It turns out that with simple mistake auto commit could create endless spiral.