### PR TITLE
Handle for statement in transpiler

### DIFF
--- a/pkg/gotohelm/ast.go
+++ b/pkg/gotohelm/ast.go
@@ -10,6 +10,34 @@ type Node interface {
 	Write(io.Writer)
 }
 
+type Until struct {
+	Expr Node
+}
+
+func (u *Until) Write(w io.Writer) {
+	w.Write([]byte("until ("))
+	u.Expr.Write(w)
+	w.Write([]byte("|int)"))
+}
+
+type UntilStep struct {
+	Start Node
+	Stop  Node
+	Step  Node
+}
+
+func (u *UntilStep) Write(w io.Writer) {
+	w.Write([]byte("untilStep ("))
+	u.Start.Write(w)
+	w.Write([]byte("|int)"))
+	w.Write([]byte(" ("))
+	u.Stop.Write(w)
+	w.Write([]byte("|int)"))
+	w.Write([]byte(" ("))
+	u.Step.Write(w)
+	w.Write([]byte("|int)"))
+}
+
 type ParenExpr struct {
 	Expr Node
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -53,6 +53,7 @@ func Syntax() map[string]any {
 
 	return map[string]any{
 		"sliceExpr": slice,
+		"forExpr":   forExpr(10),
 	}
 }
 
@@ -133,4 +134,45 @@ func binaryExprs() {
 	_ = map[string]any{} != nil
 	// TODO strings
 	// TODO floats
+}
+
+func forExpr(interation int) [][]string {
+	result := [][]string{}
+
+	// ["0","1","2","3","4","5","6","7","8","9"]
+	test := []string{}
+	for i := 0; i < interation; i++ {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// ["2","3","4","5","6","7","8","9"]
+	test = []string{}
+	for i := 2; i < interation; i++ {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// ["2","4","6","8"]
+	test = []string{}
+	for i := 2; i < interation; i += 2 {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// ["17","15","13","11"]
+	test = []string{}
+	for i := 17; i > interation; i -= 2 {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// This for loop is noop as the condition should be greater than. The test array will be empty.
+	test = []string{}
+	for i := 17; i < interation; i -= 2 {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	return result
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -55,6 +55,7 @@ func Syntax() map[string]any {
 
 	return map[string]any{
 		"sliceExpr": slice,
+		"forExpr":   forExpr(10),
 	}
 }
 
@@ -135,4 +136,45 @@ func binaryExprs() {
 	_ = map[string]any{} != nil
 	// TODO strings
 	// TODO floats
+}
+
+func forExpr(interation int) [][]string {
+	result := [][]string{}
+
+	// ["0","1","2","3","4","5","6","7","8","9"]
+	test := []string{}
+	for i := 0; i < interation; i++ {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// ["2","3","4","5","6","7","8","9"]
+	test = []string{}
+	for i := 2; i < interation; i++ {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// ["2","4","6","8"]
+	test = []string{}
+	for i := 2; i < interation; i += 2 {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// ["17","15","13","11"]
+	test = []string{}
+	for i := 17; i > interation; i -= 2 {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	// This for loop is noop as the condition should be greater than. The test array will be empty.
+	test = []string{}
+	for i := 17; i < interation; i -= 2 {
+		test = append(test, fmt.Sprintf("%d", i))
+	}
+	result = append(result, test)
+
+	return result
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -23,7 +23,7 @@
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "string") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- (dict "r" (dict "sliceExpr" $slice )) | toJson -}}
+{{- (dict "r" (dict "sliceExpr" $slice "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list 10) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -93,6 +93,40 @@
 {{- $_ = (ne (int64 1) (int64 1)) -}}
 {{- $_ = (eq (dict ) (coalesce nil)) -}}
 {{- $_ = (ne (dict ) (coalesce nil)) -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "syntax.forExpr" -}}
+{{- $interation := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (list ) -}}
+{{- $test := (list ) -}}
+{{- range $_, $i := untilStep (0|int) ($interation|int) (1|int) -}}
+{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $test) -}}
+{{- $test = (list ) -}}
+{{- range $_, $i := untilStep (2|int) ($interation|int) (1|int) -}}
+{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $test) -}}
+{{- $test = (list ) -}}
+{{- range $_, $i := untilStep (2|int) ($interation|int) (2|int) -}}
+{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $test) -}}
+{{- $test = (list ) -}}
+{{- range $_, $i := untilStep (17|int) ($interation|int) (-2|int) -}}
+{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $test) -}}
+{{- $test = (list ) -}}
+{{- range $_, $i := untilStep ($interation|int) (17|int) (-2|int) -}}
+{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $test) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
Current go template does not have for statement iteration. To work around
the range loop using `until` buildin function. As the `until` counts from 0,
the `for` loop needs to have integer iterator that starts from 0.