### PR TITLE
redpanda: remove ImageRepository schema validation

### DIFF
--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -82,7 +82,7 @@ type SecurityContext struct {
 }
 
 type Image struct {
-	Repository ImageRepository `json:"repository" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda"`
+	Repository string `json:"repository" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda"`
 	Tag        ImageTag        `json:"tag" jsonschema:"default=Chart.appVersion"`
 	PullPolicy string          `json:"pullPolicy" jsonschema:"required,pattern=^(Always|Never|IfNotPresent)$,description=The Kubernetes Pod image pull policy."`
 }
@@ -383,7 +383,7 @@ type Statefulset struct {
 		Controllers struct {
 			Image struct {
 				Tag        ImageTag        `json:"tag" jsonschema:"required,default=Chart.appVersion"`
-				Repository ImageRepository `json:"repository" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda-operator"`
+				Repository string `json:"repository" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda-operator"`
 			} `json:"image"`
 			Enabled         bool                    `json:"enabled"`
 			Resources       any                     `json:"resources"`

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -333,7 +333,6 @@
         "repository": {
           "default": "docker.redpanda.com/redpandadata/redpanda",
           "description": "container image repository",
-          "pattern": "^[a-z0-9-_/.]+$",
           "type": "string"
         },
         "tag": {
@@ -1590,7 +1589,6 @@
                   "properties": {
                     "repository": {
                       "default": "docker.redpanda.com/redpandadata/redpanda-operator",
-                      "pattern": "^[a-z0-9-_/.]+$",
                       "type": "string"
                     },
                     "tag": {

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -62,9 +62,9 @@ type PartialSecurityContext struct {
 }
 
 type PartialImage struct {
-	Repository *ImageRepository `json:"repository,omitempty" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda"`
-	Tag        *ImageTag        `json:"tag,omitempty" jsonschema:"default=Chart.appVersion"`
-	PullPolicy *string          `json:"pullPolicy,omitempty" jsonschema:"required,pattern=^(Always|Never|IfNotPresent)$,description=The Kubernetes Pod image pull policy."`
+	Repository *string   `json:"repository,omitempty" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda"`
+	Tag        *ImageTag `json:"tag,omitempty" jsonschema:"default=Chart.appVersion"`
+	PullPolicy *string   `json:"pullPolicy,omitempty" jsonschema:"required,pattern=^(Always|Never|IfNotPresent)$,description=The Kubernetes Pod image pull policy."`
 }
 
 type PartialService struct {
@@ -271,8 +271,8 @@ type PartialStatefulset struct {
 		} `json:"configWatcher,omitempty"`
 		Controllers struct {
 			Image struct {
-				Tag        *ImageTag        `json:"tag,omitempty" jsonschema:"required,default=Chart.appVersion"`
-				Repository *ImageRepository `json:"repository,omitempty" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda-operator"`
+				Tag        *ImageTag `json:"tag,omitempty" jsonschema:"required,default=Chart.appVersion"`
+				Repository *string   `json:"repository,omitempty" jsonschema:"required,default=docker.redpanda.com/redpandadata/redpanda-operator"`
 			} `json:"image,omitempty"`
 			Enabled         *bool                   `json:"enabled,omitempty"`
 			Resources       any                     `json:"resources,omitempty"`

--- a/charts/redpanda/values_util.go
+++ b/charts/redpanda/values_util.go
@@ -13,12 +13,6 @@ func (ImageTag) JSONSchemaExtend(schema *jsonschema.Schema) {
 	schema.Pattern = `^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$|^$`
 }
 
-type ImageRepository string
-
-func (ImageRepository) JSONSchemaExtend(schema *jsonschema.Schema) {
-	schema.Pattern = "^[a-z0-9-_/.]+$"
-}
-
 type MemoryAmount string
 
 func (MemoryAmount) JSONSchemaExtend(schema *jsonschema.Schema) {


### PR DESCRIPTION
Previously, the `image.repository` field had a weak regex associated with it to prevent invalid values from being passed to Kubernetes. This accidentally prevented users from leveraging repositories that contained a specified port due to the `:` character.

Rather than extending the regex or replacing it with an appropriate URL regex, this commit opts to remove the validation entirely. This string is never parsed internally within the chart and Kubernetes itself will provide appropriate error messages if required.

Fixes #1292