### PR TITLE
introduce pkg/valuesutil

### DIFF
--- a/cmd/genschema/main.go
+++ b/cmd/genschema/main.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/invopop/jsonschema"
 	"github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/helm-charts/pkg/valuesutil"
 )
 
 func Must[T any](value T, err error) T {
@@ -43,14 +44,8 @@ func main() {
 	// Because of jsonschema's usage of an ordered map, the key ordering is a
 	// bit strange. Round trip through an untyped map[string]any to have go
 	// sort the keys alphabetically. (This helps reduce diff churn).
-	var untyped map[string]any
-	if err := json.Unmarshal(Must(json.Marshal(schema)), &untyped); err != nil {
-		panic(err)
-	}
+	untyped := Must(valuesutil.UnmarshalInto[any](schema))
+	data := Must(json.MarshalIndent(untyped, "", "  "))
 
-	data, err := json.MarshalIndent(untyped, "", "  ")
-	if err != nil {
-		panic(err.Error())
-	}
 	fmt.Printf("%s\n", data)
 }

--- a/flake.nix
+++ b/flake.nix
@@ -67,7 +67,7 @@
                 # 2. Run `nix develop`
                 # 3. Copy the output value into vendorHash
                 # TODO: Figure out a better way to update this.
-                vendorHash = "sha256-7nAKTLGNZm5sfqjlI8RzBBskl2EAyv9cz3WpOZd2Tio=";
+                vendorHash = "sha256-tIFpf0UcsI7vmQZGfTKOzGH/6gM+FYiTt2foojLgOjY=";
               };
             in
             {

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,9 @@ require (
 	github.com/homeport/dyff v1.7.1
 	github.com/imdario/mergo v0.3.11
 	github.com/invopop/jsonschema v0.12.0
+	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb
 	github.com/mitchellh/mapstructure v1.5.0
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/stretchr/testify v1.8.4
 	github.com/wk8/go-ordered-map/v2 v2.1.8
 	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
@@ -18,6 +20,7 @@ require (
 	k8s.io/api v0.29.2
 	k8s.io/apimachinery v0.29.2
 	k8s.io/client-go v0.29.2
+	k8s.io/utils v0.0.0-20230726121419-3b25d923346b
 	sigs.k8s.io/controller-runtime v0.17.2
 	sigs.k8s.io/yaml v1.4.0
 )
@@ -91,7 +94,6 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.110.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20231010175941-2dd684a91f00 // indirect
-	k8s.io/utils v0.0.0-20230726121419-3b25d923346b // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lucasb-eyer/go-colorful v1.2.0 h1:1nnpGOrhyZZuNyfu1QjKiUICQ74+3FNCN69Aj6K7nkY=
 github.com/lucasb-eyer/go-colorful v1.2.0/go.mod h1:R4dSotOR9KMtayYi1e77YzuveK+i7ruzyGqttikkLy0=
+github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb h1:w1g9wNDIE/pHSTmAaUhv4TZQuPBS6GV3mMz5hkgziIU=
+github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-ciede2000 v0.0.0-20170301095244-782e8c62fec3 h1:BXxTozrOU8zgC5dkpn3J6NTRdoP+hjok/e+ACr4Hibk=
@@ -153,6 +155,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.11.1-0.20231026093722-fa6a31e0812c h1:fPpdjePK1atuOg28PXfNSqgwf9I/qD1Hlo39JFwKBXk=
 github.com/rogpeppe/go-internal v1.11.1-0.20231026093722-fa6a31e0812c/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3 h1:n661drycOFuPLCN3Uc8sB6B/s6Z4t2xvBgU1htSHuq8=
 github.com/sergi/go-diff v1.3.2-0.20230802210424-5b0b94c5c0d3/go.mod h1:A0bzQcvG0E7Rwjx0REVgAGH58e96+X0MeOfepqsbeW4=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/pkg/valuesutil/fuzz.go
+++ b/pkg/valuesutil/fuzz.go
@@ -1,0 +1,228 @@
+package valuesutil
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
+	"regexp"
+	"slices"
+
+	"github.com/invopop/jsonschema"
+	"github.com/lucasjones/reggen"
+	"k8s.io/utils/ptr"
+)
+
+// Generate generates a go values that is valid for the provided JSON schema.
+// It may be used to "fuzz" or property test charts to ensure that all paths
+// are appropriately explored and that the schema is well formed for the chart.
+func Generate(rng *rand.Rand, s *jsonschema.Schema) any {
+	g := generator{rng: rng, maxDepth: 15, defs: buildDefMap(s), skipDeprecated: true}
+	return g.generate(0, s)
+}
+
+func buildDefMap(s *jsonschema.Schema) jsonschema.Definitions {
+	mapping := map[string]*jsonschema.Schema{"#" + s.Anchor: s}
+	for def, schema := range s.Definitions {
+		mapping["#/$defs/"+def] = schema
+	}
+	return mapping
+}
+
+type generator struct {
+	defs           jsonschema.Definitions
+	maxDepth       int
+	rng            *rand.Rand
+	skipDeprecated bool
+	reggenCache    map[string]*reggen.Generator
+}
+
+func (g *generator) generateRegex(pattern string) string {
+	if g.reggenCache == nil {
+		g.reggenCache = map[string]*reggen.Generator{}
+	}
+	if _, ok := g.reggenCache[pattern]; !ok {
+		gen := must(reggen.NewGenerator(pattern))
+		gen.SetSeed(int64(g.rng.Int()))
+		g.reggenCache[pattern] = gen
+	}
+	return g.reggenCache[pattern].Generate(5)
+}
+
+func (g *generator) generate(depth int, s *jsonschema.Schema) any {
+	if depth > g.maxDepth {
+		panic("exceeded max depth")
+	}
+
+	serialized := string(must(json.Marshal(s)))
+
+	switch {
+	case s == nil:
+		panic("Why is s nil?")
+
+	case serialized == "true":
+		return nil
+
+	case s.Ref != "":
+		if referred, ok := g.defs[s.Ref]; ok {
+			return g.generate(depth, referred)
+		}
+		panic(fmt.Sprintf("unknown ref: %q", s.Ref))
+
+	case s.DynamicRef != "":
+		if referred, ok := g.defs[s.DynamicRef]; ok {
+			return g.generate(depth, referred)
+		}
+		panic(fmt.Sprintf("unknown dynamic ref: %q", s.DynamicRef))
+
+	case s.Const != nil:
+		return s.Const
+
+	case len(s.Enum) > 0:
+		return pickone(g.rng, s.Enum)
+
+	case len(s.OneOf) > 0:
+		return g.generate(depth, pickone(g.rng, s.OneOf))
+
+	case len(s.AnyOf) > 0:
+		return g.generate(depth, pickone(g.rng, s.AnyOf))
+	}
+
+	switch s.Type {
+	case "null":
+		return nil
+
+	case "boolean":
+		// Flip a coin.
+		return g.rng.Intn(2) == 0
+
+	case "number":
+		fallthrough
+
+	case "integer":
+		max, _ := s.Maximum.Int64()
+		min, _ := s.Minimum.Int64()
+		if max == 0 {
+			max = math.MaxInt16
+			// TODO this causes too many issues right now as setting a type to
+			// int doesn't automatically result in the upper and lower
+			// boundaries being applied.
+			// max = math.MaxInt64
+		}
+		return int(min) + g.rng.Intn(int(max-min))
+
+	case "string":
+		if s.Pattern != "" {
+			if s.MinLength != nil || s.MaxLength != nil {
+				panic("unsupported pattern + min/maxlength")
+			}
+			return g.generateRegex(s.Pattern)
+		}
+
+		min := int(ptr.Deref(s.MinLength, 0))
+		max := int(ptr.Deref(s.MaxLength, 10))
+
+		var result string
+		const alphabet = "1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ!@#$%^&*()-_=+"
+		for i := 0; i < min+g.rng.Intn(max-min); i++ {
+			result += string(alphabet[g.rng.Intn(len(alphabet))])
+		}
+		return result
+
+	case "array":
+		min := int(ptr.Deref(s.MinItems, 0))
+		max := int(ptr.Deref(s.MaxItems, 5))
+
+		itemSchema := s.Items
+		if itemSchema == nil {
+			itemSchema = jsonschema.TrueSchema
+		}
+
+		items := []any{}
+		for i := 0; i < min+g.rng.Intn(max-min); i++ {
+			items = append(items, g.generate(depth, itemSchema))
+		}
+		return items
+
+	case "object":
+		val := map[string]any{}
+		min := int(ptr.Deref(s.MinProperties, uint64(s.Properties.Len())))
+		max := int(ptr.Deref(s.MaxProperties, uint64(s.Properties.Len()+5)))
+
+		for _, key := range s.Required {
+			schema, ok := s.Properties.Get(key)
+			if !ok {
+				// This might be okay in cases of AdditionalProperties or pattern properties...
+				panic(fmt.Sprintf("missing required property %q", key))
+			}
+
+			if g.skipDeprecated && schema.Deprecated {
+				continue
+			}
+
+			val[key] = g.generate(depth, schema)
+		}
+
+		var patterns []string
+		var schemas []*jsonschema.Schema
+
+		for pair := s.Properties.Oldest(); pair != nil; pair = pair.Next() {
+			required := slices.Contains(s.Required, pair.Key)
+			if required || (g.skipDeprecated && pair.Value.Deprecated) {
+				continue
+			}
+
+			patterns = append(patterns, regexp.QuoteMeta(pair.Key))
+			schemas = append(schemas, pair.Value)
+		}
+
+		for pattern, schema := range s.PatternProperties {
+			if g.skipDeprecated && schema.Deprecated {
+				continue
+			}
+			patterns = append(patterns, pattern)
+			schemas = append(schemas, schema)
+		}
+
+		addlProps := string(must(json.Marshal(s.AdditionalProperties)))
+		if addlProps != "null" && addlProps != "false" {
+			if !(g.skipDeprecated && s.AdditionalProperties.Deprecated) {
+				patterns = append(patterns, `\w+`)
+				schemas = append(schemas, s.AdditionalProperties)
+			}
+		}
+
+		// If there are no optional properties to add, bail early or if we're
+		// starting to get too "deep" progressively decrease the likelihood of
+		// going even deeper.
+		if len(patterns) == 0 || depth+g.rng.Intn(g.maxDepth) >= g.maxDepth {
+			return val
+		}
+
+		for i := len(val); i < min+g.rng.Intn(max-min); i++ {
+			j := g.rng.Intn(len(patterns))
+
+			schema := schemas[j]
+			pattern := patterns[j]
+
+			key := g.generateRegex(pattern)
+			val[key] = g.generate(depth+1, schema)
+		}
+
+		return val
+
+	default:
+		panic(fmt.Sprintf("unhandled schema: %s", serialized))
+	}
+}
+
+func must[T any](v T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+func pickone[T any](rng *rand.Rand, l []T) T {
+	return l[rng.Intn(len(l))]
+}

--- a/pkg/valuesutil/fuzz_test.go
+++ b/pkg/valuesutil/fuzz_test.go
@@ -1,0 +1,190 @@
+package valuesutil
+
+import (
+	"encoding/json"
+	"math/rand"
+	"reflect"
+	"testing"
+	"testing/quick"
+	"time"
+
+	"github.com/invopop/jsonschema"
+	"github.com/stretchr/testify/require"
+	orderedmap "github.com/wk8/go-ordered-map/v2"
+	"k8s.io/utils/ptr"
+)
+
+// TestGenerate is both an example of how to utilize [Generate] with
+// [quick.Check] and a property test for [Generate]. It's a bit mind bending.
+func TestGenerate(t *testing.T) {
+	configs := []*quick.Config{
+		// 1st property: Given a schema describing JSON schemas, we can generate
+		// valid JSON schemas.
+		{Values: func(args []reflect.Value, rng *rand.Rand) {
+			args[0] = reflect.ValueOf(metaSchema)
+			args[1] = reflect.ValueOf(Generate(rng, metaSchema))
+		}},
+		// 2st property: For any valid JSON schema, we can generate a value that is
+		// valid. NB: We're relying on our 1st property to ensure that this
+		// property always receives valid JSONSchemas.
+		{Values: func(args []reflect.Value, rng *rand.Rand) {
+			schema, _ := UnmarshalInto[*jsonschema.Schema](Generate(rng, metaSchema))
+			args[0] = reflect.ValueOf(schema)
+			args[1] = reflect.ValueOf(Generate(rng, metaSchema))
+		}},
+	}
+
+	for _, cfg := range configs {
+		if err := quick.Check(func(schema *jsonschema.Schema, instance any) bool {
+			return Validate(schema, instance) == nil
+		}, cfg); err != nil {
+			err := err.(*quick.CheckError)
+			schema := err.In[0].(*jsonschema.Schema)
+			instance := err.In[1].(any)
+
+			t.Logf("Schema: %#v", schema)
+			t.Logf("Invalid Generated Value: %#v", instance)
+			require.NoError(t, err)
+		}
+	}
+}
+
+// TestGenerateDeterministic asserts that [Generate] is deterministic and
+// produces the same value when given a particular seed.
+func TestGenerateDeterministic(t *testing.T) {
+	f := func(seed int64) any {
+		return Generate(rand.New(rand.NewSource(seed)), metaSchema)
+	}
+	require.NoError(t, quick.CheckEqual(f, f, &quick.Config{}))
+}
+
+// FuzzGenerate is effectively equivalent to [TestGenerate]'s 1st property with
+// the added benefit that it can save failures as regression cases to
+// ./testdata.
+func FuzzGenerate(f *testing.F) {
+	f.Add(time.Now().UnixNano())
+	f.Fuzz(func(t *testing.T, seed int64) {
+		rng := rand.New(rand.NewSource(seed))
+		instance := Generate(rng, metaSchema)
+		require.NoError(t, Validate(metaSchema, instance))
+	})
+}
+
+// metaSchema is a jsonschema that describes JSON schemas. It's used instead of
+// loading the actual JSONSchema metaschema because [Generate] only implements
+// a subset of features and the metaschema isn't fully complete as it allows
+// specifying fields like maxProperties on arrays.
+var metaSchema = &jsonschema.Schema{
+	Definitions: jsonschema.Definitions{
+		"any": &jsonschema.Schema{Const: true},
+		"null": &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"type"},
+			Properties: Props(map[string]*jsonschema.Schema{
+				"type": {Const: "null"},
+			}),
+		},
+		"integer": &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"type"},
+			Properties: Props(map[string]*jsonschema.Schema{
+				"type":    {Const: "integer"},
+				"minimum": {Type: "integer", Minimum: json.Number("0"), Maximum: json.Number("1000")},
+				"maximum": {Type: "integer", Minimum: json.Number("1001"), Maximum: json.Number("10000")},
+			}),
+		},
+		"boolean": &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"type"},
+			Properties: Props(map[string]*jsonschema.Schema{
+				"type": {Const: "boolean"},
+			}),
+		},
+		"string": &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"type"},
+			Properties: Props(map[string]*jsonschema.Schema{
+				"type":      {Const: "string"},
+				"minLength": {Type: "integer", Minimum: json.Number("0"), Maximum: json.Number("3")},
+				"maxLength": {Type: "integer", Minimum: json.Number("4"), Maximum: json.Number("7")},
+			}),
+		},
+		"scalar": &jsonschema.Schema{
+			AnyOf: []*jsonschema.Schema{
+				{Ref: "#/$defs/any"},
+				{Ref: "#/$defs/boolean"},
+				{Ref: "#/$defs/integer"},
+				{Ref: "#/$defs/null"},
+				{Ref: "#/$defs/string"},
+			},
+		},
+		"array": &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"type", "items"},
+			Properties: Props(map[string]*jsonschema.Schema{
+				"type": {Const: "array"},
+				"items": {AnyOf: []*jsonschema.Schema{
+					{Ref: "#/$defs/array"},
+					{Ref: "#/$defs/object"},
+					{Ref: "#/$defs/scalar"},
+				}},
+				"minItems": {Type: "integer", Minimum: json.Number("0"), Maximum: json.Number("3")},
+				"maxItems": {Type: "integer", Minimum: json.Number("4"), Maximum: json.Number("7")},
+			}),
+		},
+		"object": &jsonschema.Schema{
+			Type:     "object",
+			Required: []string{"type", "properties"},
+			Properties: Props(map[string]*jsonschema.Schema{
+				"type": {Const: "object"},
+				"properties": {
+					Type:          "object",
+					MaxProperties: ptr.To(uint64(10)),
+					MinProperties: ptr.To(uint64(0)),
+					AdditionalProperties: &jsonschema.Schema{
+						AnyOf: []*jsonschema.Schema{
+							{Ref: "#/$defs/array"},
+							{Ref: "#/$defs/object"},
+							{Ref: "#/$defs/scalar"},
+						},
+					},
+				},
+				// TODO get additionalProperties and patternProperties working.
+				// "patternProperties": {
+				// 	Type:          "object",
+				// 	MaxProperties: ptr.To(uint64(10)),
+				// 	MinProperties: ptr.To(uint64(0)),
+				// 	PatternProperties: map[string]*jsonschema.Schema{
+				// 		`(\.|\\w|\\d){3,5}`: {
+				// 			AnyOf: []*jsonschema.Schema{
+				// 				{Ref: "#/$defs/array"},
+				// 				{Ref: "#/$defs/object"},
+				// 				{Ref: "#/$defs/scalar"},
+				// 			},
+				// 		},
+				// 	},
+				// },
+				// "additionalProperties": {
+				// 	Type: "object",
+				// 	OneOf: []*jsonschema.Schema{
+				// 		{Ref: "#/$defs/array"},
+				// 		{Ref: "#/$defs/object"},
+				// 		{Ref: "#/$defs/scalar"},
+				// 	},
+				// },
+			}),
+		},
+	},
+	AnyOf: []*jsonschema.Schema{
+		{Ref: "#/$defs/object"},
+	},
+}
+
+// Props is a helper for constructing inline OrderedMaps.
+func Props(init map[string]*jsonschema.Schema) *orderedmap.OrderedMap[string, *jsonschema.Schema] {
+	props := jsonschema.NewProperties()
+	for key, value := range init {
+		props.Set(key, value)
+	}
+	return props
+}

