### PR TITLE
Add namespace to templates for resources where it's missing

### DIFF
--- a/charts/console/templates/deployment.yaml
+++ b/charts/console/templates/deployment.yaml
@@ -19,6 +19,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "console.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "console.labels" . | nindent 4 }}
   {{- with .Values.annotations }}

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -19,6 +19,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "console.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels: {{- include "console.labels" . | nindent 4 }}
   {{- with .Values.service.annotations }}
   annotations: {{- toYaml . | nindent 4 }}

--- a/charts/console/templates/serviceaccount.yaml
+++ b/charts/console/templates/serviceaccount.yaml
@@ -20,6 +20,7 @@ kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "console.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "console.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/console/templates/tests/test-connection.yaml
+++ b/charts/console/templates/tests/test-connection.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ include "console.fullname" . }}-test-connection"
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "console.labels" . | nindent 4 }}
   annotations:

--- a/charts/redpanda/templates/rbac.yaml
+++ b/charts/redpanda/templates/rbac.yaml
@@ -170,6 +170,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "redpanda.fullname" . }}-sidecar-controllers
+  namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- with include "full.labels" . }}
   {{- . | nindent 4 }}
@@ -221,6 +222,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: {{ include "redpanda.fullname" . }}-sidecar-controllers
+  namespace: {{ .Release.Namespace | quote }}
   labels:
   {{- with include "full.labels" . }}
   {{- . | nindent 4 }}
@@ -233,6 +235,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ include "redpanda.fullname" . }}-sidecar-controllers
+  namespace: {{ .Release.Namespace | quote }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "redpanda.serviceAccountName" . }}

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -36,6 +36,7 @@ apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "redpanda.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
 {{- with include "full.labels" . }}
   {{- . | nindent 4 }}


### PR DESCRIPTION
I'm attempting to use the redpanda helm chart via kustomize, and I'm encountering the fact that some portions of redpanda's helm templates have an entry for `namespace: ` whereas others don't and rely on helm to install it based on `--namespace` implicitly. Unfortunately kustomize doesn't respect this behavior ([issue](https://github.com/kubernetes-sigs/kustomize/issues/5566)). My thinking is that if _some_ portions of redpanda's helm charts support templating it, that it'd be nice to have this behavior be more consistent.

I understand that helm also hasn't fully settled on its stance on this either ([issue](https://github.com/helm/helm/issues/5465)).

Apologies if this was suggested before. I looked around, but it's hard to search for.