### PR TITLE
redpanda: partially migrate STS volumes/mounts

### DIFF
--- a/charts/redpanda/templates/_statefulset.go.tpl
+++ b/charts/redpanda/templates/_statefulset.go.tpl
@@ -77,3 +77,24 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "redpanda.StatefulSetVolumes" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $volumes := (get (fromJson (include "redpanda.CommonVolumes" (dict "a" (list $dot) ))) "r") -}}
+{{- $fullname := (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") -}}
+{{- $volumes = (concat $volumes (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.50s-sts-lifecycle" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" "lifecycle-scripts" )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "configMap" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" $fullname )) (dict )) )) (dict "name" $fullname )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "emptyDir" (mustMergeOverwrite (dict ) (dict )) )) (dict "name" "config" )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.51s-configurator" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%.51s-configurator" $fullname) )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%s-config-watcher" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%s-config-watcher" $fullname) )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.49s-fs-validator" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%.49s-fs-validator" $fullname) )))) -}}
+{{- (dict "r" $volumes) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.StatefulSetVolumeMounts" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $mounts := (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r") -}}
+{{- $mounts = (concat $mounts (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "config" "mountPath" "/etc/redpanda" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") "mountPath" "/tmp/base-config" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "lifecycle-scripts" "mountPath" "/var/lifecycle" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "datadir" "mountPath" "/var/lib/redpanda/data" )))) -}}
+{{- (dict "r" $mounts) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -261,18 +261,10 @@ spec:
   {{- end }}
 {{- end }}
           securityContext: {{ include "container-security-context" . | nindent 12 }}
-          volumeMounts: {{ include "common-mounts" . | nindent 12 }}
+          volumeMounts: {{ (get ((include "redpanda.StatefulSetVolumeMounts" (dict "a" (list .))) | fromJson) "r") | toYaml | nindent 12 }}
 {{- if dig "extraVolumeMounts" false .Values.statefulset -}}
   {{ tpl .Values.statefulset.extraVolumeMounts . | nindent 12 }}
 {{- end }}
-            - name: config
-              mountPath: /etc/redpanda
-            - name: {{ template "redpanda.fullname" . }}
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
 {{- if and (include "storage-tiered-config" .|fromJson).cloud_storage_enabled (ne (include "storage-tiered-mountType" .) "none") }}
             - name: {{ default "tiered-storage-dir" .Values.storage.persistentVolume.nameOverwrite }}
               mountPath: {{ include "tieredStorage.cacheDirectory" . }}
@@ -330,14 +322,10 @@ spec:
           securityContext: {{- toYaml .Values.statefulset.sideCars.controllers.securityContext | nindent 12 }}
           {{- end }}
       {{- end }}
-      volumes: {{ include "common-volumes" . | nindent 8 }}
+      volumes: {{ (get ((include "redpanda.StatefulSetVolumes" (dict "a" (list .))) | fromJson) "r") | toYaml | nindent 8 }}
       {{- if dig "extraVolumes" false .Values.statefulset -}}
         {{ tpl .Values.statefulset.extraVolumes . | nindent 8 }}
       {{- end }}
-        - name: lifecycle-scripts
-          secret:
-            secretName: {{ (include "redpanda.fullname" . | trunc 50 ) }}-sts-lifecycle
-            defaultMode: 0o775
         - name: datadir
       {{- if .Values.storage.persistentVolume.enabled }}
           persistentVolumeClaim:
@@ -361,23 +349,6 @@ spec:
           {{- end }}
         {{- end }}
       {{- end }}
-        - name: {{ template "redpanda.fullname" . }}
-          configMap:
-            name: {{ template "redpanda.fullname" . }}
-        - name: config
-          emptyDir: {}
-        - name: {{ (include "redpanda.fullname" .) | trunc 51 }}-configurator
-          secret:
-            secretName: {{ (include "redpanda.fullname" .) | trunc 51 }}-configurator
-            defaultMode: 0o775
-        - name: {{ template "redpanda.fullname" . }}-config-watcher
-          secret:
-            secretName: {{ template "redpanda.fullname" . }}-config-watcher
-            defaultMode: 0o775
-        - name: {{ (include "redpanda.fullname" .) | trunc 49 }}-fs-validator
-          secret:
-            secretName: {{ (include "redpanda.fullname" .) | trunc 49 }}-fs-validator
-            defaultMode: 0o775
 {{- if semverCompare ">=1.16-0" .Capabilities.KubeVersion.GitVersion }}
       topologySpreadConstraints:
     {{- range $v := .Values.statefulset.topologySpreadConstraints }}

--- a/charts/redpanda/testdata/ci/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/01-default-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -805,15 +805,14 @@ spec:
             runAsNonRoot: null
             runAsUser: 101
           volumeMounts: 
-            
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -832,31 +831,30 @@ spec:
             - name: redpanda-config-watcher
               mountPath: /etc/secrets/config-watcher/scripts
       volumes: 
-        
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -911,14 +911,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -950,28 +950,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -925,14 +925,14 @@ spec:
             - mountPath: /etc/secrets/users
               name: users
               readOnly: true
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -958,28 +958,28 @@ spec:
             secretName: redpanda-users
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -1056,14 +1056,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1101,28 +1101,28 @@ spec:
             secretName: redpanda-users
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
@@ -1057,14 +1057,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1096,28 +1096,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
@@ -1029,14 +1029,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1074,28 +1074,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
@@ -1067,16 +1067,16 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: test-extra-volume
               mountPath: /fake/lifecycle
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
           resources:
             limits:
               cpu: 1
@@ -1108,34 +1108,34 @@ spec:
           secret:
             defaultMode: 288
             secretName: redpanda-external-cert
+        - name: lifecycle-scripts
+          secret:
+            defaultMode: 509
+            secretName: redpanda-sts-lifecycle
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: test-extra-volume
           secret:
             secretName: redpanda-sts-lifecycle
             defaultMode: 0774
-        - name: lifecycle-scripts
-          secret:
-            secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
@@ -1088,14 +1088,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1133,28 +1133,28 @@ spec:
             secretName: some-users
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: external-tls-secret
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
@@ -1039,14 +1039,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1078,28 +1078,28 @@ spec:
             secretName: external-tls-secret
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
@@ -830,15 +830,14 @@ spec:
             runAsNonRoot: null
             runAsUser: 101
           volumeMounts: 
-            
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -857,31 +856,30 @@ spec:
             - name: redpanda-config-watcher
               mountPath: /etc/secrets/config-watcher/scripts
       volumes: 
-        
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
@@ -1163,14 +1163,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1215,28 +1215,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             requests:
               cpu: 1
@@ -990,28 +990,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -1033,14 +1033,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1074,31 +1074,31 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
         - name: tiered-storage-dir
           emptyDir:
             sizeLimit: 5.36870912e+09
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -1034,14 +1034,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1075,31 +1075,31 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
         - name: tiered-storage-dir
           emptyDir:
             sizeLimit: 5.36870912e+09
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -1032,14 +1032,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1073,31 +1073,31 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
         - name: tiered-storage-dir
           emptyDir:
             sizeLimit: 5.36870912e+09
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -969,14 +969,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1010,31 +1010,31 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
         - name: tiered-storage-dir
           emptyDir:
             sizeLimit: 5.36870912e+09
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -1033,14 +1033,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1074,28 +1074,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -1034,14 +1034,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1075,28 +1075,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -1032,14 +1032,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1073,28 +1073,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -969,14 +969,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1010,28 +1010,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -1033,14 +1033,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1074,28 +1074,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -1034,14 +1034,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1075,28 +1075,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -1032,14 +1032,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1073,28 +1073,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -969,14 +969,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: shadow-index-cache
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1010,28 +1010,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -949,14 +949,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -988,28 +988,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
@@ -952,14 +952,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -991,28 +991,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
@@ -1021,14 +1021,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1060,28 +1060,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
@@ -963,14 +963,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1002,28 +1002,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
@@ -1163,14 +1163,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1229,28 +1229,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
@@ -1159,14 +1159,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1198,28 +1198,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
@@ -1137,14 +1137,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1176,28 +1176,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
@@ -1161,14 +1161,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1206,28 +1206,28 @@ spec:
             secretName: redpanda-users
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
@@ -1011,14 +1011,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1050,28 +1050,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
@@ -953,14 +953,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -992,28 +992,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -985,14 +985,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
             - name: tiered-storage-dir
               mountPath: /var/lib/redpanda/data/cloud_storage_cache
           resources:
@@ -1026,31 +1026,31 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
         - name: tiered-storage-dir
           emptyDir:
             sizeLimit: 11G
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
@@ -944,14 +944,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -983,28 +983,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
@@ -1007,14 +1007,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1046,28 +1046,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
@@ -950,14 +950,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -989,28 +989,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
@@ -946,14 +946,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -985,28 +985,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
@@ -1009,14 +1009,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1048,28 +1048,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
@@ -952,14 +952,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -991,28 +991,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
@@ -946,14 +946,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -985,28 +985,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
@@ -1009,14 +1009,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1048,28 +1048,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
@@ -952,14 +952,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -991,28 +991,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
@@ -946,14 +946,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -985,28 +985,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
@@ -1009,14 +1009,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1048,28 +1048,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
@@ -952,14 +952,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -991,28 +991,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
@@ -1011,14 +1011,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1050,28 +1050,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
@@ -954,14 +954,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -993,28 +993,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
@@ -1011,14 +1011,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1050,28 +1050,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
@@ -954,14 +954,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -993,28 +993,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
@@ -948,14 +948,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -987,28 +987,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
@@ -1011,14 +1011,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -1050,28 +1050,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
@@ -954,14 +954,14 @@ spec:
               name: redpanda-default-cert
             - mountPath: /etc/tls/certs/external
               name: redpanda-external-cert
-            - name: config
-              mountPath: /etc/redpanda
-            - name: redpanda
-              mountPath: /tmp/base-config
-            - name: lifecycle-scripts
-              mountPath: /var/lifecycle
-            - name: datadir
-              mountPath: /var/lib/redpanda/data
+            - mountPath: /etc/redpanda
+              name: config
+            - mountPath: /tmp/base-config
+              name: redpanda
+            - mountPath: /var/lifecycle
+              name: lifecycle-scripts
+            - mountPath: /var/lib/redpanda/data
+              name: datadir
           resources:
             limits:
               cpu: 1
@@ -993,28 +993,28 @@ spec:
             secretName: redpanda-external-cert
         - name: lifecycle-scripts
           secret:
+            defaultMode: 509
             secretName: redpanda-sts-lifecycle
-            defaultMode: 0o775
+        - configMap:
+            name: redpanda
+          name: redpanda
+        - emptyDir: {}
+          name: config
+        - name: redpanda-configurator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-configurator
+        - name: redpanda-config-watcher
+          secret:
+            defaultMode: 509
+            secretName: redpanda-config-watcher
+        - name: redpanda-fs-validator
+          secret:
+            defaultMode: 509
+            secretName: redpanda-fs-validator
         - name: datadir
           persistentVolumeClaim:
             claimName: datadir
-        - name: redpanda
-          configMap:
-            name: redpanda
-        - name: config
-          emptyDir: {}
-        - name: redpanda-configurator
-          secret:
-            secretName: redpanda-configurator
-            defaultMode: 0o775
-        - name: redpanda-config-watcher
-          secret:
-            secretName: redpanda-config-watcher
-            defaultMode: 0o775
-        - name: redpanda-fs-validator
-          secret:
-            secretName: redpanda-fs-validator
-            defaultMode: 0o775
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: topology.kubernetes.io/zone


### PR DESCRIPTION
This commit migrates the easiest of the redpanda volumes and volume mounts into go code. This change is in preparation of an upcoming change to the `truststore_file` that will allow specifying a ConfigMap key to be mounted.