### PR TITLE
gotohelm: automatically handle (T, error) returns on builtins

### DIFF
--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -276,10 +276,12 @@ func Concat[T any](lists ...[]T) []T {
 }
 
 // Atoi is the go equivalent of sprig's `atoi`.
+// +gotohelm:builtin=atoi
 func Atoi(in string) (int, error) {
 	return strconv.Atoi(in)
 }
 
+// +gotohelm:builtin=float64
 func Float64(in string) (float64, error) {
 	return strconv.ParseFloat(in, 64)
 }

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -15,20 +15,21 @@ type AStruct struct {
 // in helmette return the same values as the transpiled versions.
 func Sprig() map[string]any {
 	return map[string]any{
-		"concat":   concat(),
-		"default":  default_(),
-		"keys":     keys(),
-		"empty":    empty(),
-		"strings":  stringsFunctions(),
-		"unset":    unset(),
-		"regex":    regex(),
-		"atoi":     atoi(),
-		"float":    float(),
-		"len":      lenTest(),
+		"atoi":    atoi(),
+		"concat":  concat(),
+		"default": default_(),
+		"empty":   empty(),
+		"errTypes": errTypes(),
 		"first":    first(),
-		"toString": toString(),
+		"float":   float(),
+		"keys":    keys(),
+		"len":     lenTest(),
 		"min":      minFunc(),
+		"regex":   regex(),
+		"strings": stringsFunctions(),
+		"toString": toString(),
 		"trim":     trim(),
+		"unset":   unset(),
 	}
 }
 
@@ -108,7 +109,7 @@ func float() []float64 {
 	errorHappen := 0.3
 	if err != nil {
 		// The error will never happen in go template engine. That's why sprig is swallowing/omitting any error
-		//errorHappen = 1.3
+		// errorHappen = 1.3
 	}
 	return []float64{
 		f,
@@ -133,7 +134,7 @@ func atoi() []int {
 	errorHappen := 0
 	if err != nil {
 		// The error will never happen in go template engine. That's why sprig is swallowing/omitting any error
-		//errorHappen = 1
+		// errorHappen = 1
 	}
 	return []int{
 		positive,
@@ -219,5 +220,16 @@ func empty() []bool {
 		helmette.Empty(AStruct{}),
 		helmette.Empty(AStruct{Value: 0}),
 		helmette.Empty(AStruct{Value: 1}),
+	}
+}
+
+func errTypes() []any {
+	// Tests for sprig functions that should technically return (T, error) but
+	// can't due to template limitation.
+	// We can't currently exercise failure cases here as the test harness
+	// doesn't handle it.
+	return []any{
+		helmette.Compact2(helmette.Atoi("1")),
+		helmette.Compact2(helmette.Float64("1.1")),
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -16,20 +16,21 @@ type AStruct struct {
 // in helmette return the same values as the transpiled versions.
 func Sprig() map[string]any {
 	return map[string]any{
+		"atoi":     atoi(),
 		"concat":   concat(),
 		"default":  default_(),
-		"keys":     keys(),
 		"empty":    empty(),
-		"strings":  stringsFunctions(),
-		"unset":    unset(),
-		"regex":    regex(),
-		"atoi":     atoi(),
-		"float":    float(),
-		"len":      lenTest(),
+		"errTypes": errTypes(),
 		"first":    first(),
-		"toString": toString(),
+		"float":    float(),
+		"keys":     keys(),
+		"len":      lenTest(),
 		"min":      minFunc(),
+		"regex":    regex(),
+		"strings":  stringsFunctions(),
+		"toString": toString(),
 		"trim":     trim(),
+		"unset":    unset(),
 	}
 }
 
@@ -113,7 +114,7 @@ func float() []float64 {
 	errorHappen := 0.3
 	if err != nil {
 		// The error will never happen in go template engine. That's why sprig is swallowing/omitting any error
-		//errorHappen = 1.3
+		// errorHappen = 1.3
 	}
 	return []float64{
 		f,
@@ -142,7 +143,7 @@ func atoi() []int {
 	errorHappen := 0
 	if err != nil {
 		// The error will never happen in go template engine. That's why sprig is swallowing/omitting any error
-		//errorHappen = 1
+		// errorHappen = 1
 	}
 	return []int{
 		positive,
@@ -228,5 +229,16 @@ func empty() []bool {
 		helmette.Empty(AStruct{}),
 		helmette.Empty(AStruct{Value: 0}),
 		helmette.Empty(AStruct{Value: 1}),
+	}
+}
+
+func errTypes() []any {
+	// Tests for sprig functions that should technically return (T, error) but
+	// can't due to template limitation.
+	// We can't currently exercise failure cases here as the test harness
+	// doesn't handle it.
+	return []any{
+		helmette.Compact2(helmette.Atoi("1")),
+		helmette.Compact2(helmette.Float64("1.1")),
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,7 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "errTypes" (get (fromJson (include "sprig.errTypes" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -136,6 +136,13 @@
 {{- define "sprig.empty" -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (list (empty (coalesce nil)) (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" (coalesce nil) )) (empty 1) (empty 0) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict "Value" 0 ) (dict ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" 0 ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" 1 ))))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.errTypes" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (list (get (fromJson (include "_shims.compact" (dict "a" (list (list (atoi "1") nil)) ))) "r") (get (fromJson (include "_shims.compact" (dict "a" (list (list (float64 "1.1") nil)) ))) "r"))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Previously, gotohelm required special casing for functions that returned `(T, error)` as helm/sprig functions have no notion of returning errors.

This commit adds automatic detection for such cases. Any function annotated with `+gotohelm:builtin=` that returns `(T, error)` will automatically be wrapped with `list nil` to simulate a successful return.