### PR TITLE
Add trimSuffix function to helmette

### DIFF
--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -41,10 +41,22 @@ func First[T any](x []T) any {
 	return x[0]
 }
 
+// TrimSuffix is the go equivalent of sprig's `trimSuffix`
+// +gotohelm:builtin=trimSuffix
+func TrimSuffix(suffix, s string) string {
+	if strings.HasSuffix(s, suffix) {
+		return strings.TrimSuffix(s, suffix)
+	}
+	return s
+}
+
 // TrimPrefix is the go equivalent of sprig's `trimPrefix`
 // +gotohelm:builtin=trimPrefix
 func TrimPrefix(prefix, s string) string {
-	return strings.TrimPrefix(s, prefix)
+	if strings.HasSuffix(s, prefix) {
+		return strings.TrimPrefix(s, prefix)
+	}
+	return s
 }
 
 // SortAlpha is the go equivalent of sprig's `sortAlpha`

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -27,7 +27,19 @@ func Sprig() map[string]any {
 		"len":      lenTest(),
 		"first":    first(),
 		"toString": toString(),
-		"min":     minFunc(),
+		"min":      minFunc(),
+		"trim":     trim(),
+	}
+}
+
+func trim() []string {
+	return []string{
+		helmette.TrimSuffix("test-kd", "-kd"),
+		helmette.TrimPrefix("test-kd", "test"),
+		helmette.TrimSuffix("test-kd", "none"),
+		helmette.TrimPrefix("test-kd", "none"),
+		helmette.TrimSuffix("test-kd", ""),
+		helmette.TrimPrefix("test-kd", ""),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -29,6 +29,18 @@ func Sprig() map[string]any {
 		"first":    first(),
 		"toString": toString(),
 		"min":      minFunc(),
+		"trim":     trim(),
+	}
+}
+
+func trim() []string {
+	return []string{
+		helmette.TrimSuffix("test-kd", "-kd"),
+		helmette.TrimPrefix("test-kd", "test"),
+		helmette.TrimSuffix("test-kd", "none"),
+		helmette.TrimPrefix("test-kd", "none"),
+		helmette.TrimSuffix("test-kd", ""),
+		helmette.TrimPrefix("test-kd", ""),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,14 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.trim" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (list (trimSuffix "test-kd" "-kd") (trimPrefix "test-kd" "test") (trimSuffix "test-kd" "none") (trimPrefix "test-kd" "none") (trimSuffix "test-kd" "") (trimPrefix "test-kd" ""))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
`trimSuffix` function is required for Redpanda configuration conversion.

Reference

https://github.com/redpanda-data/helm-charts/blob/9d0f4fcf9929c8c8574d8cd5137da1bd7b7e94e3/charts/redpanda/templates/_helpers.tpl#L169