### PR TITLE
redpanda: migrate security context helpers to go

### DIFF
--- a/charts/redpanda/ci/34-security-contexts-novalues.yaml
+++ b/charts/redpanda/ci/34-security-contexts-novalues.yaml
@@ -1,0 +1,35 @@
+statefulset:
+  # Deprecated field. Do not copy or you'll get coal for Christmas.
+  podSecurityContext:
+    runAsUser: 1111
+    runAsGroup: 2222
+    fsGroup: 3333
+    fsGroupChangePolicy: "OnRootMismatch"
+
+  securityContext:
+    runAsUser: 4444
+    runAsGroup: 5555
+    fsGroup: 6666
+    fsGroupChangePolicy: "OnRootMismatch"
+
+  sideCars:
+    configWatcher:
+      securityContext:
+        runAsGroup: 7777
+        runAsUser: 8888
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: false
+    controllers:
+      enabled: true
+      securityContext:
+        runAsGroup: 1234
+        runAsUser: 5678
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
+        privileged: false
+        readOnlyRootFilesystem: false
+
+rbac:
+  enabled: true

--- a/charts/redpanda/templates/_helpers.go.tpl
+++ b/charts/redpanda/templates/_helpers.go.tpl
@@ -226,6 +226,26 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "redpanda.PodSecurityContext" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $sc := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.statefulset.podSecurityContext $values.statefulset.securityContext) ))) "r") -}}
+{{- (dict "r" (mustMergeOverwrite (dict ) (dict "fsGroup" $sc.fsGroup "fsGroupChangePolicy" $sc.fsGroupChangePolicy ))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.ContainerSecurityContext" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $sc := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.statefulset.podSecurityContext $values.statefulset.securityContext) ))) "r") -}}
+{{- (dict "r" (mustMergeOverwrite (dict ) (dict "runAsUser" $sc.runAsUser "runAsGroup" (coalesce $sc.runAsGroup $sc.fsGroup) "allowPrivilegeEscalation" $sc.allowPriviledgeEscalation "runAsNonRoot" $sc.runAsNonRoot ))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda.cleanForK8s" -}}
 {{- $in := (index .a 0) -}}
 {{- range $_ := (list 1) -}}

--- a/charts/redpanda/templates/_helpers.tpl
+++ b/charts/redpanda/templates/_helpers.tpl
@@ -289,23 +289,12 @@ than 1 core.
 {{- toJson (dict "bool" $result) -}}
 {{- end -}}
 
-# manage backward compatibility with renaming podSecurityContext to securityContext
 {{- define "pod-security-context" -}}
-fsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
-fsGroupChangePolicy: {{ dig "securityContext" "fsGroupChangePolicy" "OnRootMismatch" .Values.statefulset }}
+{{- get ((include "redpanda.PodSecurityContext" (dict "a" (list .))) | fromJson) "r" | toYaml }}
 {{- end -}}
 
-# for backward compatibility, force a default on releases that didn't
-# set the podSecurityContext.runAsUser before
 {{- define "container-security-context" -}}
-runAsUser: {{ dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset }}
-runAsGroup: {{ dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset }}
-{{- if hasKey .Values.statefulset.securityContext "allowPrivilegeEscalation" }}
-allowPrivilegeEscalation: {{ dig "podSecurityContext" "allowPrivilegeEscalation" .Values.statefulset.securityContext.allowPrivilegeEscalation .Values.statefulset }}
-{{- end -}}
-{{- if hasKey .Values.statefulset.securityContext "runAsNonRoot" }}
-runAsNonRoot: {{ dig "podSecurityContext" "runAsNonRoot" .Values.statefulset.securityContext.runAsNonRoot .Values.statefulset }}
-{{- end -}}
+{{- get ((include "redpanda.ContainerSecurityContext" (dict "a" (list .))) | fromJson) "r" | toYaml }}
 {{- end -}}
 
 {{- define "admin-tls-curl-flags" -}}

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1323,7 +1327,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1396,7 +1402,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -681,8 +681,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: config
@@ -794,8 +796,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: config
@@ -976,7 +980,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1040,7 +1046,9 @@ spec:
                 http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -782,8 +782,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -899,8 +901,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1286,7 +1290,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1359,7 +1365,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -798,8 +798,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -914,8 +916,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1102,7 +1106,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1169,7 +1175,9 @@ spec:
                 http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -921,8 +921,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1041,8 +1043,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1437,7 +1441,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1517,7 +1523,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -928,8 +928,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1045,8 +1047,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1432,7 +1436,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1505,7 +1511,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -884,8 +884,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-cert2-cert
@@ -1015,8 +1017,10 @@ spec:
             - name: schema-ext3
               containerPort: 28081
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-cert2-cert
@@ -1506,7 +1510,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1585,7 +1591,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1322,7 +1326,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1395,7 +1401,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1327,7 +1331,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1400,7 +1406,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -953,8 +953,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1073,8 +1075,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1469,7 +1473,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1548,7 +1554,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1229,7 +1233,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1302,7 +1308,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -895,8 +895,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1012,8 +1014,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1305,7 +1309,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1378,7 +1384,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -707,8 +707,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: config
@@ -820,8 +822,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: config
@@ -1023,7 +1027,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1084,7 +1090,9 @@ spec:
                 http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1350,7 +1354,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1423,7 +1429,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -1031,8 +1031,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1148,8 +1150,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1548,7 +1552,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1621,7 +1627,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1326,7 +1330,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1399,7 +1405,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1327,7 +1331,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1400,7 +1406,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -905,8 +905,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1022,8 +1024,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1436,7 +1440,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1509,7 +1515,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -906,8 +906,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1023,8 +1025,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1439,7 +1443,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1512,7 +1518,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -904,8 +904,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1021,8 +1023,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1434,7 +1438,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1507,7 +1513,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -841,8 +841,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -958,8 +960,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1369,7 +1373,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1442,7 +1448,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -905,8 +905,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1022,8 +1024,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1444,7 +1448,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1517,7 +1523,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -906,8 +906,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1023,8 +1025,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1447,7 +1451,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1520,7 +1526,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -904,8 +904,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1021,8 +1023,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1443,7 +1447,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1516,7 +1522,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -841,8 +841,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -958,8 +960,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1378,7 +1382,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1451,7 +1457,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -905,8 +905,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1022,8 +1024,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1444,7 +1448,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1517,7 +1523,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -906,8 +906,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1023,8 +1025,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1447,7 +1451,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1520,7 +1526,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -904,8 +904,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1021,8 +1023,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1443,7 +1447,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1516,7 +1522,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -841,8 +841,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -958,8 +960,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1378,7 +1382,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1451,7 +1457,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -936,8 +938,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1323,7 +1327,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1396,7 +1402,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -820,8 +820,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -937,8 +939,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1324,7 +1328,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1397,7 +1403,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
@@ -819,8 +819,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -940,8 +942,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1327,7 +1331,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1400,7 +1406,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
@@ -834,8 +834,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -951,8 +953,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1344,7 +1348,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1417,7 +1423,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-security-contexts-novalues.yaml.golden
@@ -505,6 +505,218 @@ data:
       tls:
         enabled: true
 ---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda-rpk-bundle
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+rules:
+  - apiGroups:
+    - ""
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - limitranges
+      - persistentvolumeclaims
+      - pods
+      - pods/log
+      - replicationcontrollers
+      - resourcequotas
+      - serviceaccounts
+      - services
+    verbs:
+      - get
+      - list
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda-rpk-bundle
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda-rpk-bundle
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: redpanda-sidecar-controllers
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+rules:
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets/status
+    verbs:
+      - patch
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+---
+# Source: redpanda/templates/rbac.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: redpanda-sidecar-controllers
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.3
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: redpanda-sidecar-controllers
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: "default"
+---
 # Source: redpanda/charts/console/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -772,7 +984,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
-        fsGroup: 101
+        fsGroup: 3333
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
@@ -794,8 +1006,6 @@ spec:
               mountPath: /etc/tls/certs/default
             - name: redpanda-external-cert
               mountPath: /etc/tls/certs/external
-            - name: test-extra-volume
-              mountPath: /fake/lifecycle
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
@@ -822,37 +1032,21 @@ spec:
                   fieldPath: status.hostIP
           securityContext: 
             allowPrivilegeEscalation: null
-            runAsGroup: 101
+            runAsGroup: 2222
             runAsNonRoot: null
-            runAsUser: 101
+            runAsUser: 1111
           volumeMounts: 
             
             - name: redpanda-default-cert
               mountPath: /etc/tls/certs/default
             - name: redpanda-external-cert
               mountPath: /etc/tls/certs/external
-            - name: test-extra-volume
-              mountPath: /fake/lifecycle
             - name: config
               mountPath: /etc/redpanda
             - name: redpanda
               mountPath: /tmp/base-config
             - name: redpanda-configurator
               mountPath: /etc/secrets/configurator/scripts/
-          resources:
-            limits:
-              cpu: 200m
-              memory: 60Mi
-            requests:
-              cpu: 100m
-              memory: 20Mi
-        - name: "test-init-container"
-          image: "mintel/docker-alpine-bash-curl-jq:latest"
-          command: [ "/bin/bash", "-c" ]
-          args:
-            - |
-              set -xe
-              echo "Hello World!"
       containers:
         - name: redpanda
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
@@ -957,17 +1151,15 @@ spec:
               containerPort: 8084
           securityContext: 
             allowPrivilegeEscalation: null
-            runAsGroup: 101
+            runAsGroup: 2222
             runAsNonRoot: null
-            runAsUser: 101
+            runAsUser: 1111
           volumeMounts: 
             
             - name: redpanda-default-cert
               mountPath: /etc/tls/certs/default
             - name: redpanda-external-cert
               mountPath: /etc/tls/certs/external
-            - name: test-extra-volume
-              mountPath: /fake/lifecycle
             - name: config
               mountPath: /etc/redpanda
             - name: redpanda
@@ -987,6 +1179,13 @@ spec:
           args:
             - -c
             - 'trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh & wait $!'
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsGroup: 7777
+            runAsNonRoot: true
+            runAsUser: 8888
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -997,8 +1196,26 @@ spec:
               mountPath: /etc/redpanda
             - name: redpanda-config-watcher
               mountPath: /etc/secrets/config-watcher/scripts
-            - name: test-extra-volume
-              mountPath: /fake/lifecycle
+        - name: redpanda-controllers
+          image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.10-23.2.18
+          command:
+            - /manager
+          args:
+            - --operator-mode=false
+            - --namespace=default
+            - --health-probe-bind-address=:8085
+            - --metrics-bind-address=:9082
+            - --additional-controllers=all
+          env:
+            - name: REDPANDA_HELM_RELEASE_NAME
+              value: redpanda
+          securityContext:
+            allowPrivilegeEscalation: false
+            privileged: false
+            readOnlyRootFilesystem: false
+            runAsGroup: 1234
+            runAsNonRoot: true
+            runAsUser: 5678
       volumes: 
         
         - name: redpanda-default-cert
@@ -1009,10 +1226,6 @@ spec:
           secret:
             secretName: redpanda-external-cert
             defaultMode: 0o440
-        - name: test-extra-volume
-          secret:
-            secretName: redpanda-sts-lifecycle
-            defaultMode: 0774
         - name: lifecycle-scripts
           secret:
             secretName: redpanda-sts-lifecycle
@@ -1324,7 +1537,7 @@ spec:
         {}
       restartPolicy: Never
       securityContext: 
-        fsGroup: 101
+        fsGroup: 3333
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
@@ -1354,9 +1567,9 @@ spec:
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
           allowPrivilegeEscalation: null
-          runAsGroup: 101
+          runAsGroup: 2222
           runAsNonRoot: null
-          runAsUser: 101
+          runAsUser: 1111
         volumeMounts:
           - name: config
             mountPath: /etc/redpanda
@@ -1407,7 +1620,7 @@ spec:
         {}
       restartPolicy: Never
       securityContext: 
-        fsGroup: 101
+        fsGroup: 3333
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       containers:
@@ -1429,9 +1642,9 @@ spec:
             fi
         securityContext:
           allowPrivilegeEscalation: null
-          runAsGroup: 101
+          runAsGroup: 2222
           runAsNonRoot: null
-          runAsUser: 101
+          runAsUser: 1111
         volumeMounts:
           - name: config
             mountPath: /etc/redpanda

--- a/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
@@ -992,8 +992,10 @@ spec:
             - -c
             - 'trap "exit 0" TERM; exec /etc/secrets/fs-validator/scripts/fsValidator.sh xfs & wait $!'
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1027,8 +1029,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1144,8 +1148,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1531,7 +1537,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1604,7 +1612,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -1024,8 +1024,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1144,8 +1146,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: users
@@ -1542,7 +1546,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1621,7 +1627,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -882,8 +882,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -999,8 +1001,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1388,7 +1392,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1461,7 +1467,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -824,8 +824,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -941,8 +943,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1333,7 +1337,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1406,7 +1412,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -857,8 +857,10 @@ spec:
                   apiVersion: v1
                   fieldPath: status.hostIP
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -974,8 +976,10 @@ spec:
             - name: schema-default
               containerPort: 8084
           securityContext: 
-            runAsUser: 101
+            allowPrivilegeEscalation: null
             runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
           volumeMounts: 
             
             - name: redpanda-default-cert
@@ -1389,7 +1393,9 @@ spec:
             
             rpk cluster config import -f /tmp/cfg.yml
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config
@@ -1462,7 +1468,9 @@ spec:
                 https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
             fi
         securityContext:
+          allowPrivilegeEscalation: null
           runAsGroup: 101
+          runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
           - name: config

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -1272,6 +1272,34 @@
           ],
           "type": "object"
         },
+        "podSecurityContext": {
+          "deprecated": true,
+          "properties": {
+            "allowPriviledgeEscalation": {
+              "type": "boolean"
+            },
+            "fsGroup": {
+              "type": "integer"
+            },
+            "fsGroupChangePolicy": {
+              "enum": [
+                "OnRootMismatch",
+                "Always"
+              ],
+              "type": "string"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
+            },
+            "runAsUser": {
+              "type": "integer"
+            }
+          },
+          "type": "object"
+        },
         "podTemplate": {
           "properties": {
             "annotations": {
@@ -1424,21 +1452,29 @@
         },
         "securityContext": {
           "properties": {
+            "allowPriviledgeEscalation": {
+              "type": "boolean"
+            },
             "fsGroup": {
               "type": "integer"
             },
             "fsGroupChangePolicy": {
-              "pattern": "^(OnRootMismatch|Always)$",
+              "enum": [
+                "OnRootMismatch",
+                "Always"
+              ],
               "type": "string"
+            },
+            "runAsGroup": {
+              "type": "integer"
+            },
+            "runAsNonRoot": {
+              "type": "boolean"
             },
             "runAsUser": {
               "type": "integer"
             }
           },
-          "required": [
-            "fsGroup",
-            "runAsUser"
-          ],
           "type": "object"
         },
         "sideCars": {
@@ -1455,6 +1491,91 @@
                   "type": "object"
                 },
                 "securityContext": {
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
                   "type": "object"
                 }
               },
@@ -1485,7 +1606,94 @@
                   "type": "object"
                 },
                 "resources": true,
-                "securityContext": true
+                "securityContext": {
+                  "properties": {
+                    "allowPrivilegeEscalation": {
+                      "type": "boolean"
+                    },
+                    "capabilities": {
+                      "properties": {
+                        "add": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        },
+                        "drop": {
+                          "items": {
+                            "type": "string"
+                          },
+                          "type": "array"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "privileged": {
+                      "type": "boolean"
+                    },
+                    "procMount": {
+                      "type": "string"
+                    },
+                    "readOnlyRootFilesystem": {
+                      "type": "boolean"
+                    },
+                    "runAsGroup": {
+                      "type": "integer"
+                    },
+                    "runAsNonRoot": {
+                      "type": "boolean"
+                    },
+                    "runAsUser": {
+                      "type": "integer"
+                    },
+                    "seLinuxOptions": {
+                      "properties": {
+                        "level": {
+                          "type": "string"
+                        },
+                        "role": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        },
+                        "user": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "seccompProfile": {
+                      "properties": {
+                        "localhostProfile": {
+                          "type": "string"
+                        },
+                        "type": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "windowsOptions": {
+                      "properties": {
+                        "gmsaCredentialSpec": {
+                          "type": "string"
+                        },
+                        "gmsaCredentialSpecName": {
+                          "type": "string"
+                        },
+                        "hostProcess": {
+                          "type": "boolean"
+                        },
+                        "runAsUserName": {
+                          "type": "string"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
+                }
               },
               "type": "object"
             }
@@ -2049,6 +2257,7 @@
     }
   },
   "required": [
+    "affinity",
     "image"
   ],
   "type": "object"

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -14,7 +14,7 @@ type PartialValues struct {
 	ClusterDomain    *string           `json:"clusterDomain,omitempty"`
 	CommonLabels     map[string]string `json:"commonLabels,omitempty"`
 	NodeSelector     map[string]string `json:"nodeSelector,omitempty"`
-	Affinity         *PartialAffinity  `json:"affinity,omitempty"`
+	Affinity         *PartialAffinity  `json:"affinity,omitempty" jsonschema:"required"`
 	Tolerations      []map[string]any  `json:"tolerations,omitempty"`
 	Image            *PartialImage     `json:"image,omitempty" jsonschema:"required,description=Values used to define the container image to be used for Redpanda"`
 	Service          *PartialService   `json:"service,omitempty"`
@@ -49,6 +49,15 @@ type PartialAffinity struct {
 	NodeAffinity    map[string]any `json:"nodeAffinity,omitempty"`
 	PodAffinity     map[string]any `json:"podAffinity,omitempty"`
 	PodAntiAffinity map[string]any `json:"podAntiAffinity,omitempty"`
+}
+
+type PartialSecurityContext struct {
+	RunAsUser                 *int64                         `json:"runAsUser,omitempty"`
+	RunAsGroup                *int64                         `json:"runAsGroup,omitempty"`
+	AllowPriviledgeEscalation *bool                          `json:"allowPriviledgeEscalation,omitempty"`
+	RunAsNonRoot              *bool                          `json:"runAsNonRoot,omitempty"`
+	FSGroup                   *int64                         `json:"fsGroup,omitempty"`
+	FSGroupChangePolicy       *corev1.PodFSGroupChangePolicy `json:"fsGroupChangePolicy,omitempty"`
 }
 
 type PartialImage struct {
@@ -248,27 +257,25 @@ type PartialStatefulset struct {
 		TopologyKey       *string `json:"topologyKey,omitempty"`
 		WhenUnsatisfiable *string `json:"whenUnsatisfiable,omitempty" jsonschema:"pattern=^(ScheduleAnyway|DoNotSchedule)$"`
 	} `json:"topologySpreadConstraints,omitempty" jsonschema:"required,minItems=1"`
-	Tolerations     []any `json:"tolerations,omitempty" jsonschema:"required"`
-	SecurityContext struct {
-		FSGroup             *int    `json:"fsGroup,omitempty" jsonschema:"required"`
-		RunAsUser           *int    `json:"runAsUser,omitempty" jsonschema:"required"`
-		FSGroupChangePolicy *string `json:"fsGroupChangePolicy,omitempty" jsonschema:"pattern=^(OnRootMismatch|Always)$"`
-	} `json:"securityContext,omitempty" jsonschema:"required"`
-	SideCars struct {
+	Tolerations []any `json:"tolerations,omitempty" jsonschema:"required"`
+
+	PodSecurityContext *PartialSecurityContext `json:"podSecurityContext,omitempty"`
+	SecurityContext    *PartialSecurityContext `json:"securityContext,omitempty" jsonschema:"required"`
+	SideCars           struct {
 		ConfigWatcher struct {
-			Enabled           *bool          `json:"enabled,omitempty"`
-			ExtraVolumeMounts *string        `json:"extraVolumeMounts,omitempty"`
-			Resources         map[string]any `json:"resources,omitempty"`
-			SecurityContext   map[string]any `json:"securityContext,omitempty"`
+			Enabled           *bool                   `json:"enabled,omitempty"`
+			ExtraVolumeMounts *string                 `json:"extraVolumeMounts,omitempty"`
+			Resources         map[string]any          `json:"resources,omitempty"`
+			SecurityContext   *corev1.SecurityContext `json:"securityContext,omitempty"`
 		} `json:"configWatcher,omitempty"`
 		Controllers struct {
 			Image struct {
 				Tag        *ImageTag        `json:"tag,omitempty" jsonschema:"required,default=Chart.appVersion"`
 				Repository *ImageRepository `json:"repository,omitempty" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda-operator"`
 			} `json:"image,omitempty"`
-			Enabled         *bool `json:"enabled,omitempty"`
-			Resources       any   `json:"resources,omitempty"`
-			SecurityContext any   `json:"securityContext,omitempty"`
+			Enabled         *bool                   `json:"enabled,omitempty"`
+			Resources       any                     `json:"resources,omitempty"`
+			SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
 		} `json:"controllers,omitempty"`
 	} `json:"sideCars,omitempty" jsonschema:"required"`
 	ExtraVolumes      *string `json:"extraVolumes,omitempty"`

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -113,7 +113,7 @@ func Trunc(length int, in string) string {
 
 // Default is a go equivalent of sprig's `default`.
 // +gotohelm:builtin=default
-func Default(default_, value any) any {
+func Default[T any](default_, value T) T {
 	if Empty(value) {
 		return default_
 	}
@@ -134,13 +134,14 @@ func MustRegexMatch(pattern, s string) bool {
 
 // Coalesce is the go equivalent of sprig's `coalesce`.
 // +gotohelm:builtin=coalesce
-func Coalesce(values ...any) any {
+func Coalesce[T any](values ...T) T {
 	for _, v := range values {
 		if !Empty(v) {
 			return v
 		}
 	}
-	return nil
+	var zero T
+	return zero
 }
 
 // Empty is the go equivalent of sprig's `empty`.


### PR DESCRIPTION
#### 21b42bb7db121db64428ada98c79cd5d1cf88061 redpanda: migrate security context helpers to go

This commit migrates the `pod-security-context` and
`container-security-context` helpers from helm to go.

There's a very mild and intentional change in the behavior:
`statefulset.podSecurityContext` will not longer be merged with
`statefulset.securityContext`, it will be taken in place of it.