### PR TITLE
*: remove all usages of `deepCopy`

### DIFF
--- a/charts/connectors/templates/deployment.yaml
+++ b/charts/connectors/templates/deployment.yaml
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if .Values.deployment.create -}}
-{{- $root := deepCopy . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -234,7 +233,7 @@ spec:
       topologySpreadConstraints:
     {{- range $spread := .Values.deployment.topologySpreadConstraints }}
         - labelSelector:
-            matchLabels:  {{ include "connectors-pod-labels" $root | nindent 14 }}
+            matchLabels:  {{ include "connectors-pod-labels" $ | nindent 14 }}
           maxSkew: {{ $spread.maxSkew }}
           topologyKey: {{ $spread.topologyKey }}
           whenUnsatisfiable: {{ $spread.whenUnsatisfiable }}

--- a/charts/redpanda/templates/NOTES.txt
+++ b/charts/redpanda/templates/NOTES.txt
@@ -35,9 +35,6 @@ Any rpk command that's given to the user in in this file must be defined in _exa
 -}}
 
 {{- $anySASL := (include "sasl-enabled" . | fromJson).bool }}
-{{- $rpk := deepCopy . }}
-
-{{- $_ := set $rpk "rpk" "rpk" }}
 
 Congratulations on installing {{ .Chart.Name }}!
 
@@ -82,26 +79,26 @@ Try some sample commands:
 {{- if and $anySASL }}
 Create a user:
 
-  {{ include "rpk-acl-user-create" $rpk }}
+  {{ include "rpk-acl-user-create" . }}
 
 Give the user permissions:
 
-  {{ include "rpk-acl-create" $rpk }}
+  {{ include "rpk-acl-create" . }}
 
 {{- end }}
 
 Get the api status:
 
-  {{ include "rpk-cluster-info" $rpk }}
+  {{ include "rpk-cluster-info" . }}
 
 Create a topic
 
-  {{ include "rpk-topic-create" $rpk }}
+  {{ include "rpk-topic-create" . }}
 
 Describe the topic:
 
-  {{ include "rpk-topic-describe" $rpk }}
+  {{ include "rpk-topic-describe" . }}
 
 Delete the topic:
 
-  {{ include "rpk-topic-delete" $rpk }}
+  {{ include "rpk-topic-delete" . }}

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,30 +23,30 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-{{ .rpk }} acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }}
+rpk acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-create" -}}
-{{ .rpk }} acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic'
+rpk acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic'
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-cluster-info" -}}
-{{ .rpk }} cluster info
+rpk cluster info
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-create" -}}
-{{ .rpk }} topic create test-topic -p 3 -r {{ min (int64 .Values.statefulset.replicas) 3 }}
+rpk topic create test-topic -p 3 -r {{ min (int64 .Values.statefulset.replicas) 3 }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-describe" -}}
-{{ .rpk }} topic describe test-topic
+rpk topic describe test-topic
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-delete" -}}
-{{ .rpk }} topic delete test-topic
+rpk topic delete test-topic
 {{- end -}}

--- a/charts/redpanda/templates/cert-issuers.yaml
+++ b/charts/redpanda/templates/cert-issuers.yaml
@@ -15,7 +15,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if (include "tls-enabled" . | fromJson).bool }}
-  {{- $root := deepCopy . }}
   {{- $release := .Release }}
   {{- $values := .Values }}
   {{- range $name, $data := $values.tls.certs }}
@@ -34,7 +33,7 @@ metadata:
   name: {{ template "redpanda.fullname" $ }}-{{ $name }}-selfsigned-issuer
   namespace: {{ $release.Namespace | quote }}
   labels:
-{{- with include "full.labels" $root }}
+{{- with include "full.labels" $ }}
   {{- . | nindent 4 }}
 {{- end }}
 spec:
@@ -48,7 +47,7 @@ metadata:
   name: {{ template "redpanda.fullname" $ }}-{{ $name }}-root-issuer
   namespace: {{ $release.Namespace | quote }}
   labels:
-{{- with include "full.labels" $root }}
+{{- with include "full.labels" $ }}
   {{- . | nindent 4 }}
 {{- end }}
 spec:
@@ -62,7 +61,7 @@ metadata:
   name: {{ template "redpanda.fullname" $ }}-{{ $name }}-root-certificate
   namespace: {{ $release.Namespace | quote }}
   labels:
-{{- with include "full.labels" $root }}
+{{- with include "full.labels" $ }}
   {{- . | nindent 4 }}
 {{- end }}
 spec:

