### PR TITLE
Replace Github workflow direct definition with taskfile goal and sync test cases

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -55,9 +55,13 @@ jobs:
           - '0[1-3]*'
           - '0[4-6]*'
           - '0[7-9]*'
-          - '1[0-2]*'
-          - '1[3-5]*'
+          - '1[0-1]*'
+          - '12*'
+          - '13*'
+          - '14*'
+          - '15*'
           - '1[6-7]*'
+          - '18*'
           - '9[7-9]*' # some tests depend on a github secret that isn't available for fork PRs. Only run these tests in branch PRs.
       fail-fast: false
     runs-on: ubuntu-22.04

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -102,30 +102,15 @@ jobs:
 
       - name: install cert-manager
         run: |
-          helm repo add jetstack https://charts.jetstack.io &&
-          helm install cert-manager --namespace cert-manager \
-            --create-namespace --version v1.11.0 jetstack/cert-manager \
-            --set installCRDs=true --wait --wait-for-jobs
+          task helm:install:cert-manager
 
       - name: install prometheus-operator
         run: |
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts &&
-          helm install prometheus prometheus-community/kube-prometheus-stack \
-            --namespace prometheus --create-namespace \
-            --set prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues=false \
-            --set nodeExporter.enabled=false \
-            --set grafana.enabled=false --set kubeStateMetrics.enabled=false --set alertmanager.enabled=false \
-            --wait --wait-for-jobs
+          task helm:install:kube-prometheus-stack
 
       - name: install metallb
         run: |
-          helm repo add metallb https://metallb.github.io/metallb &&
-          helm install metallb metallb/metallb -n metallb-system \
-            --create-namespace --version 0.13.10 --wait --wait-for-jobs
-
-      - name: apply metallb resources
-        run: |
-          kubectl -n metallb-system apply -f .github/metallb-config.yaml
+          task helm:install:metallb
 
       - name: Run chart-testing install
         run: |

--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -40,6 +40,7 @@ jobs:
           - '14*'
           - '15*'
           - '1[6-7]*'
+          - '18*'
       fail-fast: false
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
Thanks to https://github.com/redpanda-data/helm-charts/pull/1101 test steps are already defined in taskfile.