### PR TITLE
redpanda: allow cert-manager integration to be (mostly) disabled

### DIFF
--- a/charts/redpanda/certs.go
+++ b/charts/redpanda/certs.go
@@ -26,7 +26,7 @@ func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
 
 	certs := []certmanagerv1.Certificate{}
 	for name, data := range values.TLS.Certs {
-		if !helmette.Empty(data.SecretRef) {
+		if !helmette.Empty(data.SecretRef) || !ptr.Deref(data.Enabled, true) {
 			continue
 		}
 
@@ -85,7 +85,11 @@ func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
 	name := values.Listeners.Kafka.TLS.Cert
 
 	data, ok := values.TLS.Certs[name]
-	if !ok || (helmette.Empty(data.SecretRef) && !ClientAuthRequired(dot)) {
+	if !ok {
+		panic(fmt.Sprintf("Certificate %q referenced but not defined", name))
+	}
+
+	if helmette.Empty(data.SecretRef) || !ClientAuthRequired(dot) {
 		return certs
 	}
 

--- a/charts/redpanda/chart_template_test.go
+++ b/charts/redpanda/chart_template_test.go
@@ -1,0 +1,314 @@
+package redpanda_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"testing"
+
+	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/helm-charts/pkg/helm"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	"github.com/redpanda-data/helm-charts/pkg/testutil"
+	"github.com/redpanda-data/helm-charts/pkg/valuesutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/yaml"
+)
+
+type TemplateTestCase struct {
+	Name       string
+	Values     any
+	ValuesFile string
+	Assert     func(*testing.T, []byte, error)
+}
+
+func TestTemplate(t *testing.T) {
+	ctx := testutil.Context(t)
+	client, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
+	require.NoError(t, err)
+
+	// Chart deps are kept within ./charts as a tgz archive, which is git
+	// ignored. Helm dep build will ensure that ./charts is in sync with
+	// Chart.lock, which is tracked by git.
+	require.NoError(t, client.RepoAdd(ctx, "redpanda", "https://charts.redpanda.com"))
+	require.NoError(t, client.DependencyBuild(ctx, "."), "failed to refresh helm dependencies")
+
+	cases := CIGoldenTestCases(t)
+	cases = append(cases, VersionGoldenTestsCases(t)...)
+	cases = append(cases, DisableCertmanagerIntegration(t)...)
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.Name, func(t *testing.T) {
+			t.Parallel()
+
+			out, err := client.Template(ctx, ".", helm.TemplateOptions{
+				Name:       "redpanda",
+				Values:     tc.Values,
+				ValuesFile: tc.ValuesFile,
+				Set: []string{
+					// Tests utilize some non-deterministic helpers (rng). We don't
+					// really care about the stability of their output, so globally
+					// disable them.
+					"tests.enabled=false",
+					// jwtSecret defaults to a random string. Can't have that
+					// in snapshot testing so set it to a static value.
+					"console.secret.login.jwtSecret=SECRETKEY",
+				},
+			})
+
+			tc.Assert(t, out, err)
+
+			// kube-lint template file
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			inputYaml := bytes.NewBuffer(out)
+
+			cmd := exec.CommandContext(ctx, "kube-linter", "lint", "-", "--format", "json")
+			cmd.Stdin = inputYaml
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			errKubeLinter := cmd.Run()
+			if errKubeLinter != nil && len(stderr.String()) > 0 {
+				t.Logf("kube-linter error(s) found for %q: \n%s\nstderr:\n%s", tc.Name, stdout.String(), stderr.String())
+			} else if errKubeLinter != nil {
+				t.Logf("kube-linter error(s) found for %q: \n%s", tc.Name, errKubeLinter)
+			}
+			// TODO: remove comment below and the logging above once we agree to linter
+			// require.NoError(t, errKubeLinter)
+		})
+	}
+}
+
+func CIGoldenTestCases(t *testing.T) []TemplateTestCase {
+	values, err := os.ReadDir("./ci")
+	require.NoError(t, err)
+
+	cases := make([]TemplateTestCase, len(values))
+	for i, f := range values {
+		name := f.Name()
+		cases[i] = TemplateTestCase{
+			Name:       name,
+			ValuesFile: "./ci/" + name,
+			Assert: func(t *testing.T, b []byte, err error) {
+				require.NoError(t, err)
+				testutil.AssertGolden(t, testutil.YAML, path.Join("testdata", "ci", name+".golden"), b)
+			},
+		}
+	}
+	return cases
+}
+
+func VersionGoldenTestsCases(t *testing.T) []TemplateTestCase {
+	// A collection of versions that should trigger all the gates guarded by
+	// "redpanda-atleast-*" helpers.
+	versions := []struct {
+		Image  redpanda.PartialImage
+		ErrMsg *string
+	}{
+		{
+			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.1.0"))},
+			ErrMsg: ptr.To("no longer supported"),
+		},
+		{
+			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.2.0"))},
+			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
+		},
+		{
+			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.3.0"))},
+			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
+		},
+		{
+			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.3.14"))},
+		},
+		{
+			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.4.0"))},
+			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
+		},
+		{
+			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.1.1"))},
+			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
+		},
+		{
+			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.1.2"))},
+		},
+		{
+			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.1.3"))},
+		},
+		{
+			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.2.1"))},
+		},
+		{
+			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.3.0"))},
+		},
+		{
+			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v24.1.0"))},
+		},
+		{
+			Image: redpanda.PartialImage{Repository: ptr.To("somecustomrepo"), Tag: ptr.To(redpanda.ImageTag("v24.1.0"))},
+		},
+	}
+
+	// A collection of features that are protected by the various above version
+	// gates.
+	permutations := []redpanda.PartialValues{
+		{
+			Config: &redpanda.PartialConfig{
+				Tunable: &redpanda.PartialTunableConfig{
+					"log_segment_size_min":  100,
+					"log_segment_size_max":  99999,
+					"kafka_batch_max_bytes": 7777,
+				},
+			},
+		},
+		{
+			Enterprise: &redpanda.PartialEnterprise{License: ptr.To("ATOTALLYVALIDLICENSE")},
+		},
+		{
+			RackAwareness: &redpanda.PartialRackAwareness{
+				Enabled:        ptr.To(true),
+				NodeAnnotation: ptr.To("topology-label"),
+			},
+		},
+	}
+
+	var cases []TemplateTestCase
+	for _, version := range versions {
+		version := version
+		for i, perm := range permutations {
+			values, err := valuesutil.UnmarshalInto[redpanda.PartialValues](perm)
+			require.NoError(t, err)
+
+			values.Image = &version.Image
+
+			name := fmt.Sprintf("%s-%s-%d", ptr.Deref(version.Image.Repository, "default"), *version.Image.Tag, i)
+
+			cases = append(cases, TemplateTestCase{
+				Name:   name,
+				Values: values,
+				Assert: func(t *testing.T, b []byte, err error) {
+					if version.ErrMsg != nil {
+						require.Error(t, err, "expected an error containing %q", *version.ErrMsg)
+						require.Contains(t, err.Error(), *version.ErrMsg, "expected an error containing %q", *version.ErrMsg)
+						return
+					}
+					require.NoError(t, err)
+					testutil.AssertGolden(t, testutil.YAML, path.Join("testdata", "versions", name+".yaml.golden"), b)
+				},
+			})
+		}
+	}
+	return cases
+}
+
+func DisableCertmanagerIntegration(t *testing.T) []TemplateTestCase {
+	assertNoCerts := func(t *testing.T, b []byte, err error) {
+		require.NoError(t, err)
+
+		// Assert that no Certificate objects are in the resultant
+		// objects when SecretRef is specified AND RequireClientAuth is
+		// false.
+		objs, err := kube.DecodeYAML(b, redpanda.Scheme)
+		require.NoError(t, err)
+
+		for _, obj := range objs {
+			_, ok := obj.(*certmanagerv1.Certificate)
+			// The -root-certificate is always created right now, ignore that
+			// one.
+			if ok && strings.HasSuffix(obj.GetName(), "-root-certificate") {
+				continue
+			}
+			require.Falsef(t, ok, "Found unexpected Certificate %q", obj.GetName())
+		}
+
+		require.NotContains(t, b, []byte(certmanagerv1.CertificateKind))
+	}
+
+	return []TemplateTestCase{
+		{
+			Name: "disable-cert-manager-overriding-defaults",
+			Values: valuesFromYAML(t, `
+tls:
+  certs:
+    default:
+      secretRef:
+        name: some-secret
+    external:
+      secretRef:
+        name: some-other-secret
+`),
+			Assert: assertNoCerts,
+		},
+		{
+			Name: "disable-cert-manager-fully-specified",
+			Values: valuesFromYAML(t, `
+listeners:
+  http:
+    external:
+      default:
+        tls:
+          cert: for-external
+          requireClientAuth: false
+    tls:
+      cert: for-internal
+  kafka:
+    external:
+      default:
+        tls:
+          cert: for-external
+          requireClientAuth: false
+    tls:
+      cert: for-internal
+  rpc:
+    tls:
+      cert: for-internal
+  schemaRegistry:
+    external:
+      default:
+        tls:
+          cert: for-external
+          requireClientAuth: false
+    tls:
+      cert: for-internal
+tls:
+  certs:
+    default:
+      enabled: false
+    external:
+      enabled: false
+    for-external:
+      secretRef:
+        name: some-other-secret
+    for-internal:
+      secretRef:
+        name: some-secret
+`),
+			Assert: assertNoCerts,
+		},
+	}
+}
+
+func valuesFromYAML(t *testing.T, values string) redpanda.PartialValues {
+	// Trim newlines to help with later comparison and avoid any weirdness with
+	// loading as it's likely to be written with `` strings.
+	values = strings.Trim(values, "\n")
+
+	var partialValues redpanda.PartialValues
+	require.NoError(t, yaml.Unmarshal([]byte(values), &partialValues))
+
+	out, err := yaml.Marshal(partialValues)
+	require.NoError(t, err)
+
+	// To preserve the sanity of debuggers, require that the value round trips
+	// back to the same string. This should catch any typos or miss-indentations
+	// that are valid YAML but invalid values.
+	require.Equal(t, string(out), values+"\n", "Provided values do NOT round trip. Check for typos and ensure your keys are alphabetized. Re-marshaled values:\n%s\n", out)
+
+	return partialValues
+}

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -1,12 +1,8 @@
 package redpanda_test
 
 import (
-	"bytes"
-	"fmt"
 	"maps"
 	"os"
-	"os/exec"
-	"path"
 	"testing"
 
 	"github.com/redpanda-data/helm-charts/charts/redpanda"
@@ -20,7 +16,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 )
 
 func TieredStorageStatic(t *testing.T) redpanda.PartialValues {
@@ -95,192 +90,6 @@ func TieredStorageSecretRefs(t *testing.T, secret *corev1.Secret) redpanda.Parti
 				},
 			},
 		},
