### PR TITLE
Update Redpanda version test matrix

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -50,7 +50,8 @@ jobs:
       matrix:
         version:
           - ""
-          - v23.1.19
+          - v23.1.21
+          - v23.2.24
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'

--- a/.github/workflows/pull_requests_from_origin.yaml
+++ b/.github/workflows/pull_requests_from_origin.yaml
@@ -44,7 +44,8 @@ jobs:
       matrix:
         version:
           - ""
-          - v23.1.19
+          - v23.1.21
+          - v23.2.24
         testvaluespattern:
           - '9[6-9]*' # some tests depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
       fail-fast: false

--- a/.github/workflows/test_redpanda.yaml
+++ b/.github/workflows/test_redpanda.yaml
@@ -16,7 +16,8 @@ jobs:
       matrix:
         version:
           - ""
-          - v23.1.19
+          - v23.1.21
+          - v23.2.24
         testvaluespattern:
           - '0[1-3]*'
           - '0[4-6]*'


### PR DESCRIPTION
In https://github.com/redpanda-data/helm-charts/pull/950 change the test against v23.2.x was lost.

Reference

https://github.com/redpanda-data/redpanda/releases/tag/v23.2.24 https://github.com/redpanda-data/redpanda/releases/tag/v23.1.21