### PR TITLE
redpanda: fix fsValidator resources

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.4
+version: 5.8.5
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.4](https://img.shields.io/badge/Version-5.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.1](https://img.shields.io/badge/AppVersion-v24.1.1-informational?style=flat-square)
+![Version: 5.8.5](https://img.shields.io/badge/Version-5.8.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.1](https://img.shields.io/badge/AppVersion-v24.1.1-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/ci/09-initcontainers-resources-values.yaml
+++ b/charts/redpanda/ci/09-initcontainers-resources-values.yaml
@@ -20,6 +20,16 @@ statefulset:
         - name: test-extra-volume
           mountPath: /fake/lifecycle
   initContainers:
+    fsValidator:
+      enabled: true
+      expectedFS: ext4 # KIND clusters from github actions use ext4
+      resources:
+        requests:
+          memory: "20Mi"
+          cpu: "100m"
+        limits:
+          memory: "60Mi"
+          cpu: "200m"
     configurator:
       resources:
         requests:
@@ -36,10 +46,26 @@ statefulset:
         - name: test-extra-volume
           mountPath: /fake/lifecycle
     setDataDirOwnership:
+      enabled: true
+      resources:
+        requests:
+          memory: "20Mi"
+          cpu: "100m"
+        limits:
+          memory: "60Mi"
+          cpu: "200m"
       extraVolumeMounts: |-
         - name: test-extra-volume
           mountPath: /fake/lifecycle
     setTieredStorageCacheDirOwnership:
+      enabled: true
+      resources:
+        requests:
+          memory: "20Mi"
+          cpu: "100m"
+        limits:
+          memory: "60Mi"
+          cpu: "200m"
       extraVolumeMounts: |-
         - name: test-extra-volume
           mountPath: /fake/lifecycle

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: datadir
               mountPath: /var/lib/redpanda/data
   {{- if get .Values.statefulset.initContainers.fsValidator "resources" }}
-          resources: {{- toYaml .Values.statefulset.fsValidator.resources | nindent 12 }}
+          resources: {{- toYaml .Values.statefulset.initContainers.fsValidator.resources | nindent 12 }}
   {{- end }}
 {{- end }}
 {{- if (include "storage-tiered-config" .|fromJson).cloud_storage_enabled }}

--- a/charts/redpanda/testdata/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/01-default-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 spec:
   maxUnavailable: 1
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 type: Opaque
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 data: 
   
@@ -361,7 +361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 data:
   profile: | 
@@ -444,7 +444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 spec:
   type: ClusterIP
@@ -487,7 +487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -613,7 +613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
 spec:
   selector:
@@ -633,7 +633,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
       annotations:
@@ -932,7 +932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
   annotations:
     # This is what defines this resource as a hook. Without this line, the
@@ -1007,7 +1007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     testlabel: exercise_common_labels_template
   annotations:
     "helm.sh/hook": post-upgrade

--- a/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -139,7 +139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -223,7 +223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -422,7 +422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -548,7 +548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -711,7 +711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -730,7 +730,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 4719797cc24da807a3e7ee94bfe7ef592cc5f2d8f86cda636ceba64a04dcd0b0
@@ -1029,7 +1029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1055,7 +1055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1079,7 +1079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1118,7 +1118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1175,7 +1175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1332,7 +1332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -472,7 +472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -728,7 +728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -747,7 +747,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 8ced03362a6eafe39caebb461f35eeb3f1abcd221a362da127a2d11c0f679274
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1138,7 +1138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   users.txt: |-
@@ -160,7 +160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -285,7 +285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -332,7 +332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -551,7 +551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -677,7 +677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -847,7 +847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -866,7 +866,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 22bc8864df0791c86464075939b736c569776459cbf9c1bb2aff400ed23c9efc
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1269,7 +1269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1310,7 +1310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1343,7 +1343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1359,7 +1359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1398,7 +1398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/06-rack-awareness-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 ---
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
@@ -57,7 +57,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -151,7 +151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -188,7 +188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -253,7 +253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -470,7 +470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -534,7 +534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
     - ""
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
     - ""
@@ -584,7 +584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -604,7 +604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -652,7 +652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -694,7 +694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -857,7 +857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -876,7 +876,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: ca166991d3d04e5ce4d1b783b16e9c719c3a4d6477618bfe37bc5f3db9d268a9
@@ -1175,7 +1175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1201,7 +1201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1264,7 +1264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1305,7 +1305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1338,7 +1338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1354,7 +1354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1393,7 +1393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1478,7 +1478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/07-multiple-listeners-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -286,7 +286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -811,7 +811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -830,7 +830,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 3be4f208b870d3b1c3c16fcf853f431264a96fefe3709940890462a08e505619
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1179,7 +1179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1307,7 +1307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1348,7 +1348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1364,7 +1364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-cert2-root-certificate
@@ -1381,7 +1381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1397,7 +1397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1414,7 +1414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1469,7 +1469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1560,7 +1560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/08-custom-podantiaffinity-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1065,7 +1065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1091,7 +1091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1115,7 +1115,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1211,7 +1211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1228,7 +1228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1368,7 +1368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/09-initcontainers-resources-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -223,6 +223,60 @@ stringData:
 
     rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
 ---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redpanda-fs-validator
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.5
+type: Opaque
+stringData:
+  fsValidator.sh: |-
+    set -e
+    EXPECTED_FS_TYPE=$1
+
+    DATA_DIR="/var/lib/redpanda/data"
+    TEST_FILE="testfile"
+
+    echo "checking data directory exist..."
+    if [ ! -d "${DATA_DIR}" ]; then
+      echo "data directory does not exists, exiting"
+      exit 1
+    fi
+
+    echo "checking filesystem type..."
+    FS_TYPE=$(df -T $DATA_DIR  | tail -n +2 | awk '{print $2}')
+
+    if [ "${FS_TYPE}" != "${EXPECTED_FS_TYPE}" ]; then
+      echo "file system found to be ${FS_TYPE} when expected ${EXPECTED_FS_TYPE}"
+      exit 1
+    fi
+
+    echo "checking if able to create a test file..."
+
+    touch ${DATA_DIR}/${TEST_FILE}
+    result=$(touch ${DATA_DIR}/${TEST_FILE} 2> /dev/null; echo $?)
+    if [ "${result}" != "0" ]; then
+      echo "could not write testfile, may not have write permission"
+      exit 1
+    fi
+
+    echo "checking if able to delete a test file..."
+
+    result=$(rm ${DATA_DIR}/${TEST_FILE} 2> /dev/null; echo $?)
+    if [ "${result}" != "0" ]; then
+      echo "could not delete testfile"
+      exit 1
+    fi
+
+    echo "passed"
+---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -234,7 +288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +639,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +821,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -800,6 +854,55 @@ spec:
               mountPath: /fake/lifecycle
             - name: redpanda
               mountPath: /etc/redpanda
+        - name: set-datadir-ownership
+          image: busybox:latest
+          command: ["/bin/sh", "-c", "chown 101:101 -R /var/lib/redpanda/data"]
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: test-extra-volume
+              mountPath: /fake/lifecycle
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 200m
+              memory: 60Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
+        - name: fs-validator
+          image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
+          command:
+            - /bin/sh
+          args:
+            - -c
+            - 'trap "exit 0" TERM; exec /etc/secrets/fs-validator/scripts/fsValidator.sh ext4 & wait $!'
+          securityContext: 
+            allowPrivilegeEscalation: null
+            runAsGroup: 101
+            runAsNonRoot: null
+            runAsUser: 101
+          volumeMounts: 
+            
+            - name: redpanda-default-cert
+              mountPath: /etc/tls/certs/default
+            - name: redpanda-external-cert
+              mountPath: /etc/tls/certs/external
+            - name: redpanda-fs-validator
+              mountPath: /etc/secrets/fs-validator/scripts/
+            - name: datadir
+              mountPath: /var/lib/redpanda/data
+          resources:
+            limits:
+              cpu: 200m
+              memory: 60Mi
+            requests:
+              cpu: 100m
+              memory: 20Mi
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.1
           command:
@@ -1092,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1118,7 +1221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1142,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1181,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1222,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1238,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1255,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1271,7 +1374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1310,7 +1413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1395,7 +1498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/10-external-addresses-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f76995dbcf55dfd8ebf788b6ea899e0afa77c0be59923885237d1469c7dd8fa2
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/11-update-sasl-users-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   users.txt: |-
@@ -162,7 +162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -287,7 +287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -346,7 +346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -575,7 +575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -709,7 +709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -879,7 +879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -898,7 +898,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 0766591fed04355f3be5edcbf374f613c0e290ec9a6a9a70c5747b8b6b94c0cb
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1342,7 +1342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1358,7 +1358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1391,7 +1391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1521,7 +1521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/12-external-cert-secrets-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 0fb743a9bdf50317a9bd224403c52c992691819f7c107e176628a03e65f3a4ff
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1090,7 +1090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1188,7 +1188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1273,7 +1273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/13-loadbalancer-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -667,7 +667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
     repdanda.com/type: "loadbalancer"
 spec:
   type: LoadBalancer
@@ -824,7 +824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -843,7 +843,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 0fb743a9bdf50317a9bd224403c52c992691819f7c107e176628a03e65f3a4ff
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1209,7 +1209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1264,7 +1264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1349,7 +1349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/14-prometheus-no-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -383,7 +383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -640,7 +640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -659,7 +659,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 8df4a4e02a9691a55c354a2adc8da664140f1cb694d105b8def29e91000d67fc
@@ -934,7 +934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   endpoints:
   - interval: 30s
@@ -980,7 +980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1053,7 +1053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/15-prometheus-tls-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   endpoints:
   - interval: 30s
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1396,7 +1396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/16-controller-sidecar-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
     - ""
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
     - ""
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
       - ""
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -657,7 +657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
       - apps
@@ -707,7 +707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -797,7 +797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -960,7 +960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -979,7 +979,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1291,7 +1291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1341,7 +1341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1380,7 +1380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1421,7 +1421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1437,7 +1437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1454,7 +1454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1470,7 +1470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1509,7 +1509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1594,7 +1594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/17-resources-without-unit-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1095,7 +1095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1199,7 +1199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1372,7 +1372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/18-single-external-address-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 198e81db02d47b8d780f95a4f6f464ea68c47337efcc683bf633a3ca55f271f6
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1183,7 +1183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1336,7 +1336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1482,7 +1482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1337,7 +1337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1376,7 +1376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -839,7 +839,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1157,7 +1157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1183,7 +1183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1287,7 +1287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1303,7 +1303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1320,7 +1320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1336,7 +1336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1480,7 +1480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -776,7 +776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 93d6e0f1db569da0eda1775d62ddfa0335211dcb90f35e1dc2c894d32381fabb
@@ -1094,7 +1094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1120,7 +1120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1183,7 +1183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1273,7 +1273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1312,7 +1312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1415,7 +1415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1254,7 +1254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1328,7 +1328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1344,7 +1344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1383,7 +1383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1490,7 +1490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1312,7 +1312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1329,7 +1329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1345,7 +1345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1384,7 +1384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -839,7 +839,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1312,7 +1312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1329,7 +1329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1345,7 +1345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1384,7 +1384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -776,7 +776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1266,7 +1266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1424,7 +1424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -642,7 +642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -840,7 +840,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: f94f7fd418c58083ac8bdc922323a6019ca82079aa612ee7b1c5d31dec880cd2
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1254,7 +1254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1311,7 +1311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1328,7 +1328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1344,7 +1344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1383,7 +1383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1490,7 +1490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -601,7 +601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -643,7 +643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -822,7 +822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -841,7 +841,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 060152065130ba16f3ff438df8f07f9b02d0d10bd6c0e42fc442ec45fdb1cd2c
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1312,7 +1312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1329,7 +1329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1345,7 +1345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1384,7 +1384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -507,7 +507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -820,7 +820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -839,7 +839,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1312,7 +1312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1329,7 +1329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1345,7 +1345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1384,7 +1384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -552,7 +552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -594,7 +594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -776,7 +776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 6d844303ea4511bc85c0def54717a84fb8bf81fae5c8a4ba45a2f4aa317672e9
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1266,7 +1266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1321,7 +1321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1424,7 +1424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/30-additional-flags-override-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1066,7 +1066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1116,7 +1116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -768,7 +768,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1067,7 +1067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1093,7 +1093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1156,7 +1156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1197,7 +1197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1213,7 +1213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1370,7 +1370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/32-statefulset-podspec-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -767,7 +767,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1070,7 +1070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1096,7 +1096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1120,7 +1120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1216,7 +1216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/33-pod-selector-lables-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -47,7 +47,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -178,7 +178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -237,7 +237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -454,7 +454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -591,7 +591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -757,7 +757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -779,7 +779,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1113,7 +1113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1137,7 +1137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1176,7 +1176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1250,7 +1250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1266,7 +1266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1305,7 +1305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1390,7 +1390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-security-contexts-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
     - ""
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
     - ""
@@ -565,7 +565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
       - ""
@@ -597,7 +597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -657,7 +657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
       - apps
@@ -707,7 +707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -755,7 +755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -797,7 +797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -960,7 +960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -979,7 +979,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1305,7 +1305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1331,7 +1331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1355,7 +1355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1394,7 +1394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1435,7 +1435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1451,7 +1451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1468,7 +1468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1484,7 +1484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1523,7 +1523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1608,7 +1608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/34-statefulset-sidecars-novalues.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   fsValidator.sh: |-
@@ -288,7 +288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -505,7 +505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -570,7 +570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
       - ""
@@ -602,7 +602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -622,7 +622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 rules:
   - apiGroups:
       - apps
@@ -672,7 +672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -762,7 +762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -944,7 +944,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1276,7 +1276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1406,7 +1406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1439,7 +1439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1455,7 +1455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1494,7 +1494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1579,7 +1579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/96-audit-logging-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   users.txt: |-
@@ -206,7 +206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -390,7 +390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -630,7 +630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -722,7 +722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -764,7 +764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -950,7 +950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -969,7 +969,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 3237c5214a7b800f207eb24759710c562761cc4eb64568b79c2bdc70010e6576
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1309,7 +1309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1372,7 +1372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1413,7 +1413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1429,7 +1429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1446,7 +1446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1462,7 +1462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1501,7 +1501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1594,7 +1594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/97-license-key-values.yaml.tpl.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -91,7 +91,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -185,7 +185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -222,7 +222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -281,7 +281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -498,7 +498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -632,7 +632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -811,7 +811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -830,7 +830,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1179,7 +1179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1259,7 +1259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1347,7 +1347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1434,7 +1434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/98-license-secret-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -753,7 +753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -772,7 +772,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: bdc12c59ed4146a58b5b4bfca4bdd4495b1b9e19e49457cce50c827e3d8977ea
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1121,7 +1121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1160,7 +1160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1201,7 +1201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1234,7 +1234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1250,7 +1250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1289,7 +1289,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1379,7 +1379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   maxUnavailable: 1
   selector:
@@ -44,7 +44,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   common.sh: |-
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   sasl-user.sh: |-
@@ -175,7 +175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 type: Opaque
 stringData:
   configurator.sh: |-
@@ -234,7 +234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data: 
   
   bootstrap.yaml: |
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 data:
   profile: | 
     name: default
@@ -554,7 +554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   type: ClusterIP
   publishNotReadyAddresses: true
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external
   namespace: default
 spec:
@@ -773,7 +773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selector:
     matchLabels: 
@@ -792,7 +792,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.4
+        helm.sh/chart: redpanda-5.8.5
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
         config.redpanda.com/checksum: 1a37359565ee5aa39f2265200feb5613c0bb27495adde5a6e1cae726a786a953
@@ -1109,7 +1109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1135,7 +1135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   duration: 43800h
   isCA: true
@@ -1159,7 +1159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1198,7 +1198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1272,7 +1272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   selfSigned: {}
 ---
@@ -1288,7 +1288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1327,7 +1327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
@@ -1435,7 +1435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.4
+    helm.sh/chart: redpanda-5.8.5
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -404,8 +404,8 @@ type Statefulset struct {
 			ExpectedFS        string         `json:"expectedFS"`
 		} `json:"fsValidator"`
 		SetDataDirOwnership struct {
-			Resources         map[string]any `json:"resources"`
 			Enabled           bool           `json:"enabled"`
+			Resources         map[string]any `json:"resources"`
 			ExtraVolumeMounts string         `json:"extraVolumeMounts"`
 		} `json:"setDataDirOwnership"`
 		SetTieredStorageCacheDirOwnership struct {

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -293,8 +293,8 @@ type PartialStatefulset struct {
 			ExpectedFS        *string        `json:"expectedFS,omitempty"`
 		} `json:"fsValidator,omitempty"`
 		SetDataDirOwnership struct {
-			Resources         map[string]any `json:"resources,omitempty"`
 			Enabled           *bool          `json:"enabled,omitempty"`
+			Resources         map[string]any `json:"resources,omitempty"`
 			ExtraVolumeMounts *string        `json:"extraVolumeMounts,omitempty"`
 		} `json:"setDataDirOwnership,omitempty"`
 		SetTieredStorageCacheDirOwnership struct {


### PR DESCRIPTION
#### f24544782020d58dfa1ab1b7bef94fa59cd852d4 redpanda: fix fsValidator resources

Previously there was a typo in the fsValidator configuration that would
result in a nil pointer exception if one attempted to specify any
resources for the fsValidator.

This commit corrects the typo and updates a test to correctly exercise
the previously bugged path.