-	}
-}
-
-type TemplateTestCase struct {
-	Name       string
-	Values     any
-	ValuesFile string
-	Assert     func(*testing.T, []byte, error)
-}
-
-func CITestCases(t *testing.T) []TemplateTestCase {
-	values, err := os.ReadDir("./ci")
-	require.NoError(t, err)
-
-	cases := make([]TemplateTestCase, len(values))
-	for i, f := range values {
-		name := f.Name()
-		cases[i] = TemplateTestCase{
-			Name:       name,
-			ValuesFile: "./ci/" + name,
-			Assert: func(t *testing.T, b []byte, err error) {
-				require.NoError(t, err)
-				testutil.AssertGolden(t, testutil.YAML, path.Join("testdata", "ci", name+".golden"), b)
-			},
-		}
-	}
-	return cases
-}
-
-func VersionTestsCases(t *testing.T) []TemplateTestCase {
-	// A collection of versions that should trigger all the gates guarded by
-	// "redpanda-atleast-*" helpers.
-	versions := []struct {
-		Image  redpanda.PartialImage
-		ErrMsg *string
-	}{
-		{
-			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.1.0"))},
-			ErrMsg: ptr.To("no longer supported"),
-		},
-		{
-			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.2.0"))},
-			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
-		},
-		{
-			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.3.0"))},
-			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
-		},
-		{
-			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.3.14"))},
-		},
-		{
-			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v22.4.0"))},
-			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
-		},
-		{
-			Image:  redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.1.1"))},
-			ErrMsg: ptr.To("does not support TLS on the RPC port. Please upgrade. See technical service bulletin 2023-01."),
-		},
-		{
-			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.1.2"))},
-		},
-		{
-			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.1.3"))},
-		},
-		{
-			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.2.1"))},
-		},
-		{
-			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v23.3.0"))},
-		},
-		{
-			Image: redpanda.PartialImage{Tag: ptr.To(redpanda.ImageTag("v24.1.0"))},
-		},
-		{
-			Image: redpanda.PartialImage{Repository: ptr.To("somecustomrepo"), Tag: ptr.To(redpanda.ImageTag("v24.1.0"))},
-		},
-	}
-
-	// A collection of features that are protected by the various above version
-	// gates.
-	permutations := []redpanda.PartialValues{
-		{
-			Config: &redpanda.PartialConfig{
-				Tunable: &redpanda.PartialTunableConfig{
-					"log_segment_size_min":  100,
-					"log_segment_size_max":  99999,
-					"kafka_batch_max_bytes": 7777,
-				},
-			},
-		},
-		{
-			Enterprise: &redpanda.PartialEnterprise{License: ptr.To("ATOTALLYVALIDLICENSE")},
-		},
-		{
-			RackAwareness: &redpanda.PartialRackAwareness{
-				Enabled:        ptr.To(true),
-				NodeAnnotation: ptr.To("topology-label"),
-			},
-		},
-	}
-
-	var cases []TemplateTestCase
-	for _, version := range versions {
-		version := version
-		for i, perm := range permutations {
-			values, err := valuesutil.UnmarshalInto[redpanda.PartialValues](perm)
-			require.NoError(t, err)
-
-			values.Image = &version.Image
-
-			name := fmt.Sprintf("%s-%s-%d", ptr.Deref(version.Image.Repository, "default"), *version.Image.Tag, i)
-
-			cases = append(cases, TemplateTestCase{
-				Name:   name,
-				Values: values,
-				Assert: func(t *testing.T, b []byte, err error) {
-					if version.ErrMsg != nil {
-						require.Error(t, err, "expected an error containing %q", *version.ErrMsg)
-						require.Contains(t, err.Error(), *version.ErrMsg, "expected an error containing %q", *version.ErrMsg)
-						return
-					}
-					require.NoError(t, err)
-					testutil.AssertGolden(t, testutil.YAML, path.Join("testdata", "versions", name+".yaml.golden"), b)
-				},
-			})
-		}
-	}
-	return cases
-}
-
-func TestTemplate(t *testing.T) {
-	ctx := testutil.Context(t)
-	client, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
-	require.NoError(t, err)
-
-	// Chart deps are kept within ./charts as a tgz archive, which is git
-	// ignored. Helm dep build will ensure that ./charts is in sync with
-	// Chart.lock, which is tracked by git.
-	require.NoError(t, client.RepoAdd(ctx, "redpanda", "https://charts.redpanda.com"))
-	require.NoError(t, client.DependencyBuild(ctx, "."), "failed to refresh helm dependencies")
-
-	cases := CITestCases(t)
-	cases = append(cases, VersionTestsCases(t)...)
-
-	for _, tc := range cases {
-		tc := tc
-		t.Run(tc.Name, func(t *testing.T) {
-			t.Parallel()
-
-			out, err := client.Template(ctx, ".", helm.TemplateOptions{
-				Name:       "redpanda",
-				Values:     tc.Values,
-				ValuesFile: tc.ValuesFile,
-				Set: []string{
-					// Tests utilize some non-deterministic helpers (rng). We don't
-					// really care about the stability of their output, so globally
-					// disable them.
-					"tests.enabled=false",
-					// jwtSecret defaults to a random string. Can't have that
-					// in snapshot testing so set it to a static value.
-					"console.secret.login.jwtSecret=SECRETKEY",
-				},
-			})
-
-			tc.Assert(t, out, err)
-
-			// kube-lint template file
-			var stdout bytes.Buffer
-			var stderr bytes.Buffer
-			inputYaml := bytes.NewBuffer(out)
-
-			cmd := exec.CommandContext(ctx, "kube-linter", "lint", "-", "--format", "json")
-			cmd.Stdin = inputYaml
-			cmd.Stdout = &stdout
-			cmd.Stderr = &stderr
-
-			errKubeLinter := cmd.Run()
-			if errKubeLinter != nil && len(stderr.String()) > 0 {
-				t.Logf("kube-linter error(s) found for %q: \n%s\nstderr:\n%s", tc.Name, stdout.String(), stderr.String())
-			} else if errKubeLinter != nil {
-				t.Logf("kube-linter error(s) found for %q: \n%s", tc.Name, errKubeLinter)
-			}
-			// TODO: remove comment below and the logging above once we agree to linter
-			// require.NoError(t, errKubeLinter)
-		})
 	}
 }
 

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -587,6 +587,20 @@
                     },
                     "prefixTemplate": {
                       "type": "string"
+                    },
+                    "tls": {
+                      "properties": {
+                        "cert": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "requireClientAuth": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -2281,6 +2295,9 @@
                 "duration": {
                   "pattern": ".*[smh]$",
                   "type": "string"
+                },
+                "enabled": {
+                  "type": "boolean"
                 },
                 "issuerRef": {
                   "properties": {

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -338,7 +338,7 @@ type PartialListeners struct {
 	SchemaRegistry *PartialSchemaRegistryListeners `json:"schemaRegistry,omitempty" jsonschema:"required"`
 	RPC            struct {
 		Port *int                `json:"port,omitempty" jsonschema:"required"`
-		TLS  *PartialExternalTLS `json:"tls,omitempty" jsonschema:"required"`
+		TLS  *PartialInternalTLS `json:"tls,omitempty" jsonschema:"required"`
 	} `json:"rpc,omitempty" jsonschema:"required"`
 }
 
@@ -389,13 +389,16 @@ type PartialPandaProxyClient struct {
 }
 
 type PartialTLSCert struct {
-	CAEnabled             *bool                   `json:"caEnabled,omitempty" jsonschema:"required"`
-	ApplyInternalDNSNames *bool                   `json:"applyInternalDNSNames,omitempty"`
-	Duration              *string                 `json:"duration,omitempty" jsonschema:"pattern=.*[smh]$"`
-	IssuerRef             *cmmeta.ObjectReference `json:"issuerRef,omitempty"`
-	SecretRef             *struct {
-		Name *string `json:"name,omitempty"`
-	} `json:"secretRef,omitempty"`
+	Enabled               *bool                     `json:"enabled,omitempty"`
+	CAEnabled             *bool                     `json:"caEnabled,omitempty" jsonschema:"required"`
+	ApplyInternalDNSNames *bool                     `json:"applyInternalDNSNames,omitempty"`
+	Duration              *string                   `json:"duration,omitempty" jsonschema:"pattern=.*[smh]$"`
+	IssuerRef             *cmmeta.ObjectReference   `json:"issuerRef,omitempty"`
+	SecretRef             *PartialNameOnlySecretRef `json:"secretRef,omitempty"`
+}
+
+type PartialNameOnlySecretRef struct {
+	Name *string `json:"name,omitempty"`
 }
 
 type PartialTLSCertMap map[string]PartialTLSCert
@@ -413,16 +416,22 @@ type PartialSASLAuth struct {
 	Users     []PartialSASLUser `json:"users,omitempty"`
 }
 
-type PartialExternalTLS struct {
+type PartialInternalTLS struct {
 	Cert              *string `json:"cert,omitempty" jsonschema:"required"`
 	Enabled           *bool   `json:"enabled,omitempty"`
 	RequireClientAuth *bool   `json:"requireClientAuth,omitempty" jsonschema:"required"`
 }
 
+type PartialExternalTLS struct {
+	Cert              *string `json:"cert,omitempty"`
+	Enabled           *bool   `json:"enabled,omitempty"`
+	RequireClientAuth *bool   `json:"requireClientAuth,omitempty"`
+}
+
 type PartialAdminListeners struct {
 	External PartialExternalListeners[PartialAdminExternal] `json:"external,omitempty"`
 	Port     *int                                           `json:"port,omitempty" jsonschema:"required"`
-	TLS      *PartialExternalTLS                            `json:"tls,omitempty" jsonschema:"required"`
+	TLS      *PartialInternalTLS                            `json:"tls,omitempty" jsonschema:"required"`
 }
 
 type PartialAdminExternal struct {
@@ -435,7 +444,7 @@ type PartialHTTPListeners struct {
 	Enabled              *bool                                         `json:"enabled,omitempty" jsonschema:"required"`
 	External             PartialExternalListeners[PartialHTTPExternal] `json:"external,omitempty"`
 	AuthenticationMethod *HTTPAuthenticationMethod                     `json:"authenticationMethod,omitempty"`
-	TLS                  *PartialExternalTLS                           `json:"tls,omitempty" jsonschema:"required"`
+	TLS                  *PartialInternalTLS                           `json:"tls,omitempty" jsonschema:"required"`
 	KafkaEndpoint        *string                                       `json:"kafkaEndpoint,omitempty" jsonschema:"required,pattern=^[A-Za-z_-][A-Za-z0-9_-]*$"`
 	Port                 *int                                          `json:"port,omitempty" jsonschema:"required"`
 }
@@ -452,7 +461,7 @@ type PartialHTTPExternal struct {
 type PartialKafkaListeners struct {
 	AuthenticationMethod *KafkaAuthenticationMethod                     `json:"authenticationMethod,omitempty"`
 	External             PartialExternalListeners[PartialKafkaExternal] `json:"external,omitempty"`
-	TLS                  *PartialExternalTLS                            `json:"tls,omitempty" jsonschema:"required"`
+	TLS                  *PartialInternalTLS                            `json:"tls,omitempty" jsonschema:"required"`
 	Port                 *int                                           `json:"port,omitempty" jsonschema:"required"`
 }
 
@@ -462,6 +471,7 @@ type PartialKafkaExternal struct {
 	Port                 *int32                     `json:"port,omitempty" jsonschema:"required"`
 	AuthenticationMethod *KafkaAuthenticationMethod `json:"authenticationMethod,omitempty"`
 	PrefixTemplate       *string                    `json:"prefixTemplate,omitempty"`
+	TLS                  *PartialExternalTLS        `json:"tls,omitempty"`
 }
 
 type PartialSchemaRegistryListeners struct {
@@ -470,7 +480,7 @@ type PartialSchemaRegistryListeners struct {
 	AuthenticationMethod *HTTPAuthenticationMethod                               `json:"authenticationMethod,omitempty"`
 	KafkaEndpoint        *string                                                 `json:"kafkaEndpoint,omitempty" jsonschema:"required,pattern=^[A-Za-z_-][A-Za-z0-9_-]*$"`
 	Port                 *int                                                    `json:"port,omitempty" jsonschema:"required"`
-	TLS                  *PartialExternalTLS                                     `json:"tls,omitempty" jsonschema:"required"`
+	TLS                  *PartialInternalTLS                                     `json:"tls,omitempty" jsonschema:"required"`
 }
 
 type PartialSchemaRegistryExternal struct {


### PR DESCRIPTION
Prior to this commit, the redpanda helm chart would almost always generate `Certificates`, even if they we're not being used. This can be frustrating for users that are not using cert-manager or want to manage the integration themselves.

This commit makes it easier to disable most of the certificates that the chart generates by fixing a mistranslated boolean check, respecting the `enabled` field on elements of `tls.certs`, and providing a few example test cases.