### PR TITLE
Fix great or equal and less or equal binary expression

### DIFF
--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -28,9 +28,6 @@ func Syntax() map[string]any {
 	_ = len([]int{})
 	_ = len(map[string]any{})
 
-	// BinaryExprs
-	binaryExprs()
-
 	// ParenExpr
 	_ = (true)
 
@@ -55,6 +52,7 @@ func Syntax() map[string]any {
 		"sliceExpr": slice,
 		"negativeNumbers": []int{-2, -4},
 		"forExpr":   forExpr(10),
+		"binaryExprs": binaryExprs(),
 	}
 }
 
@@ -97,7 +95,7 @@ func workingWithString() map[string]any {
 
 // binaryExprs are a bit tricky because we need to care about the types beyond
 // the syntax. It get's its own function because it's so expansive.
-func binaryExprs() {
+func binaryExprs() []bool {
 	// untyped ints
 	_ = 1 * 1
 	_ = 1 + 1
@@ -135,6 +133,17 @@ func binaryExprs() {
 	_ = map[string]any{} != nil
 	// TODO strings
 	// TODO floats
+
+	result := []bool{
+		1 > 2,
+		1 < 2,
+		1 >= 2,
+		1 <= 2,
+		2 >= 2,
+		2 <= 2,
+	}
+
+	return result
 }
 
 func forExpr(interation int) [][]string {

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -30,9 +30,6 @@ func Syntax() map[string]any {
 	_ = len([]int{})
 	_ = len(map[string]any{})
 
-	// BinaryExprs
-	binaryExprs()
-
 	// ParenExpr
 	_ = (true)
 
@@ -57,6 +54,7 @@ func Syntax() map[string]any {
 		"sliceExpr":       slice,
 		"negativeNumbers": []int{-2, -4},
 		"forExpr":         forExpr(10),
+		"binaryExprs":     binaryExprs(),
 	}
 }
 
@@ -99,7 +97,7 @@ func workingWithString() map[string]any {
 
 // binaryExprs are a bit tricky because we need to care about the types beyond
 // the syntax. It get's its own function because it's so expansive.
-func binaryExprs() {
+func binaryExprs() []bool {
 	// untyped ints
 	_ = 1 * 1
 	_ = 1 + 1
@@ -137,6 +135,17 @@ func binaryExprs() {
 	_ = map[string]any{} != nil
 	// TODO strings
 	// TODO floats
+
+	result := []bool{
+		1 > 2,
+		1 < 2,
+		1 >= 2,
+		1 <= 2,
+		2 >= 2,
+		2 <= 2,
+	}
+
+	return result
 }
 
 func forExpr(interation int) [][]string {

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -12,7 +12,6 @@
 {{- $_ = (int (get (fromJson (include "_shims.len" (dict "a" (list "") ))) "r")) -}}
 {{- $_ = (int (get (fromJson (include "_shims.len" (dict "a" (list (list )) ))) "r")) -}}
 {{- $_ = (int (get (fromJson (include "_shims.len" (dict "a" (list (dict )) ))) "r")) -}}
-{{- $_ := (get (fromJson (include "syntax.binaryExprs" (dict "a" (list ) ))) "r") -}}
 {{- $_ = (true) -}}
 {{- $slice := (get (fromJson (include "syntax.sliceExpr" (dict "a" (list ) ))) "r") -}}
 {{- $_ = "1234" -}}
@@ -23,7 +22,7 @@
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "string") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list 10) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list 10) ))) "r") "binaryExprs" (get (fromJson (include "syntax.binaryExprs" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -93,6 +92,9 @@
 {{- $_ = (ne (int64 1) (int64 1)) -}}
 {{- $_ = (eq (dict ) (coalesce nil)) -}}
 {{- $_ = (ne (dict ) (coalesce nil)) -}}
+{{- $result := (list (gt 1 2) (lt 1 2) (ge 1 2) (le 1 2) (ge 2 2) (le 2 2)) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
 {{- end -}}
 {{- end -}}
 

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -665,8 +665,8 @@ func (t *Transpiler) transpileExpr(n ast.Expr) Node {
 			{"_", token.LOR.String(), "_"}:  f("or"),
 			{"_", token.GTR.String(), "_"}:  f("gt"),
 			{"_", token.LSS.String(), "_"}:  f("lt"),
-			{"_", token.GEQ.String(), "_"}:  f("gte"),
-			{"_", token.LEQ.String(), "_"}:  f("lte"),
+			{"_", token.GEQ.String(), "_"}:  f("ge"),
+			{"_", token.LEQ.String(), "_"}:  f("le"),
 
 			{"float32", token.ADD.String(), "float32"}: wrapWithCast("addf", "float64"),
 			{"float32", token.MUL.String(), "float32"}: wrapWithCast("mulf", "float64"),


### PR DESCRIPTION
Go template supports great or equal and less or equal with different name 'ge' and 'le' respectively.

Reference

* https://pkg.go.dev/text/template
* https://github.com/golang/go/blob/62711d61e5ba3a6c42bc57a28c2402dd8669261f/src/text/template/doc.go#L380-L394
* https://github.com/golang/go/blob/62711d61e5ba3a6c42bc57a28c2402dd8669261f/src/text/template/funcs.go#L55-L61