### PR TITLE
Further indent podAntiAffinity matchLabels for soft anti-affinity

### DIFF
--- a/charts/redpanda/templates/_statefulset.tpl
+++ b/charts/redpanda/templates/_statefulset.tpl
@@ -91,7 +91,7 @@ podAntiAffinity:
     podAffinityTerm:
       topologyKey: {{ .Values.statefulset.podAntiAffinity.topologyKey }}
       labelSelector:
-        matchLabels: {{ include "statefulset-pod-labels-selector" . | nindent 8 }}
+        matchLabels: {{ include "statefulset-pod-labels-selector" . | nindent 10 }}
   {{- else if eq .Values.statefulset.podAntiAffinity.type "custom" -}}
     {{- toYaml .Values.statefulset.podAntiAffinity.custom | nindent 2 }}
   {{- end -}}


### PR DESCRIPTION
Currently, it ends up on the same depth as `matchLabels:` in my testing running `helm template`:

```
        podAntiAffinity:
          preferredDuringSchedulingIgnoredDuringExecution:
          - weight: 100
            podAffinityTerm:
              topologyKey: kubernetes.io/hostname
              labelSelector:
                matchLabels:
                app.kubernetes.io/component: redpanda-statefulset
                app.kubernetes.io/instance: redpanda
                app.kubernetes.io/name: redpanda
```

Which kubernetes seems to accept and interpret correctly, but when I run this yaml through any post-processing (eg `yq`) it "fixes" `matchLabels:` not having a value and sets it to `null`, causing the labels to be interpreted as keys under `labelSelector` instead, which kubernetes rejects as not matching the sts spec.