### PR TITLE
Bump redpanda and redpanda-operator helm chart version

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.21
+version: 0.4.22
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
-appVersion: v2.1.16-23.3.11
+appVersion: v2.1.18-23.3.13
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,11 +34,11 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.16-23.3.11
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.18-23.3.13
     - name: configurator
-      image: docker.redpanda.com/redpandadata/configurator:v2.1.16-23.3.11
+      image: docker.redpanda.com/redpandadata/configurator:v2.1.18-23.3.13
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+      image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   artifacthub.io/crds: |

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.21](https://img.shields.io/badge/Version-0.4.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.16-23.3.11](https://img.shields.io/badge/AppVersion-v2.1.16--23.3.11-informational?style=flat-square)
+![Version: 0.4.22](https://img.shields.io/badge/Version-0.4.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.18-23.3.13](https://img.shields.io/badge/AppVersion-v2.1.18--23.3.13-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.2
+version: 5.8.3
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v23.3.11
+appVersion: v24.1.1
 
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
@@ -56,7 +56,7 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+      image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
     - name: busybox
       image: busybox:latest
     - name: mintel/docker-alpine-bash-curl-jq

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.2](https://img.shields.io/badge/Version-5.8.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v23.3.11](https://img.shields.io/badge/AppVersion-v23.3.11-informational?style=flat-square)
+![Version: 5.8.3](https://img.shields.io/badge/Version-5.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.1](https://img.shields.io/badge/AppVersion-v24.1.1-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1274,7 +1274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1298,7 +1298,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1357,7 +1357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1380,7 +1380,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 spec:
   maxUnavailable: 1
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 data: 
   
@@ -361,7 +361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 data:
   profile: | 
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 spec:
   type: ClusterIP
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -613,7 +613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
 spec:
   selector:
@@ -643,7 +643,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -659,7 +659,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -693,7 +693,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -811,7 +811,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
   annotations:
     # This is what defines this resource as a hook. Without this line, the
@@ -951,7 +951,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -998,7 +998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     testlabel: exercise_common_labels_template
   annotations:
     "helm.sh/hook": post-upgrade
@@ -1023,7 +1023,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -223,7 +223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -422,7 +422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -548,7 +548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -740,7 +740,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -760,7 +760,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -798,7 +798,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -920,7 +920,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1023,7 +1023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1049,7 +1049,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1074,7 +1074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1198,7 +1198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1237,7 +1237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1261,7 +1261,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1343,7 +1343,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -728,7 +728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -757,7 +757,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -776,7 +776,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -813,7 +813,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -934,7 +934,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1053,7 +1053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1077,7 +1077,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1130,7 +1130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1153,7 +1153,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -677,7 +677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -847,7 +847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -876,7 +876,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -899,7 +899,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -940,7 +940,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1065,7 +1065,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1174,7 +1174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1316,7 +1316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1349,7 +1349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1388,7 +1388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1412,7 +1412,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1500,7 +1500,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 ---
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -188,7 +188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -253,7 +253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -470,7 +470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -534,7 +534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
     - ""
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
     - ""
@@ -584,7 +584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -604,7 +604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -694,7 +694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -857,7 +857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -886,7 +886,7 @@ spec:
       serviceAccountName: redpanda
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -906,7 +906,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -944,7 +944,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1066,7 +1066,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1169,7 +1169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1328,7 +1328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1344,7 +1344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1383,7 +1383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1407,7 +1407,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1466,7 +1466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1489,7 +1489,7 @@ spec:
       serviceAccountName: redpanda
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -286,7 +286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -811,7 +811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -862,7 +862,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -902,7 +902,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1038,7 +1038,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1173,7 +1173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1199,7 +1199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1261,7 +1261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1336,7 +1336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1352,7 +1352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-cert2-root-certificate
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1385,7 +1385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1402,7 +1402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1418,7 +1418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1457,7 +1457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1481,7 +1481,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1546,7 +1546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1569,7 +1569,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1085,7 +1085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1201,7 +1201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1234,7 +1234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1273,7 +1273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1297,7 +1297,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1356,7 +1356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1379,7 +1379,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -799,7 +799,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -853,7 +853,7 @@ spec:
               echo "Hello World!"
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -977,7 +977,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1112,7 +1112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1137,7 +1137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1174,7 +1174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1228,7 +1228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1261,7 +1261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1324,7 +1324,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1383,7 +1383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1406,7 +1406,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1150,7 +1150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1302,7 +1302,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1361,7 +1361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1384,7 +1384,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   users.txt: |-
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -709,7 +709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -879,7 +879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -908,7 +908,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -931,7 +931,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -972,7 +972,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1097,7 +1097,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1348,7 +1348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1381,7 +1381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1420,7 +1420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1444,7 +1444,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1509,7 +1509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1532,7 +1532,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1085,7 +1085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1125,7 +1125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1141,7 +1141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1204,7 +1204,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1286,7 +1286,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -824,7 +824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -853,7 +853,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -873,7 +873,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -911,7 +911,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1033,7 +1033,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1136,7 +1136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1161,7 +1161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1201,7 +1201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1256,7 +1256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1280,7 +1280,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1339,7 +1339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1362,7 +1362,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -640,7 +640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -669,7 +669,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -685,7 +685,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -719,7 +719,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -837,7 +837,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -928,7 +928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   endpoints:
   - interval: 30s
@@ -974,7 +974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -998,7 +998,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1068,7 +1068,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1252,7 +1252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   endpoints:
   - interval: 30s
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1325,7 +1325,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1384,7 +1384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1407,7 +1407,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
     - ""
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
     - ""
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
       - ""
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -657,7 +657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
       - apps
@@ -707,7 +707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -797,7 +797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -960,7 +960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -989,7 +989,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -1009,7 +1009,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -1047,7 +1047,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1169,7 +1169,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1336,7 +1336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1411,7 +1411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1427,7 +1427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1444,7 +1444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1460,7 +1460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1499,7 +1499,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1523,7 +1523,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1582,7 +1582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1605,7 +1605,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -960,7 +960,7 @@ spec:
               cpu: 1
               memory: 2500Mi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1063,7 +1063,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1089,7 +1089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1114,7 +1114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1189,7 +1189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1301,7 +1301,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1360,7 +1360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1383,7 +1383,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1150,7 +1150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1302,7 +1302,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1361,7 +1361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1384,7 +1384,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -850,7 +850,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -883,7 +883,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -921,7 +921,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1045,7 +1045,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1177,7 +1177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1293,7 +1293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1310,7 +1310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1389,7 +1389,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1470,7 +1470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1493,7 +1493,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -851,7 +851,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -884,7 +884,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -922,7 +922,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1046,7 +1046,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1152,7 +1152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1178,7 +1178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1203,7 +1203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1327,7 +1327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1366,7 +1366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1390,7 +1390,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1473,7 +1473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1496,7 +1496,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -849,7 +849,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -882,7 +882,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -920,7 +920,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1044,7 +1044,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1177,7 +1177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1293,7 +1293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1310,7 +1310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1389,7 +1389,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1468,7 +1468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1491,7 +1491,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -786,7 +786,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -819,7 +819,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -857,7 +857,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -981,7 +981,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1088,7 +1088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1114,7 +1114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1139,7 +1139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1176,7 +1176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1214,7 +1214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1326,7 +1326,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: RPK_CLOUD_STORAGE_AZURE_SHARED_KEY
@@ -1403,7 +1403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1426,7 +1426,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -850,7 +850,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -883,7 +883,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -921,7 +921,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1045,7 +1045,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1210,7 +1210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1397,7 +1397,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1478,7 +1478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1501,7 +1501,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -851,7 +851,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -884,7 +884,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -922,7 +922,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1046,7 +1046,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1160,7 +1160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1335,7 +1335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1374,7 +1374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1398,7 +1398,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1481,7 +1481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1504,7 +1504,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -849,7 +849,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -882,7 +882,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -920,7 +920,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1044,7 +1044,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1160,7 +1160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1335,7 +1335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1374,7 +1374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1398,7 +1398,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1500,7 +1500,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -786,7 +786,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -819,7 +819,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -857,7 +857,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -981,7 +981,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1123,7 +1123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1256,7 +1256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1272,7 +1272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1335,7 +1335,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: RPK_CLOUD_STORAGE_AZURE_SHARED_KEY
@@ -1412,7 +1412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1435,7 +1435,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -850,7 +850,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -883,7 +883,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -921,7 +921,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1045,7 +1045,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1210,7 +1210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1397,7 +1397,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1478,7 +1478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1501,7 +1501,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -851,7 +851,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -884,7 +884,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -922,7 +922,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1046,7 +1046,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1160,7 +1160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1335,7 +1335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1374,7 +1374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1398,7 +1398,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1481,7 +1481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1504,7 +1504,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -849,7 +849,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -882,7 +882,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -920,7 +920,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1044,7 +1044,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1160,7 +1160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1286,7 +1286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1335,7 +1335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1374,7 +1374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1398,7 +1398,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1500,7 +1500,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -786,7 +786,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -819,7 +819,7 @@ spec:
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -857,7 +857,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -981,7 +981,7 @@ spec:
               cpu: 400m
               memory: 2.0Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1123,7 +1123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1256,7 +1256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1272,7 +1272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1335,7 +1335,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: RPK_CLOUD_STORAGE_AZURE_SHARED_KEY
@@ -1412,7 +1412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1435,7 +1435,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -957,7 +957,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1274,7 +1274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1298,7 +1298,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1357,7 +1357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1380,7 +1380,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -778,7 +778,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -798,7 +798,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -836,7 +836,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -958,7 +958,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1061,7 +1061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1112,7 +1112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1203,7 +1203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1236,7 +1236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1299,7 +1299,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1358,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1381,7 +1381,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -777,7 +777,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -797,7 +797,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -961,7 +961,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1064,7 +1064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1090,7 +1090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1115,7 +1115,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1152,7 +1152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1302,7 +1302,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1361,7 +1361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1384,7 +1384,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -237,7 +237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -591,7 +591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -792,7 +792,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -812,7 +812,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -850,7 +850,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -972,7 +972,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1081,7 +1081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1107,7 +1107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1132,7 +1132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1169,7 +1169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1256,7 +1256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1319,7 +1319,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1378,7 +1378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1401,7 +1401,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   fsValidator.sh: |-
@@ -288,7 +288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -570,7 +570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
       - ""
@@ -602,7 +602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -622,7 +622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 rules:
   - apiGroups:
       - apps
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -762,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -954,7 +954,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -985,7 +985,7 @@ spec:
             - name: datadir
               mountPath: /var/lib/redpanda/data
         - name: fs-validator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1005,7 +1005,7 @@ spec:
             - name: datadir
               mountPath: /var/lib/redpanda/data
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -1043,7 +1043,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1165,7 +1165,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1356,7 +1356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1394,7 +1394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1410,7 +1410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1427,7 +1427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1443,7 +1443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1482,7 +1482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1506,7 +1506,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env: []
         command: ["bash","-c"]
@@ -1565,7 +1565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1588,7 +1588,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   users.txt: |-
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -630,7 +630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -722,7 +722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -764,7 +764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -950,7 +950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -979,7 +979,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -1002,7 +1002,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -1043,7 +1043,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1168,7 +1168,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1328,7 +1328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1403,7 +1403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1419,7 +1419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1436,7 +1436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1452,7 +1452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1491,7 +1491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1515,7 +1515,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1582,7 +1582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1605,7 +1605,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -632,7 +632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -811,7 +811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -860,7 +860,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -898,7 +898,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -1020,7 +1020,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1123,7 +1123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1174,7 +1174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1265,7 +1265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1337,7 +1337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1361,7 +1361,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1445,7 +1445,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -782,7 +782,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -802,7 +802,7 @@ spec:
             - name: redpanda
               mountPath: /etc/redpanda
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -840,7 +840,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -962,7 +962,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1065,7 +1065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1091,7 +1091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1279,7 +1279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1303,7 +1303,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1367,7 +1367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1390,7 +1390,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data: 
   
   bootstrap.yaml: |
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 data:
   profile: | 
     name: default
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   name: redpanda-external
   namespace: default
 spec:
@@ -773,7 +773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selector:
     matchLabels: 
@@ -802,7 +802,7 @@ spec:
       serviceAccountName: default
       initContainers:
         - name: tuning
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -835,7 +835,7 @@ spec:
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
         - name: redpanda-configurator
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/bash
             - -c
@@ -873,7 +873,7 @@ spec:
               mountPath: /etc/secrets/configurator/scripts/
       containers:
         - name: redpanda
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           env: 
             - name: SERVICE_NAME
               valueFrom:
@@ -997,7 +997,7 @@ spec:
               cpu: 1
               memory: 2.5Gi
         - name: config-watcher
-          image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
             - /bin/sh
           args:
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   duration: 43800h
   isCA: true
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   selfSigned: {}
 ---
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1341,7 +1341,7 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       containers:
       - name: redpanda-post-install
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         
         env:
         - name: REDPANDA_LICENSE
@@ -1423,7 +1423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.2
+    helm.sh/chart: redpanda-5.8.3
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation
@@ -1446,7 +1446,7 @@ spec:
       serviceAccountName: default
       containers:
       - name: redpanda-post-upgrade
-        image: docker.redpanda.com/redpandadata/redpanda:v23.3.11
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
         command: ["/bin/bash", "-c"]
         args:
           - |


### PR DESCRIPTION
### Bump Redpanda chart version

As new version 24.1.1 of Redpanda is released this commit bumps helm
chart version and appVersion.

### Reference

https://github.com/redpanda-data/redpanda/releases/tag/v24.1.1

### Bump Redpanda operator chart version

#### What's Changed
* Remove cluster to redpanda migration tool by @RafalKorepta in https://github.com/redpanda-data/redpanda-operator/pull/120
* Control pod deletion behaviour via annotation by @koikonom in https://github.com/redpanda-data/redpanda-operator/pull/112
* Add Tiered Storage config options for Azure by @JakeSCahill in https://github.com/redpanda-data/redpanda-operator/pull/127

#### New Contributors
* @koikonom made their first contribution in https://github.com/redpanda-data/redpanda-operator/pull/112

**Full Changelog**: https://github.com/redpanda-data/redpanda-operator/compare/v2.1.17-23.3.11...v2.1.18-23.3.13