--- a/charts/redpanda/templates/connectors/connectors.yaml
+++ b/charts/redpanda/templates/connectors/connectors.yaml
@@ -101,8 +101,7 @@ limitations under the License.
 
 {{ $connectorsValues := merge $connectorsValues (dict "Values" (dict "deployment" (dict "create" (not .Values.connectors.deployment.create)))) }}
 {{ $connectorsValues := merge $connectorsValues (dict "Values" (dict "test" (dict "create" (not .Values.connectors.test.create)))) }}
-{{ $helmVars := deepCopy .Subcharts.connectors }}
-{{ $helmVars := merge $connectorsValues $helmVars }}
+{{ $helmVars := merge $connectorsValues .Subcharts.connectors }}
 {{ include (print .Subcharts.connectors.Template.BasePath "/deployment.yaml") $helmVars }}
 ---
 {{ include (print .Subcharts.connectors.Template.BasePath "/tests/01-mm2-values.yaml") $helmVars }}

--- a/charts/redpanda/templates/console/configmap-and-deployment.yaml
+++ b/charts/redpanda/templates/console/configmap-and-deployment.yaml
@@ -14,7 +14,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
-{{ $values := .Values }}
 
 {{/* Secret */}}
 {{ $secretConfig := dict ( dict
@@ -39,8 +38,7 @@ limitations under the License.
   "secret" $secretConfig
   )}}
 
-{{ $console := deepCopy .Subcharts.console }}
-{{ $console = merge $config $console }}
+{{ $console := merge $config .Subcharts.console }}
 ---
 {{ include (print .Subcharts.console.Template.BasePath "/secret.yaml") $console }}
   {{ end }}
@@ -56,7 +54,7 @@ limitations under the License.
 {{/* brokers */}}
 {{ $kafkaBrokers := list }}
 {{ range (include "seed-server-list" . | mustFromJson) }}
-  {{ $kafkaBrokers = append $kafkaBrokers (printf "%s:%d" . (int $values.listeners.kafka.port)) }}
+  {{ $kafkaBrokers = append $kafkaBrokers (printf "%s:%d" . (int $.Values.listeners.kafka.port)) }}
 {{ end }}
 
 {{/* sasl */}}
