### PR TITLE
gotohelm: add supprt for ptr.To/Deref/Equal

### DIFF
--- a/charts/redpanda/templates/_shims.tpl
+++ b/charts/redpanda/templates/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/internal/bootstrap/bootstrap.go
+++ b/pkg/gotohelm/internal/bootstrap/bootstrap.go
@@ -68,3 +68,19 @@ func len(m map[string]any) int {
 	}
 	return Len(m)
 }
+
+// re-implementation of k8s.io/utils/ptr.Deref.
+func ptr_Deref(ptr, def any) any {
+	if ptr != nil {
+		return ptr
+	}
+	return def
+}
+
+// re-implementation of k8s.io/utils/ptr.Equal.
+func ptr_Equal(a, b any) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	return a == b
+}

--- a/pkg/gotohelm/testdata/src/example/astrewrites/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/astrewrites/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/directives/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/directives/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/flowcontrol/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/flowcontrol/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/inputs/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/k8s/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/k8s/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.go
@@ -5,6 +5,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 func K8s() map[string]any {
@@ -20,6 +21,21 @@ func K8s() map[string]any {
 			intstr.FromInt(10),
 			intstr.FromInt32(11),
 			intstr.FromString("12"),
+		},
+		"ptr.Deref": []any{
+			ptr.Deref(ptr.To(3), 4),
+			ptr.Deref(nil, 3),
+			ptr.Deref(ptr.To(""), "oh?"),
+		},
+		"ptr.To": []any{
+			ptr.To("hello"),
+			ptr.To(0),
+			ptr.To(map[string]string{}),
+		},
+		"ptr.Equal": []bool{
+			ptr.Equal[int](nil, nil),
+			ptr.Equal(nil, ptr.To(3)),
+			ptr.Equal(ptr.To(3), ptr.To(3)),
 		},
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.rewritten.go
@@ -6,6 +6,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 func K8s() map[string]any {
@@ -21,6 +22,21 @@ func K8s() map[string]any {
 			intstr.FromInt(10),
 			intstr.FromInt32(11),
 			intstr.FromString("12"),
+		},
+		"ptr.Deref": []any{
+			ptr.Deref(ptr.To(3), 4),
+			ptr.Deref(nil, 3),
+			ptr.Deref(ptr.To(""), "oh?"),
+		},
+		"ptr.To": []any{
+			ptr.To("hello"),
+			ptr.To(0),
+			ptr.To(map[string]string{}),
+		},
+		"ptr.Equal": []bool{
+			ptr.Equal[int](nil, nil),
+			ptr.Equal(nil, ptr.To(3)),
+			ptr.Equal(ptr.To(3), ptr.To(3)),
 		},
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
@@ -2,7 +2,7 @@
 
 {{- define "k8s.K8s" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list 10 11 "12") )) | toJson -}}
+{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list 10 11 "12") "ptr.Deref" (list (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list 3 4) ))) "r") (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (coalesce nil) 3) ))) "r") (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list "" "oh?") ))) "r")) "ptr.To" (list "hello" 0 (dict )) "ptr.Equal" (list (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (coalesce nil)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) 3) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list 3 3) ))) "r")) )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/labels/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/labels/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/mutability/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/mutability/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/sprig/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/sprig/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/syntax/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/syntax/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/typing/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/typing/_shims.tpl
@@ -75,3 +75,29 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.ptr_Deref" -}}
+{{- $ptr := (index .a 0) -}}
+{{- $def := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $ptr (coalesce nil)) -}}
+{{- (dict "r" $ptr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $def) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.ptr_Equal" -}}
+{{- $a := (index .a 0) -}}
+{{- $b := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $a (coalesce nil)) (eq $b (coalesce nil))) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (eq $a $b)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -836,6 +836,12 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 		}
 	case "k8s.io/apimachinery/pkg/util/intstr.FromInt32", "k8s.io/apimachinery/pkg/util/intstr.FromInt", "k8s.io/apimachinery/pkg/util/intstr.FromString":
 		return args[0]
+	case "k8s.io/utils/ptr.Deref":
+		return &Call{FuncName: "_shims.ptr_Deref", Arguments: args}
+	case "k8s.io/utils/ptr.To":
+		return args[0]
+	case "k8s.io/utils/ptr.Equal":
+		return &Call{FuncName: "_shims.ptr_Equal", Arguments: args}
 	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.MustDuration":
 		return args[0]
 	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.Dig":


### PR DESCRIPTION
#### 3c831f2ca305147d3bd370a49abdc18b941ce2ab gotohelm: add supprt for ptr.To/Deref/Equal

This commit add support for the `To`, `Deref`, and `Equal` methods of
Kubernetes' ptr package.