### PR TITLE
Improve Unsupported error reporting

### DIFF
--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -35,9 +35,11 @@ func (u *Unsupported) Error() string {
 	var b bytes.Buffer
 	fmt.Fprintf(&b, "unsupported ast.Node: %T\n", u.Node)
 	fmt.Fprintf(&b, "%s\n", u.Msg)
+	fmt.Fprintf(&b, "%s\n\t", u.Fset.PositionFor(u.Node.Pos(), false).String())
 	if err := format.Node(&b, u.Fset, u.Node); err != nil {
 		panic(err) // Oh the irony
 	}
+
 	return b.String()
 }
 


### PR DESCRIPTION
Previously the node reference might point to the rewritten code. That might be hard to find the file where the error comes from. This commit introduces a file path, line number and offset.

Previous:
```
Failed to transpile "redpanda": unsupported ast.Node: *ast.CallExpr
type checks on numeric types are unreliable due to JSON casting all numbers to float64's. Instead use `helmette.IsNumeric` or `helmette.AsIntegral
helmette.TypeTest[float64](v)
```

New:
```
Failed to transpile "redpanda": unsupported ast.Node: *ast.CallExpr
type checks on numeric types are unreliable due to JSON casting all numbers to float64's. Instead use `helmette.IsNumeric` or `helmette.AsIntegral`
/Users/rafalkorepta/workspace/redpanda/helm-charts/charts/redpanda/values.go:864:37
        helmette.TypeTest[float64](v)
```

Fixes #1346 