@@ -73,7 +71,7 @@ limitations under the License.
 {{ if (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool }}
   {{ $proto = "https" }}
 {{ end }}
-{{ $port := int $values.listeners.schemaRegistry.port }}
+{{ $port := int $.Values.listeners.schemaRegistry.port }}
 {{ range (include "seed-server-list" . | mustFromJson) }}
   {{ $urls = append $urls (printf "%s://%s:%d" $proto . $port) }}
 {{ end }}
@@ -83,16 +81,15 @@ limitations under the License.
 
 {{ $connectConfig := dict }}
 {{ if .Values.connectors.enabled }}
-{{ $connectorsValues := deepCopy .Subcharts.connectors }}
-{{ $connectorsValues = merge $connectorsValues .Values.connectors }}
+{{ $connectorsValues = merge (dict) $.Subcharts.connector .Values.connectors }}
 {{/* Connector */}}
 {{/* Currently Kafka connect helm chart does not support TLS configuraiton. That's why tls enabled is set explicitly to false*/}}
 {{/* Currently Kafka connect helm chart does not support basic auth. That's why username and password is set explicitly to empty string*/}}
 {{ $connectConfig = dict
-  "enabled" $values.connectors.enabled
+  "enabled" $.Values.connectors.enabled
   "clusters" (list
     (dict
-      "url" (printf "http://%s.%s.svc.%s:%s" (include "connectors.serviceName" $connectorsValues) .Release.Namespace ($values.clusterDomain | trimSuffix ".") ($values.connectors.connectors.restPort | toString ))
+      "url" (printf "http://%s.%s.svc.%s:%s" (include "connectors.serviceName" $connectorsValues) .Release.Namespace ($.Values.clusterDomain | trimSuffix ".") ($.Values.connectors.connectors.restPort | toString ))
       "name" "connectors"
       "tls" (dict
         "enabled" "false"
@@ -125,7 +122,7 @@ limitations under the License.
       "connect" $connectConfig
 }}
 
-{{ $consoleConfig := deepCopy .Values.console.config | merge $consoleConfig  }}
+{{ $consoleConfig := merge $consoleConfig .Values.console.config }}
 
 {{ $config := dict
     "Values" (dict
@@ -135,8 +132,7 @@ limitations under the License.
     )
 }}
 
-{{ $console := deepCopy .Subcharts.console }}
-{{ $console = merge $config $console }}
+{{ $console := merge $config .Subcharts.console }}
 ---
 {{ include (print .Subcharts.console.Template.BasePath "/configmap.yaml") $console }}
 {{ $configmap = include (print .Subcharts.console.Template.BasePath "/configmap.yaml") $console }}
@@ -285,7 +281,7 @@ limitations under the License.
   "extraEnv" $extraEnv
   "secret" $secretConfig
   "enterprise" $enterprise
-  "image" $values.console.image
+  "image" $.Values.console.image
   "autoscaling" .Values.console.autoscaling
   "replicaCount" .Values.console.replicaCount
   "strategy" .Values.console.strategy
@@ -317,8 +313,7 @@ limitations under the License.
 {{ $consoleValues := merge $consoleValues (dict "Values" (dict "podAnnotations" (dict "checksum-redpanda-chart/config" ( $configmap | toYaml | sha256sum )))) }}
 {{ end }}
 
-{{ $helmVars := deepCopy .Subcharts.console }}
-{{ $helmVars := merge $consoleValues $helmVars }}
+{{ $helmVars := merge $consoleValues .Subcharts.console }}
 
 ---
 {{ include (print .Subcharts.console.Template.BasePath "/deployment.yaml") $helmVars }}

--- a/charts/redpanda/templates/post-install-upgrade-job.yaml
+++ b/charts/redpanda/templates/post-install-upgrade-job.yaml
@@ -16,7 +16,6 @@ limitations under the License.
 */}}
 {{- if .Values.post_install_job.enabled }}
 {{- $values := .Values }}
-{{- $root := deepCopy . }}
 ---
 apiVersion: batch/v1
 kind: Job

--- a/charts/redpanda/templates/post-upgrade.yaml
+++ b/charts/redpanda/templates/post-upgrade.yaml
@@ -17,7 +17,6 @@ limitations under the License.
 {{- if .Values.post_upgrade_job.enabled }}
 {{- $service := .Values.listeners.admin -}}
 {{- $cert := get .Values.tls.certs $service.tls.cert -}}
-{{- $root := deepCopy . }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -22,7 +22,6 @@ limitations under the License.
 {{- $internalAdvertiseAddress := printf "%s.%s" "$(SERVICE_NAME)" (include "redpanda.internal.domain" .) -}}
 {{- $uid := dig "podSecurityContext" "runAsUser" .Values.statefulset.securityContext.runAsUser .Values.statefulset -}}
 {{- $gid := dig "podSecurityContext" "fsGroup" .Values.statefulset.securityContext.fsGroup .Values.statefulset -}}
-{{- $root := deepCopy . }}
 
 {{- if not (include "redpanda-atleast-22-2-0" . | fromJson).bool -}}
   {{- if eq (get .Values "force" | default false) false -}}

--- a/charts/redpanda/templates/tests/test-auditLogging.yaml
+++ b/charts/redpanda/templates/tests/test-auditLogging.yaml
@@ -19,10 +19,7 @@
   as part of setting auditLogging being enabled.
 */}}
 {{- if and .Values.tests.enabled .Values.auditLogging.enabled (include "redpanda-atleast-23-3-0" . | fromJson).bool }}
-{{- $rpk := deepCopy . }}
 {{- $sasl := .Values.auth.sasl }}
-{{- $_ := set $rpk "rpk" "rpk" }}
-{{- $_ := set $rpk "dummySasl" false }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -16,10 +16,9 @@ limitations under the License.
 */}}
 {{- if and .Values.tests.enabled .Values.connectors.enabled .Values.console.enabled }}
 {{- $sasl := .Values.auth.sasl }}
-{{- $root := deepCopy . }}
 {{- $values := .Values }}
-{{ $consoleValues := dict "Values" (deepCopy .Values.console) "Release" .Release "Chart" .Subcharts.console.Chart }}
-{{ $connectorsVars := dict "Values" (deepCopy .Values.connectors) "Release" .Release "Chart" .Subcharts.connectors.Chart }}
+{{ $consoleValues := dict "Values" .Values.console "Release" .Release "Chart" .Subcharts.console.Chart }}
+{{ $connectorsVars := dict "Values" .Values.connectors "Release" .Release "Chart" .Subcharts.connectors.Chart }}
 {{/* brokers */}}
 {{- $kafkaBrokers := list }}
 {{- range (include "seed-server-list" . | mustFromJson) }}
