### PR TITLE
Stop processing packages that reports errors

### DIFF
--- a/cmd/genpartial/main.go
+++ b/cmd/genpartial/main.go
@@ -66,19 +66,6 @@ func main() {
 	}
 }
 
-// PackageErrors returns any error reported by pkg during load or nil.
-func PackageErrors(pkg *packages.Package) error {
-	for _, err := range pkg.Errors {
-		return err
-	}
-
-	for _, err := range pkg.TypeErrors {
-		return err
-	}
-
-	return nil
-}
-
 func GeneratePartial(pkg *packages.Package, structName string, out io.Writer) error {
 	root := pkg.Types.Scope().Lookup(structName)
 

--- a/cmd/genpartial/main_test.go
+++ b/cmd/genpartial/main_test.go
@@ -74,8 +74,6 @@ func TestGenerateParital(t *testing.T) {
 	pkg := pkgs[1]
 	require.Equal(t, "main", pkg.Name)
 
-	require.NoError(t, PackageErrors(pkg))
-
 	require.EqualError(t, GeneratePartial(pkg, "Values", nil), `named struct not found in package "main": "Values"`)
 
 	var buf bytes.Buffer

--- a/pkg/gotohelm/rewrite_test.go
+++ b/pkg/gotohelm/rewrite_test.go
@@ -43,16 +43,6 @@ func TestLoadPackages(t *testing.T) {
 
 				testutil.AssertGolden(t, testutil.Text, filename, buf.Bytes())
 			}
-
-			// Assert that there are no error AFTER writing the updated goldens to
-			// disk so there's something to debug.
-			for _, err := range pkg.Errors {
-				require.NoError(t, err)
-			}
-
-			for _, err := range pkg.TypeErrors {
-				require.NoError(t, err)
-			}
 		})
 	}
 }

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -55,15 +55,6 @@ func Transpile(pkg *packages.Package) (_ *Chart, err error) {
 		}
 	}()
 
-	// Ensure there are no errors in the package before we transpile it.
-	for _, err := range pkg.TypeErrors {
-		return nil, err
-	}
-
-	for _, err := range pkg.Errors {
-		return nil, err
-	}
-
 	t := &Transpiler{
 		Package:   pkg,
 		Fset:      pkg.Fset,

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -130,13 +130,6 @@ func TestTranspile(t *testing.T) {
 	}, "./...")
 	require.NoError(t, err)
 
