### PR TITLE
Add docker-tag-list to nix shell

### DIFF
--- a/.github/docker-tag-list.nix
+++ b/.github/docker-tag-list.nix
@@ -1,0 +1,29 @@
+{ buildGoModule
+, fetchFromGitHub
+, lib
+}:
+
+buildGoModule rec {
+  pname = "docker-tag-list";
+  version = "1.0.1";
+
+  # Don't run tests.
+  doCheck = false;
+  doInstallCheck = false;
+
+  src = fetchFromGitHub {
+    owner = "joejulian";
+    repo = pname;
+    rev = "v${version}";
+    hash = "sha256-iT+GIiO3YQWrOHMD1NoSbwtJLEspCYtKFQcTKicRttc=";
+  };
+
+  vendorHash = "sha256-YzDIwLdz6ETZi4y1Eqa8/EizLVqxGirGJCLBmjztNg8=";
+
+  meta = with lib; {
+    description = "print lists of docker image tags";
+	homepage = "https://github.com/joejulian/docker-tag-list";
+    license = licenses.asl20;
+    mainProgram = "docker-tag-list";
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -22,6 +22,7 @@
               (final: prev: {
                 chart-releaser = pkgs.callPackage ./.github/chart-releaser.nix { };
                 chart-testing = pkgs.callPackage ./.github/chart-testing.nix { };
+                docker-tag-list = pkgs.callPackage ./.github/docker-tag-list.nix { };
               })
             ];
           };
@@ -80,17 +81,19 @@
               pkgs.actionlint # Github Workflow definition linter https://github.com/rhysd/actionlint
               pkgs.chart-releaser
               pkgs.chart-testing
+              pkgs.docker-tag-list # Utility to list out docker tags
               pkgs.dyff
+              pkgs.gh # Github CLI
               pkgs.git
               pkgs.go
               pkgs.go-task
               pkgs.helm-docs
               pkgs.jq # CLI JSON swiss army knife
               pkgs.kind
+              pkgs.kube-linter
               pkgs.kubectl
               pkgs.kubernetes-helm
               pkgs.kustomize
-              pkgs.kube-linter
               pkgs.yq # jq but for YAML
             ];
           };


### PR DESCRIPTION
Prior to this commit, docker-tag-list was not included in the nix
development shell. This caused `.github/bump_chart_version.sh` to fail
in the `nightly_version_checks.yaml` workflow.

This commit adds a nix packaging of `docker-tag-list` to let the
workflow succeed once again.