@@ -62,13 +61,13 @@ spec:
 
           connectorsState () {
             echo check connectors expand status
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ (deepCopy .Values.connectors).connectors.restPort }}/connectors?expand=status
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors?expand=status
             echo check connectors expand info
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ (deepCopy .Values.connectors).connectors.restPort }}/connectors?expand=info
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors?expand=info
             echo check connector configuration
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ (deepCopy .Values.connectors).connectors.restPort }}/connectors/$CONNECTOR_NAME
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors/$CONNECTOR_NAME
             echo check connector topics
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ (deepCopy .Values.connectors).connectors.restPort }}/connectors/$CONNECTOR_NAME/topics
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors/$CONNECTOR_NAME/topics
           }
           
           {{- if .Values.auth.sasl.enabled }}

--- a/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
+++ b/charts/redpanda/templates/tests/test-internal-external-tls-secrets.yaml
@@ -16,7 +16,6 @@ limitations under the License.
 */}}
 {{- if and .Values.tests.enabled (include "tls-enabled" . | fromJson).bool ( eq .Values.external.type "NodePort" ) }}
   {{- $values := .Values }}
-  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -73,7 +72,7 @@ spec:
           -CAfile {{ printf "/etc/tls/certs/%s" $name }}/ca.crt
           {{- end }}
           -key {{ printf "/etc/tls/certs/%s" $name }}/tls.key
-          -connect {{ include "admin-api-urls" $root }}'
+          -connect {{ include "admin-api-urls" $ }}'
         {{- end }}
 
         {{- if eq $cert.secretRef.name "external-tls-secret" }}
@@ -90,7 +89,7 @@ spec:
           -connect {{ $values.external.domain }}:{{ $port }}'
           {{- end }}
 
