### PR TITLE
Add toYaml function to sprig helmette

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	golang.org/x/exp v0.0.0-20231226003508-02704c960a9b
 	golang.org/x/net v0.25.0
 	golang.org/x/tools v0.17.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.29.5
 	k8s.io/apimachinery v0.29.5
@@ -166,7 +167,6 @@ require (
 	google.golang.org/protobuf v1.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.5 // indirect
 	k8s.io/apiserver v0.29.5 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -14,7 +14,22 @@ import (
 	"github.com/Masterminds/sprig/v3"
 	"github.com/imdario/mergo"
 	"golang.org/x/exp/maps"
+	"gopkg.in/yaml.v3"
 )
+
+// ToYAML is the go equivalent of helm's `toYaml`.
+//
+// Reference
+// https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L51
+// https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L78-L89
+// +gotohelm:builtin=toYaml
+func ToYaml(value any) string {
+	marshalled, err := yaml.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(marshalled)
+}
 
 // Min is the go equivalent of sprig's `min`
 // +gotohelm:builtin=min

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -15,21 +15,33 @@ type AStruct struct {
 // in helmette return the same values as the transpiled versions.
 func Sprig() map[string]any {
 	return map[string]any{
-		"atoi":    atoi(),
-		"concat":  concat(),
-		"default": default_(),
-		"empty":   empty(),
+		"atoi":     atoi(),
+		"concat":   concat(),
+		"default":  default_(),
+		"empty":    empty(),
 		"errTypes": errTypes(),
 		"first":    first(),
-		"float":   float(),
-		"keys":    keys(),
-		"len":     lenTest(),
+		"float":    float(),
+		"keys":     keys(),
+		"len":      lenTest(),
 		"min":      minFunc(),
-		"regex":   regex(),
-		"strings": stringsFunctions(),
+		"regex":    regex(),
+		"strings":  stringsFunctions(),
 		"toString": toString(),
 		"trim":     trim(),
-		"unset":   unset(),
+		"unset":    unset(),
+		"yaml":     yaml(),
+	}
+}
+
+func yaml() any {
+	return []string{
+		helmette.ToYaml(nil),
+		helmette.ToYaml(map[string]string{
+			"test": "test",
+		}),
+		helmette.ToYaml(map[string]string{}),
+		helmette.ToYaml([]string{"test", "test2"}),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -31,6 +31,18 @@ func Sprig() map[string]any {
 		"toString": toString(),
 		"trim":     trim(),
 		"unset":    unset(),
+		"yaml":     yaml(),
+	}
+}
+
+func yaml() any {
+	return []string{
+		helmette.ToYaml(nil),
+		helmette.ToYaml(map[string]string{
+			"test": "test",
+		}),
+		helmette.ToYaml(map[string]string{}),
+		helmette.ToYaml([]string{"test", "test2"}),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -2,7 +2,14 @@
 
 {{- define "sprig.Sprig" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "errTypes" (get (fromJson (include "sprig.errTypes" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "atoi" (get (fromJson (include "sprig.atoi" (dict "a" (list ) ))) "r") "concat" (get (fromJson (include "sprig.concat" (dict "a" (list ) ))) "r") "default" (get (fromJson (include "sprig.default_" (dict "a" (list ) ))) "r") "empty" (get (fromJson (include "sprig.empty" (dict "a" (list ) ))) "r") "errTypes" (get (fromJson (include "sprig.errTypes" (dict "a" (list ) ))) "r") "first" (get (fromJson (include "sprig.first" (dict "a" (list ) ))) "r") "float" (get (fromJson (include "sprig.float" (dict "a" (list ) ))) "r") "keys" (get (fromJson (include "sprig.keys" (dict "a" (list ) ))) "r") "len" (get (fromJson (include "sprig.lenTest" (dict "a" (list ) ))) "r") "min" (get (fromJson (include "sprig.minFunc" (dict "a" (list ) ))) "r") "regex" (get (fromJson (include "sprig.regex" (dict "a" (list ) ))) "r") "strings" (get (fromJson (include "sprig.stringsFunctions" (dict "a" (list ) ))) "r") "toString" (get (fromJson (include "sprig.toString" (dict "a" (list ) ))) "r") "trim" (get (fromJson (include "sprig.trim" (dict "a" (list ) ))) "r") "unset" (get (fromJson (include "sprig.unset" (dict "a" (list ) ))) "r") "yaml" (get (fromJson (include "sprig.yaml" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "sprig.yaml" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (list (toYaml (coalesce nil)) (toYaml (dict "test" "test" )) (toYaml (dict )) (toYaml (list "test" "test2")))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -249,6 +249,7 @@ func NewHelmRunner(chartName, chartDir string, cfg *kube.RESTConfig, logf func(s
 	funcs := sprig.FuncMap()
 	funcs["include"] = runner.includeFn
 	funcs["lookup"] = runner.lookupFn
+	funcs["toYaml"] = helmette.ToYaml
 
 	runner.tpl = runner.tpl.Funcs(funcs)
 


### PR DESCRIPTION
The `toYaml` function is not part of the sprig library, but helm provides it. The `toYaml` is required for Redpanda configuration conversion to go.

Referance

https://github.com/redpanda-data/helm-charts/blob/9d0f4fcf9929c8c8574d8cd5137da1bd7b7e94e3/charts/redpanda/templates/_configmap.tpl#L69 https://github.com/redpanda-data/helm-charts/blob/9d0f4fcf9929c8c8574d8cd5137da1bd7b7e94e3/charts/redpanda/templates/_configmap.tpl#L79 https://github.com/redpanda-data/helm-charts/blob/9d0f4fcf9929c8c8574d8cd5137da1bd7b7e94e3/charts/redpanda/templates/_configmap.tpl#L157

helm function definition

https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L49-L68