### PR TITLE
redpanda: wrap rpk cluster health in a retry loop

### DIFF
--- a/charts/redpanda/templates/secrets.yaml
+++ b/charts/redpanda/templates/secrets.yaml
@@ -174,8 +174,15 @@ stringData:
 
     set -e
 
+    # rpk cluster health can exit non-zero if it's unable to dial brokers. This
+    # can happen for many reasons but we never want this script to crash as it
+    # would take down yet another broker and make a bad situation worse.
+    # Instead, just wait for the command to eventually exit zero.
     echo "Waiting for cluster to be ready"
-    rpk cluster health --watch --exit-when-healthy
+    until rpk cluster health --watch --exit-when-healthy; do
+      echo "rpk cluster health failed. Waiting 5 seconds before trying again..."
+      sleep 5
+    done
 
   {{- if and $sasl.enabled (not (empty $sasl.secretRef )) }}
     while true; do


### PR DESCRIPTION
#### e0b8d5f895d7d368972e29cfaab50c57fe30719f redpanda: wrap rpk cluster health in a retry loop

It was recently discovered that `rpk cluster health --watch
--exit-when-healthy` can exit non-zero in cases where trying to dial a
broker fails. This causes a cascading error as it results in a sidecar
of redpanda to then crash and bring down the pod.

To mitigate, this commit wraps the `rpk cluster health --watch
--exit-when-healthy` line of the the config-watcher's `sasl-user.sh`
script in a back off loop.