--- a/pkg/valuesutil/valuesutil.go
+++ b/pkg/valuesutil/valuesutil.go
@@ -1,0 +1,71 @@
+package valuesutil
+
+import (
+	"bytes"
+	"encoding/json"
+
+	"github.com/invopop/jsonschema"
+	schemavalidator "github.com/santhosh-tekuri/jsonschema/v5"
+)
+
+// Validate returns an error if instance is not considered valid by schema.
+// Otherwise it returns nil.
+func Validate(schema *jsonschema.Schema, instance any) error {
+	c := schemavalidator.NewCompiler()
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(schema); err != nil {
+		return err
+	}
+
+	if err := c.AddResource(string(schema.ID), &buf); err != nil {
+		return err
+	}
+
+	validator, err := c.Compile(string(schema.ID))
+	if err != nil {
+		return err
+	}
+
+	return validator.Validate(instance)
+}
+
+func GenerateSchema(instance any) *jsonschema.Schema {
+	r := jsonschema.Reflector{
+		ExpandedStruct:             true,
+		DoNotReference:             true,
+		RequiredFromJSONSchemaTags: true,
+	}
+
+	return r.Reflect(instance)
+}
+
+// RoundTripThrough round trips input through T. It may be used to understand
+// how various types affect JSON marshalling or apply go's defaulting to an
+// untyped value.
+func RoundTripThrough[T any, K any](input K) (K, error) {
+	through, err := UnmarshalInto[T](input)
+	if err != nil {
+		var zero K
+		return zero, err
+	}
+
+	return UnmarshalInto[K](through)
+}
+
+// UnmarshalInto "converts" input into T by marshalling input to JSON and then
+// unmarshalling into T.
+func UnmarshalInto[T any](input any) (T, error) {
+	var output T
+	var buf bytes.Buffer
+
+	if err := json.NewEncoder(&buf).Encode(input); err != nil {
+		return output, err
+	}
+
+	if err := json.NewDecoder(&buf).Decode(&output); err != nil {
+		return output, err
+	}
+
+	return output, nil
+}

--- a/pkg/valuesutil/valuesutil_test.go
+++ b/pkg/valuesutil/valuesutil_test.go
@@ -1,0 +1,28 @@
+package valuesutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnmarshalInto(t *testing.T) {
+	// NB: Can't use table tests here due to the use of generics.
+	{
+		out, err := UnmarshalInto[int](10)
+		assert.NoError(t, err)
+		assert.Equal(t, 10, out)
+	}
+
+	{
+		out, err := UnmarshalInto[any](struct {
+			Foo string
+			Bar int
+		}{Foo: "hello world", Bar: 12})
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]any{
+			"Foo": "hello world",
+			"Bar": float64(12),
+		}, out)
+	}
+}


### PR DESCRIPTION
This commit introduces `pkg/valuesutil` which contains a set of
utilities to work with helm values and jsonschemas. Most notably, it
includes the `Generate` function which can deterministically produce a
randomized output that is considered valid for a given json schema.

Future commits will utilize this utility to both fuzz and property test
the redpanda chart.

Examples of both fuzz testing and property testing with go's builtin
constructs are included in `fuzz_test.go`.