### PR TITLE
redpanda: release 5.8.4

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.3
+version: 5.8.4
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.3](https://img.shields.io/badge/Version-5.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.1](https://img.shields.io/badge/AppVersion-v24.1.1-informational?style=flat-square)
+![Version: 5.8.4](https://img.shields.io/badge/Version-5.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.1](https://img.shields.io/badge/AppVersion-v24.1.1-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 spec:
   maxUnavailable: 1
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 data: 
   
@@ -361,7 +361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 data:
   profile: | 
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 spec:
   type: ClusterIP
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -613,7 +613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
 spec:
   selector:
@@ -633,7 +633,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
       annotations:
@@ -932,7 +932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
   annotations:
     # This is what defines this resource as a hook. Without this line, the
@@ -1007,7 +1007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     testlabel: exercise_common_labels_template
   annotations:
     "helm.sh/hook": post-upgrade

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -223,7 +223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -422,7 +422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -548,7 +548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -730,7 +730,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 4719797cc24da807a3e7ee94bfe7ef592cc5f2d8f86cda636ceba64a04dcd0b0
@@ -1029,7 +1029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1055,7 +1055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1188,7 +1188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1204,7 +1204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1243,7 +1243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1328,7 +1328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -728,7 +728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -747,7 +747,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 8ced03362a6eafe39caebb461f35eeb3f1abcd221a362da127a2d11c0f679274
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1138,7 +1138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -677,7 +677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -847,7 +847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -866,7 +866,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 22bc8864df0791c86464075939b736c569776459cbf9c1bb2aff400ed23c9efc
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1231,7 +1231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1306,7 +1306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1322,7 +1322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1339,7 +1339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1355,7 +1355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1394,7 +1394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 ---
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -188,7 +188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -253,7 +253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -470,7 +470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -534,7 +534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
     - ""
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
     - ""
@@ -584,7 +584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -604,7 +604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -694,7 +694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -857,7 +857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -876,7 +876,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: ca166991d3d04e5ce4d1b783b16e9c719c3a4d6477618bfe37bc5f3db9d268a9
@@ -1175,7 +1175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1201,7 +1201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1226,7 +1226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1350,7 +1350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1389,7 +1389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1474,7 +1474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -286,7 +286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -811,7 +811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -830,7 +830,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 3be4f208b870d3b1c3c16fcf853f431264a96fefe3709940890462a08e505619
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1179,7 +1179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1267,7 +1267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1342,7 +1342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1358,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-cert2-root-certificate
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1391,7 +1391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1408,7 +1408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1424,7 +1424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1463,7 +1463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1554,7 +1554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1065,7 +1065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1091,7 +1091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1279,7 +1279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1364,7 +1364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1118,7 +1118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1234,7 +1234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1251,7 +1251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1267,7 +1267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1306,7 +1306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1391,7 +1391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f76995dbcf55dfd8ebf788b6ea899e0afa77c0be59923885237d1469c7dd8fa2
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1156,7 +1156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   users.txt: |-
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -709,7 +709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -879,7 +879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -898,7 +898,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 0766591fed04355f3be5edcbf374f613c0e290ec9a6a9a70c5747b8b6b94c0cb
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1338,7 +1338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1354,7 +1354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1387,7 +1387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1426,7 +1426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1517,7 +1517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 0fb743a9bdf50317a9bd224403c52c992691819f7c107e176628a03e65f3a4ff
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1091,7 +1091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1131,7 +1131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -824,7 +824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -843,7 +843,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 0fb743a9bdf50317a9bd224403c52c992691819f7c107e176628a03e65f3a4ff
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1167,7 +1167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1347,7 +1347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -640,7 +640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -659,7 +659,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 8df4a4e02a9691a55c354a2adc8da664140f1cb694d105b8def29e91000d67fc
@@ -934,7 +934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   endpoints:
   - interval: 30s
@@ -980,7 +980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1053,7 +1053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1258,7 +1258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   endpoints:
   - interval: 30s
@@ -1307,7 +1307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1392,7 +1392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
     - ""
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
     - ""
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
       - ""
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -657,7 +657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
       - apps
@@ -707,7 +707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -797,7 +797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -960,7 +960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -979,7 +979,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1291,7 +1291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1342,7 +1342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1379,7 +1379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1417,7 +1417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1433,7 +1433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1450,7 +1450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1466,7 +1466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1505,7 +1505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1590,7 +1590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1095,7 +1095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1120,7 +1120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1228,7 +1228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1368,7 +1368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 198e81db02d47b8d780f95a4f6f464ea68c47337efcc683bf633a3ca55f271f6
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1156,7 +1156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1183,7 +1183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1299,7 +1299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1316,7 +1316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1478,7 +1478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1209,7 +1209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1372,7 +1372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1481,7 +1481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -839,7 +839,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1183,7 +1183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1299,7 +1299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1316,7 +1316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1476,7 +1476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -776,7 +776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 93d6e0f1db569da0eda1775d62ddfa0335211dcb90f35e1dc2c894d32381fabb
@@ -1094,7 +1094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1120,7 +1120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1236,7 +1236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1253,7 +1253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1269,7 +1269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1411,7 +1411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1253,7 +1253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1291,7 +1291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1307,7 +1307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1324,7 +1324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1340,7 +1340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1379,7 +1379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1486,7 +1486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1254,7 +1254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1325,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1341,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1380,7 +1380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -839,7 +839,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1254,7 +1254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1325,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1341,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1380,7 +1380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -776,7 +776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1420,7 +1420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1253,7 +1253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1291,7 +1291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1307,7 +1307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1324,7 +1324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1340,7 +1340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1379,7 +1379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1486,7 +1486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1254,7 +1254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1325,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1341,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1380,7 +1380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -839,7 +839,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1254,7 +1254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1325,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1341,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1380,7 +1380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -776,7 +776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1420,7 +1420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -768,7 +768,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1067,7 +1067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1093,7 +1093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1118,7 +1118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1193,7 +1193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1209,7 +1209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1226,7 +1226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1242,7 +1242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1366,7 +1366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1070,7 +1070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1121,7 +1121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -237,7 +237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -591,7 +591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -779,7 +779,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1113,7 +1113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1138,7 +1138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1175,7 +1175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1213,7 +1213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1386,7 +1386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-security-contexts-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
     - ""
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
     - ""
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
       - ""
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -657,7 +657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
       - apps
@@ -707,7 +707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -797,7 +797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -960,7 +960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -979,7 +979,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1305,7 +1305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1331,7 +1331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1356,7 +1356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1393,7 +1393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1431,7 +1431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1447,7 +1447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1464,7 +1464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1480,7 +1480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1519,7 +1519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1604,7 +1604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   fsValidator.sh: |-
@@ -288,7 +288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -570,7 +570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
       - ""
@@ -602,7 +602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -622,7 +622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 rules:
   - apiGroups:
       - apps
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -762,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -944,7 +944,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1276,7 +1276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1327,7 +1327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1364,7 +1364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1402,7 +1402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1418,7 +1418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1435,7 +1435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1451,7 +1451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1490,7 +1490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1575,7 +1575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   users.txt: |-
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -630,7 +630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -722,7 +722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -764,7 +764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -950,7 +950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -969,7 +969,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 3237c5214a7b800f207eb24759710c562761cc4eb64568b79c2bdc70010e6576
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1309,7 +1309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1409,7 +1409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1425,7 +1425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1442,7 +1442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1458,7 +1458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1497,7 +1497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1590,7 +1590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -632,7 +632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -811,7 +811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -830,7 +830,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1343,7 +1343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -772,7 +772,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1122,7 +1122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1197,7 +1197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1213,7 +1213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data: 
   
   bootstrap.yaml: |
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 data:
   profile: | 
     name: default
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   name: redpanda-external
   namespace: default
 spec:
@@ -773,7 +773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selector:
     matchLabels: 
@@ -792,7 +792,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.3
+        helm.sh/chart: redpanda-5.8.4
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 1a37359565ee5aa39f2265200feb5613c0bb27495adde5a6e1cae726a786a953
@@ -1109,7 +1109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1135,7 +1135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   duration: 43800h
   isCA: true
@@ -1160,7 +1160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1197,7 +1197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   dnsNames:
     - redpanda-cluster.redpanda.default.svc.cluster.local
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1251,7 +1251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   selfSigned: {}
 ---
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1323,7 +1323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1431,7 +1431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.3
+    helm.sh/chart: redpanda-5.8.4
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation


### PR DESCRIPTION
A previous commit intended to perform a release but was on an outdated version of `main` and accidentally bumped the version to what main was already at.

This commit bumps the redpanda version to 5.8.4 to appropriately release 81f99f7d7b7a4dbdd9e568ac84492f5c2ac17c6f.