-          {{- if and (eq $values.listeners.schemaRegistry.external.default.tls.cert $name) (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
+          {{- if and (eq $values.listeners.schemaRegistry.external.default.tls.cert $name) (include "redpanda-22-2-x-without-sasl" $ | fromJson).bool }}
           echo "-----> testing external tls: schema registry"
             {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}
           retry 5 'openssl s_client -verify_return_error -prexit
@@ -101,7 +100,7 @@ spec:
           -connect {{ $values.external.domain }}:{{ $port }}'
           {{- end }}
 
-          {{- if and (eq $values.listeners.http.external.default.tls.cert $name) (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
+          {{- if and (eq $values.listeners.http.external.default.tls.cert $name) (include "redpanda-22-2-x-without-sasl" $ | fromJson).bool }}
           echo "-----> testing external tls: http api"
             {{- $port := ( first $values.listeners.http.external.default.advertisedPorts ) }}
           retry 5 'openssl s_client -verify_return_error -prexit

--- a/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-internal-tls-status.yaml
@@ -17,7 +17,6 @@ limitations under the License.
 {{- if and .Values.tests.enabled (include "kafka-internal-tls-enabled" . | fromJson).bool (not (include "sasl-enabled" . | fromJson).bool) -}}
   {{- $service := .Values.listeners.kafka -}}
   {{- $cert := get .Values.tls.certs $service.tls.cert -}}
-  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/redpanda/templates/tests/test-kafka-nodelete.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-nodelete.yaml
@@ -17,8 +17,6 @@ limitations under the License.
 {{- if and .Values.tests.enabled (dig "kafka_nodelete_topics" "[]" $.Values.config.cluster) }}
 {{- $noDeleteTopics := .Values.config.cluster.kafka_nodelete_topics }}
 {{- $sasl := .Values.auth.sasl }}
-{{- $root := deepCopy . }}
-{{- $rpk := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -16,8 +16,6 @@ limitations under the License.
 */}}
 {{- if .Values.tests.enabled }}
 {{- $sasl := .Values.auth.sasl }}
-{{- $root := deepCopy . }}
-{{- $rpk := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-sasl-status.yaml
@@ -15,10 +15,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 {{- if and .Values.tests.enabled (include "sasl-enabled" . | fromJson).bool }}
-{{- $rpk := deepCopy . }}
 {{- $sasl := .Values.auth.sasl }}
-{{- $_ := set $rpk "rpk" "rpk" }}
-{{- $_ := set $rpk "dummySasl" false }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -66,13 +63,13 @@ spec:
           done
           sleep 3
 
-          {{ include "rpk-cluster-info" $rpk }}
-          {{ include "rpk-acl-user-create" $rpk }}
-          {{ include "rpk-acl-create" $rpk }}
+          {{ include "rpk-cluster-info" $ }}
+          {{ include "rpk-acl-user-create" $ }}
+          {{ include "rpk-acl-create" $ }}
           sleep 3
-          {{ include "rpk-topic-create" $rpk }}
-          {{ include "rpk-topic-describe" $rpk }}
-          {{ include "rpk-topic-delete" $rpk }}
+          {{ include "rpk-topic-create" $ }}
+          {{ include "rpk-topic-describe" $ }}
+          {{ include "rpk-topic-delete" $ }}
           rpk acl user delete myuser
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources:

--- a/charts/redpanda/templates/tests/test-loadbalancer-tls.yaml
+++ b/charts/redpanda/templates/tests/test-loadbalancer-tls.yaml
@@ -16,7 +16,6 @@
   */}}
 {{- if and .Values.tests.enabled .Values.tls.enabled ( eq .Values.external.type "LoadBalancer" ) -}}
   {{- $values := .Values }}
-  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -93,7 +92,7 @@ spec:
           done
       {{- end }}
 
-    {{- if (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
+    {{- if (include "redpanda-22-2-x-without-sasl" $ | fromJson).bool }}
       {{- if eq $values.listeners.schemaRegistry.external.default.tls.cert $name }}
           echo "-----> testing external tls: schema registry"
           {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}

--- a/charts/redpanda/templates/tests/test-nodeport-tls.yaml
+++ b/charts/redpanda/templates/tests/test-nodeport-tls.yaml
@@ -16,7 +16,6 @@
   */}}
 {{- if and .Values.tests.enabled .Values.tls.enabled ( eq .Values.external.type "NodePort" ) -}}
   {{- $values := .Values }}
-  {{- $root := deepCopy . }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -92,7 +91,7 @@ spec:
           done
           {{- end }}
 
-    {{- if (include "redpanda-22-2-x-without-sasl" $root | fromJson).bool }}
+    {{- if (include "redpanda-22-2-x-without-sasl" $ | fromJson).bool }}
           {{- if eq $values.listeners.schemaRegistry.external.default.tls.cert $name }}
           echo "-----> testing external tls: schema registry"
           {{- $port := ( first $values.listeners.schemaRegistry.external.default.advertisedPorts ) }}

--- a/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-pandaproxy-internal-tls-status.yaml
@@ -17,7 +17,6 @@ limitations under the License.
 {{- if and .Values.tests.enabled (include "http-internal-tls-enabled" . | fromJson).bool .Values.listeners.http.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool -}}
   {{- $service := .Values.listeners.http -}}
   {{- $cert := get .Values.tls.certs $service.tls.cert -}}
-  {{- $root := deepCopy . }}
   {{- $sasl := .Values.auth.sasl }}
 apiVersion: v1
 kind: Pod

--- a/charts/redpanda/templates/tests/test-sasl-updated.yaml
+++ b/charts/redpanda/templates/tests/test-sasl-updated.yaml
@@ -16,10 +16,6 @@ limitations under the License.
 */}}
 
 {{- if and .Values.tests.enabled (include "sasl-enabled" . | fromJson).bool (eq .Values.auth.sasl.secretRef "some-users") -}}
-    {{- $rpk := deepCopy . }}
-    {{- $sasl := .Values.auth.sasl }}
-    {{- $_ := set $rpk "rpk" "rpk" }}
-    {{- $_ := set $rpk "dummySasl" false }}
 apiVersion: v1
 kind: Pod
 metadata:
@@ -66,7 +62,7 @@ spec:
           done
 
           # check that sasl is not broken
-          {{ include "rpk-cluster-info" $rpk }}
+          {{ include "rpk-cluster-info" $ }}
       volumeMounts: {{ include "default-mounts" . | nindent 8 }}
       resources:
 {{- toYaml .Values.statefulset.resources | nindent 12 }}

--- a/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
+++ b/charts/redpanda/templates/tests/test-schemaregistry-internal-tls-status.yaml
@@ -17,7 +17,6 @@ limitations under the License.
 {{- if and .Values.tests.enabled (include "schemaRegistry-internal-tls-enabled" . | fromJson).bool .Values.listeners.schemaRegistry.enabled (include "redpanda-22-2-x-without-sasl" . | fromJson).bool -}}
   {{- $service := .Values.listeners.schemaRegistry -}}
   {{- $cert := get .Values.tls.certs $service.tls.cert -}}
-  {{- $root := deepCopy . }}
   {{- $sasl := .Values.auth.sasl }}
   {{- $randNumber := randNumeric 3 }}
 apiVersion: v1


### PR DESCRIPTION
Recent exploration into the performance of `helm template` has shown that that VAST majority of execution time is due to calls to `deepCopy`. 50% is executing deepCopy itself and the other 50% is go's GC attempting to keep up with the massive allocations and cleanups.

Upon auditing our charts, it became apparent that most usages of `deepCopy` are not required with many instances not being used at all.

This commit removes all usages of `deepCopy` across all charts in this repository.