### PR TITLE
Add first function from helm chart engine

### DIFF
--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -14,6 +14,20 @@ import (
 	"golang.org/x/exp/maps"
 )
 
+// First function can not return `T` as sprig implementation
+// will return nil if array is of the size 0.
+//
+// # Reference
+// https://github.com/Masterminds/sprig/blob/581758eb7d96ae4d113649668fa96acc74d46e7f/list.go#L161-L163
+// +gotohelm:builtin=first
+func First[T any](x []T) any {
+	if len(x) == 0 {
+		return nil
+	}
+
+	return x[0]
+}
+
 // TrimPrefix is the go equivalent of sprig's `trimPrefix`
 // +gotohelm:builtin=trimPrefix
 func TrimPrefix(prefix, s string) string {

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -25,6 +25,28 @@ func Sprig() map[string]any {
 		"atoi":    atoi(),
 		"float":   float(),
 		"len":     lenTest(),
+		"first":   first(),
+	}
+}
+
+func first() []any {
+	return []any{
+		helmette.First[string]([]string{"one", "two"}),
+		helmette.First[int]([]int{-3, -4}),
+		helmette.First[float64]([]float64{5.5, 6.6}),
+		helmette.First[uint]([]uint{7, 8}),
+		helmette.First[bool]([]bool{true, false}),
+		helmette.First[bool]([]bool{false, true}),
+		// Empty arrays
+		helmette.First[bool]([]bool{}),
+		helmette.First[uint]([]uint{}),
+		helmette.First[float64]([]float64{}),
+		helmette.First[int]([]int{}),
+		helmette.First[string]([]string{}),
+		helmette.First[byte]([]byte{}),
+		// The []bytes array that is represented as string in go template
+		// the first function will panic as string is not array.
+		//helmette.First[byte]([]byte{"test"}),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -26,6 +26,28 @@ func Sprig() map[string]any {
 		"atoi":    atoi(),
 		"float":   float(),
 		"len":     lenTest(),
+		"first":   first(),
+	}
+}
+
+func first() []any {
+	return []any{
+		helmette.First[string]([]string{"one", "two"}),
+		helmette.First[int]([]int{-3, -4}),
+		helmette.First[float64]([]float64{5.5, 6.6}),
+		helmette.First[uint]([]uint{7, 8}),
+		helmette.First[bool]([]bool{true, false}),
+		helmette.First[bool]([]bool{false, true}),
+		// Empty arrays
+		helmette.First[bool]([]bool{}),
+		helmette.First[uint]([]uint{}),
+		helmette.First[float64]([]float64{}),
+		helmette.First[int]([]int{}),
+		helmette.First[string]([]string{}),
+		helmette.First[byte]([]byte{}),
+		// The []bytes array that is represented as string in go template
+		// the first function will panic as string is not array.
+		//helmette.First[byte]([]byte{"test"}),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,14 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.first" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (list (first (list "one" "two")) (first (list -3 -4)) (first (list 5.5 6.6)) (first (list 7 8)) (first (list true false)) (first (list false true)) (first (list )) (first (list )) (first (list )) (first (list )) (first (list )) (first (list )))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -53,6 +53,7 @@ func Syntax() map[string]any {
 
 	return map[string]any{
 		"sliceExpr": slice,
+		"negativeNumbers": []int{-2, -4},
 		"forExpr":   forExpr(10),
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -54,8 +54,9 @@ func Syntax() map[string]any {
 	_ = helmette.Compact2(helmette.TypeTest[map[string]any](x))
 
 	return map[string]any{
-		"sliceExpr": slice,
-		"forExpr":   forExpr(10),
+		"sliceExpr":       slice,
+		"negativeNumbers": []int{-2, -4},
+		"forExpr":         forExpr(10),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -23,7 +23,7 @@
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "string") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- (dict "r" (dict "sliceExpr" $slice "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list 10) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list 10) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -748,6 +748,10 @@ func (t *Transpiler) transpileExpr(n ast.Expr) Node {
 		case token.AND:
 			// Can't take addresses in templates so just return the variable.
 			return t.transpileExpr(n.X)
+		case token.SUB:
+			if i, ok := n.X.(*ast.BasicLit); ok {
+				return &Literal{Value: fmt.Sprintf("-%s", i.Value)}
+			}
 		}
 
 	case *ast.IndexExpr:


### PR DESCRIPTION
To handle Redpanda configuration in go code the `first` function needs to be included to helmette as part of the sprig definition.

Negative numbers are recognized as `ast.UnaryExpr` with sub token. Now they can be transpiled.

P.S. The `[]byte` array can be represented only in Go, but not in template.