-	// Ensure there are no compile errors before proceeding.
-	for _, pkg := range pkgs {
-		for _, err := range pkg.Errors {
-			require.NoErrorf(t, err, "failed to compile %q", pkg.Name)
-		}
-	}
-
 	// Create and populate the test environment.
 	ctl := kubetest.NewEnv(t)
 	for _, obj := range seedObjects {


### PR DESCRIPTION
Error from go `packages.Load` function returns an error when patterns was invalid as defined by the underlying build system. Errors associated with a particular package are recorded in the corresponding Package's Errors list.

Error happens during `go test` execution with outdated `go.sum` file:

```
=== RUN   TestLoadPackages
--- FAIL: TestLoadPackages (0.59s)
panic: pkg errors (/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/testdata/src/example/astrewrites/astrewrites.go:4:9: could not import k8s.io/api/core/v1 (invalid package name: "")): 1:9: expected 'EOF', found 'type' [recovered]
	panic: pkg errors (/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/testdata/src/example/astrewrites/astrewrites.go:4:9: could not import k8s.io/api/core/v1 (invalid package name: "")): 1:9: expected 'EOF', found 'type' [recovered]
	panic: pkg errors (/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/testdata/src/example/astrewrites/astrewrites.go:4:9: could not import k8s.io/api/core/v1 (invalid package name: "")): 1:9: expected 'EOF', found 'type'

goroutine 1278 [running]:
testing.tRunner.func1.2({0x106431100, 0x1401c250f90})
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1631 +0x1c4
testing.tRunner.func1()
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1634 +0x33c
panic({0x106431100?, 0x1401c250f90?})
	/opt/homebrew/opt/go/libexec/src/runtime/panic.go:770 +0x124
golang.org/x/tools/go/ast/astutil.Apply.func1()
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:46 +0xb8
panic({0x106431100?, 0x1401c250f90?})
	/opt/homebrew/opt/go/libexec/src/runtime/panic.go:770 +0x124
github.com/redpanda-data/helm-charts/pkg/gotohelm.typeToNode(0x1400079b800, {0x1066c8d78, 0x10733ef40})
	/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/rewrite.go:110 +0x114
github.com/redpanda-data/helm-charts/pkg/gotohelm.rewriteMultiValueSyntaxToHelpers.func2(0x1401c267330)
	/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/rewrite.go:271 +0x208
golang.org/x/tools/go/ast/astutil.(*application).apply(0x1401c267320, {0x1066c9048?, 0x140066a5680?}, {0x1060d29b4?, 0x0?}, 0x0?, {0x1066c90c0?, 0x14006470ed0?})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:197 +0x160
golang.org/x/tools/go/ast/astutil.(*application).applyList(0x1401c267320, {0x1066c9048, 0x140066a5680}, {0x1060d29b4, 0x3})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:482 +0x78
golang.org/x/tools/go/ast/astutil.(*application).apply(0x1401c267320, {0x1066c9688?, 0x14006470f00?}, {0x1060d3088?, 0x0?}, 0x0?, {0x1066c9048?, 0x140066a5680?})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:336 +0x890
golang.org/x/tools/go/ast/astutil.(*application).applyList(0x1401c267320, {0x1066c9688, 0x14006470f00}, {0x1060d3088, 0x4})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:482 +0x78
golang.org/x/tools/go/ast/astutil.(*application).apply(0x1401c267320, {0x1066c9688?, 0x14006470f30?}, {0x1060d3088?, 0x18?}, 0x1401c22b400?, {0x1066c9688?, 0x14006470f00?})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:351 +0x91c
golang.org/x/tools/go/ast/astutil.(*application).applyList(0x1401c267320, {0x1066c9688, 0x14006470f30}, {0x1060d3088, 0x4})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:482 +0x78
golang.org/x/tools/go/ast/astutil.(*application).apply(0x1401c267320, {0x1066c8f58?, 0x14006470f60?}, {0x1060d3014?, 0x14000f678c8?}, 0x105046030?, {0x1066c9688?, 0x14006470f30?})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:351 +0x91c
golang.org/x/tools/go/ast/astutil.(*application).apply(0x1401c267320, {0x1066c8e68?, 0x14000963ae0?}, {0x1060d3c3e?, 0x14000963ae0?}, 0x1060d3c3e?, {0x1066c8f58?, 0x14006470f60?})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:427 +0x10cc
golang.org/x/tools/go/ast/astutil.(*application).applyList(0x1401c267320, {0x1066c8e68, 0x14000963ae0}, {0x1060d3c3e, 0x5})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:482 +0x78
golang.org/x/tools/go/ast/astutil.(*application).apply(0x1401c267320, {0x1066c9c50?, 0x1401c250ea0?}, {0x1060d3084?, 0x18?}, 0x14000268008?, {0x1066c8e68?, 0x14000963ae0?})
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:433 +0x46c
golang.org/x/tools/go/ast/astutil.Apply({0x1066c8e68, 0x14000963ae0}, 0x1401c270330, 0x0)
	/Users/rafalkorepta/go/pkg/mod/golang.org/x/tools@v0.17.0/go/ast/astutil/rewrite.go:51 +0x10c
github.com/redpanda-data/helm-charts/pkg/gotohelm.rewriteMultiValueSyntaxToHelpers(0x1400079b800, 0x14000963ae0)
	/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/rewrite.go:247 +0xf0
github.com/redpanda-data/helm-charts/pkg/gotohelm.LoadPackages(0x14000df7e90, {0x14001fcf930, 0x1, 0x1})
	/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/rewrite.go:60 +0x29c
github.com/redpanda-data/helm-charts/pkg/gotohelm.TestLoadPackages(0x14001996680)
	/Users/rafalkorepta/workspace/redpanda/helm-charts/pkg/gotohelm/rewrite_test.go:19 +0x1d8
testing.tRunner(0x14001996680, 0x1066bbef0)
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1689 +0xec
created by testing.(*T).Run in goroutine 1
	/opt/homebrew/opt/go/libexec/src/testing/testing.go:1742 +0x318

Process finished with the exit code 1
```