### PR TITLE
Handle instance methods with pointer receiver

### DIFF
--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -54,10 +54,32 @@ func Syntax() map[string]any {
 	_, _ = x.(map[string]any)
 
 	return map[string]any{
-		"sliceExpr": slice,
+		"sliceExpr":       slice,
 		"negativeNumbers": []int{-2, -4},
-		"forExpr":   forExpr(10),
-		"binaryExprs": binaryExprs(),
+		"forExpr":         forExpr(10),
+		"binaryExprs":     binaryExprs(),
+		"instance-method": instanceMethod(),
+	}
+}
+
+type TestStruct struct {
+	TestBoolean bool
+}
+
+func (ts *TestStruct) InstanceMethod() bool {
+	return ts.TestBoolean
+}
+
+func instanceMethod() any {
+	t := TestStruct{
+		TestBoolean: true,
+	}
+	f := TestStruct{
+		TestBoolean: false,
+	}
+	return []bool{
+		t.InstanceMethod(),
+		f.InstanceMethod(),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -61,6 +61,28 @@ func Syntax() map[string]any {
 		"negativeNumbers": []int{-2, -4},
 		"forExpr":         forExpr(10),
 		"binaryExprs":     binaryExprs(),
+		"instance-method": instanceMethod(),
+	}
+}
+
+type TestStruct struct {
+	TestBoolean bool
+}
+
+func (ts *TestStruct) InstanceMethod() bool {
+	return ts.TestBoolean
+}
+
+func instanceMethod() any {
+	t := TestStruct{
+		TestBoolean: true,
+	}
+	f := TestStruct{
+		TestBoolean: false,
+	}
+	return []bool{
+		t.InstanceMethod(),
+		f.InstanceMethod(),
 	}
 }
 

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -23,7 +23,24 @@
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "string") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list (10 | int)) ))) "r") "binaryExprs" (get (fromJson (include "syntax.binaryExprs" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list (10 | int)) ))) "r") "binaryExprs" (get (fromJson (include "syntax.binaryExprs" (dict "a" (list ) ))) "r") "instance-method" (get (fromJson (include "syntax.instanceMethod" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "syntax.TestStruct.InstanceMethod" -}}
+{{- $ts := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" $ts.TestBoolean) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "syntax.instanceMethod" -}}
+{{- range $_ := (list 1) -}}
+{{- $t := (mustMergeOverwrite (dict "TestBoolean" false ) (dict "TestBoolean" true )) -}}
+{{- $f := (mustMergeOverwrite (dict "TestBoolean" false ) (dict "TestBoolean" false )) -}}
+{{- (dict "r" (list (get (fromJson (include "syntax.TestStruct.InstanceMethod" (dict "a" (list $t) ))) "r") (get (fromJson (include "syntax.TestStruct.InstanceMethod" (dict "a" (list $f) ))) "r"))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Instance methods are transpiled into templates that receives as a first argument the instance of the struct. Any function call that have pointer receiver would be translated to template `include` statement with one argument which is struct itself.

There is special case for Values.AsMap method as it is not defined as seperated template, but rather it is build in feature of the helm engine.

In future improvements instance methods transpilation could support arguments.

Fixes #1329 