### PR TITLE
reduce cache busting for gotohelm

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -60,6 +60,8 @@ tasks:
       - helm-docs -c ./charts/
       - task: chart:generate:redpanda
       - go mod tidy
+      # Ensure flake.nix has been formatted.
+      - nix fmt
       # Fail on any generated diffs.
       - git diff --exit-code
       # Actually run linters.


### PR DESCRIPTION
#### c30e78984cd87a5732c7860bec4473886f9d90c3 reduce cache busting for gotohelm

As genschema uses reflection, it needs to import the redpanda chart's
gocode which results in needing to rebuild gotohelm and genpartial much
more frequently than strictly is necessary which slows down development.

This commit splits the source regex filters for gotohelm, genpartial, and
genschema by each package such that changes to the redpanda chart don't
required gotohelm to be needlessly rebuilt. This should improve both CI
and local development iteration times.

As an added bonus, this commit also add `nix fmt` to CI.