### PR TITLE
redpanda: configmap refactors

### DIFF
--- a/charts/redpanda/chart.go
+++ b/charts/redpanda/chart.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -25,6 +26,7 @@ var (
 func init() {
 	must(scheme.AddToScheme(Scheme))
 	must(certmanagerv1.AddToScheme(Scheme))
+	must(monitoringv1.AddToScheme(Scheme))
 
 	// NB: We can't directly unmarshal into a helmette.Chart as adding json
 	// tags to it breaks gotohelm.

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -16,6 +16,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 func TieredStorageStatic(t *testing.T) redpanda.PartialValues {
@@ -138,6 +139,120 @@ func TestChart(t *testing.T) {
 		require.Equal(t, true, config["cloud_storage_enabled"])
 		require.Equal(t, "from-secret-access-key", config["cloud_storage_access_key"])
 	})
+}
+
+const latestRedpandaHelmChartVersionBeforeGoTransipler = "5.8.8"
+
+func TestConfigMap(t *testing.T) {
+	ctx := testutil.Context(t)
+	client, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
+	require.NoError(t, err)
+
+	require.NoError(t, client.RepoAdd(ctx, "redpanda", "https://charts.redpanda.com"))
+	require.NoError(t, client.RepoUpdate(ctx))
+
+	values, err := os.ReadDir("./ci")
+	require.NoError(t, err)
+
+	for _, v := range values {
+		v := v
+		t.Run(v.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			// First generate latest released Redpanda charts manifests. From ConfigMap bootstrap,
+			// redpanda node configuration and RPK profile.
+			manifests, err := client.Template(ctx, "redpanda/redpanda", helm.TemplateOptions{
+				Name:       "redpanda",
+				ValuesFile: "./ci/" + v.Name(),
+				Set: []string{
+					// Tests utilize some non-deterministic helpers (rng). We don't
+					// really care about the stability of their output, so globally
+					// disable them.
+					"tests.enabled=false",
+					// jwtSecret defaults to a random string. Can't have that
+					// in snapshot testing so set it to a static value.
+					"console.secret.login.jwtSecret=SECRETKEY",
+				},
+				Version: latestRedpandaHelmChartVersionBeforeGoTransipler,
+			})
+			require.NoError(t, err)
+
+			oldConf, err := extractRedpandaConfigsFromConfigMap(manifests)
+			require.NoError(t, err)
+
+			// Now helm template will generate Redpanda configuration from local definition
+			manifests, err = client.Template(ctx, ".", helm.TemplateOptions{
+				Name:       "redpanda",
+				ValuesFile: "./ci/" + v.Name(),
+				Set: []string{
+					// Tests utilize some non-deterministic helpers (rng). We don't
+					// really care about the stability of their output, so globally
+					// disable them.
+					"tests.enabled=false",
+					// jwtSecret defaults to a random string. Can't have that
+					// in snapshot testing so set it to a static value.
+					"console.secret.login.jwtSecret=SECRETKEY",
+				},
+			})
+			require.NoError(t, err)
+
+			newConf, err := extractRedpandaConfigsFromConfigMap(manifests)
+			require.NoError(t, err)
+
+			require.JSONEq(t, oldConf.redpanda, newConf.redpanda)
+			require.JSONEq(t, oldConf.bootstrap, newConf.bootstrap)
+			require.JSONEq(t, oldConf.rpkProfile, newConf.rpkProfile)
+		})
+	}
+}
+
+type configmapRepresentation struct {
+	redpanda   string
+	bootstrap  string
+	rpkProfile string
+}
+
+// extractRedpandaConfigsFromConfigMap is parsing all manifests (resources)
+// created by helm template execution. Redpanda helm chart creates 3 distinct
+// files in ConfigMap: redpanda.yaml (node, tunable and cluster configuration),
+// bootstrap.yaml (only cluster configuration) and profile (external connectivity rpk profile).
+func extractRedpandaConfigsFromConfigMap(manifests []byte) (*configmapRepresentation, error) {
+	var result configmapRepresentation
+	objs, err := kube.DecodeYAML(manifests, redpanda.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, obj := range objs {
+		switch obj := obj.(type) {
+		case *corev1.ConfigMap:
+			switch obj.Name {
+			case "redpanda":
+				r := obj.Data["redpanda.yaml"]
+				jsonR, err := yaml.YAMLToJSON([]byte(r))
+				if err != nil {
+					return nil, err
+				}
+				result.redpanda = string(jsonR)
+
+				b := obj.Data["bootstrap.yaml"]
+				jsonB, err := yaml.YAMLToJSON([]byte(b))
+				if err != nil {
+					return nil, err
+				}
+				result.bootstrap = string(jsonB)
+			case "redpanda-rpk":
+				p := obj.Data["profile"]
+				jsonP, err := yaml.YAMLToJSON([]byte(p))
+				if err != nil {
+					return nil, err
+				}
+				result.rpkProfile = string(jsonP)
+			}
+		}
+	}
+
+	return &result, nil
 }
 
 func TestLabels(t *testing.T) {

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -19,18 +19,767 @@ package redpanda
 import (
 	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 )
+
+func ConfigMap(dot *helmette.Dot) []corev1.ConfigMap {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	bootstrap := map[string]any{
+		"kafka_enable_authorization": values.Auth.IsSASLEnabled(),
+		"enable_sasl":                values.Auth.IsSASLEnabled(),
+		"enable_rack_awareness":      values.RackAwareness.Enabled,
+		"storage_min_free_bytes":     values.Storage.StorageMinFreeBytes(),
+	}
+
+	bootstrap = helmette.Merge(bootstrap, values.AuditLogging.Translate(dot, values.Auth.IsSASLEnabled()))
+	bootstrap = helmette.Merge(bootstrap, values.Logging.Translate())
+	bootstrap = helmette.Merge(bootstrap, values.Config.Tunable.Translate())
+	bootstrap = helmette.Merge(bootstrap, values.Config.Cluster.Translate(values.Statefulset.Replicas, false))
+	bootstrap = helmette.Merge(bootstrap, values.Auth.Translate(values.Auth.IsSASLEnabled()))
+
+	// configureUsageStats(bootstrap, dot)
+	// configureTunable(bootstrap, dot)
+	// configureClusterConfiguration(bootstrap, dot, false)
+	// configureSuperUsers(bootstrap, dot)
+
+	redpanda := map[string]any{
+		"kafka_enable_authorization": values.Auth.IsSASLEnabled(),
+		"enable_sasl":                values.Auth.IsSASLEnabled(),
+		"empty_seed_starts_cluster":  false,
+		"storage_min_free_bytes":     values.Storage.StorageMinFreeBytes(),
+		"seed_servers":               values.Listeners.CreateSeedServers(values.Statefulset.Replicas, Fullname(dot), InternalDomain(dot)),
+	}
+
+	redpanda = helmette.Merge(redpanda, values.AuditLogging.Translate(dot, values.Auth.IsSASLEnabled()))
+	redpanda = helmette.Merge(redpanda, values.Logging.Translate())
+	redpanda = helmette.Merge(redpanda, values.Config.Tunable.Translate())
+	redpanda = helmette.Merge(redpanda, values.Config.Cluster.Translate(values.Statefulset.Replicas, true))
+	redpanda = helmette.Merge(redpanda, values.Auth.Translate(values.Auth.IsSASLEnabled()))
+	redpanda = helmette.Merge(redpanda, values.Config.Node.Translate())
+
+	// configureUsageStats(redpanda, dot)
+	// configureTunable(redpanda, dot)
+	// configureClusterConfiguration(redpanda, dot, true)
+	// configureNodeConfiguration(redpanda, dot)
+	configureListeners(redpanda, dot)
+	// configureSuperUsers(redpanda, dot)
+
+	redpandaYaml := map[string]any{
+		"redpanda":               redpanda,
+		"schema_registry":        schemaRegistry(dot),
+		"schema_registry_client": kafkaClient(dot),
+		"pandaproxy":             pandaProxyListener(dot),
+		"pandaproxy_client":      kafkaClient(dot),
+		"rpk":                    rpkConfiguration(dot),
+		"config_file":            "/etc/redpanda/redpanda.yaml",
+	}
+
+	if RedpandaAtLeast_23_3_0(dot) && values.AuditLogging.Enabled && values.Auth.IsSASLEnabled() {
+		redpandaYaml["audit_log_client"] = kafkaClient(dot)
+	}
+
+	redpandaYaml = helmette.Merge(redpandaYaml, values.Storage.Translate())
+
+	cms := []corev1.ConfigMap{
+		{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      Fullname(dot),
+				Namespace: dot.Release.Namespace,
+				Labels:    FullLabels(dot),
+			},
+			Data: map[string]string{
+				"bootstrap.yaml": helmette.ToYaml(bootstrap),
+				"redpanda.yaml":  helmette.ToYaml(redpandaYaml),
+			},
+		},
+	}
+
+	if values.External.Enabled {
+		cms = append(cms, corev1.ConfigMap{
+			TypeMeta: v1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: v1.ObjectMeta{
+				Name:      fmt.Sprintf("%s-rpk", Fullname(dot)),
+				Namespace: dot.Release.Namespace,
+				Labels:    FullLabels(dot),
+			},
+			Data: map[string]string{
+				"profile": helmette.ToYaml(rpkProfile(dot)),
+			},
+		})
+	}
+	return cms
+}
+
+func rpkProfile(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	brokerList := []string{}
+	for i := 0; i < values.Statefulset.Replicas; i++ {
+		brokerList = append(brokerList, fmt.Sprintf("%s:%d", advertisedHost(dot, i), int(advertisedKafkaPort(dot, i))))
+	}
+
+	adminAdvertisedList := []string{}
+	for i := 0; i < values.Statefulset.Replicas; i++ {
+		adminAdvertisedList = append(adminAdvertisedList, fmt.Sprintf("%s:%d", advertisedHost(dot, i), int(advertisedAdminPort(dot, i))))
+	}
+
+	kafkaTLS := brokersTLSConfiguration(dot)
+	if _, ok := kafkaTLS["truststore_file"]; ok {
+		kafkaTLS["ca_file"] = "ca.crt"
+		delete(kafkaTLS, "truststore_file")
+	}
+
+	adminTLS := adminTLSConfiguration(dot)
+	if _, ok := adminTLS["truststore_file"]; ok {
+		adminTLS["ca_file"] = "ca.crt"
+		delete(adminTLS, "truststore_file")
+	}
+
+	ka := map[string]any{
+		"brokers": brokerList,
+		"tls":     nil,
+	}
+
+	if len(kafkaTLS) > 0 {
+		ka["tls"] = kafkaTLS
+	}
+
+	aa := map[string]any{
+		"addresses": adminAdvertisedList,
+		"tls":       nil,
+	}
+
+	if len(adminTLS) > 0 {
+		aa["tls"] = adminTLS
+	}
+
+	result := map[string]any{
+		"name":      getFistExternalKafkaListener(dot),
+		"kafka_api": ka,
+		"admin_api": aa,
+	}
+
+	return result
+}
+
+func advertisedKafkaPort(dot *helmette.Dot, i int) int {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	externalKafkaListenerName := getFistExternalKafkaListener(dot)
+
+	listener := values.Listeners.Kafka.External[externalKafkaListenerName]
+
+	port := int(values.Listeners.Kafka.Port)
+
+	if int(listener.Port) > int(1) {
+		port = int(listener.Port)
+	}
+
+	if len(listener.AdvertisedPorts) > 1 {
+		port = int(listener.AdvertisedPorts[i])
+	} else if len(listener.AdvertisedPorts) == 1 {
+		port = int(listener.AdvertisedPorts[0])
+	}
+
+	return port
+}
+
+func advertisedAdminPort(dot *helmette.Dot, i int) int {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	keys := helmette.Keys(values.Listeners.Admin.External)
+
+	helmette.SortAlpha(keys)
+
+	externalAdminListenerName := helmette.First(keys)
+
+	listener := values.Listeners.Admin.External[externalAdminListenerName.(string)]
+
+	port := int(values.Listeners.Admin.Port)
+
+	if int(listener.Port) > 1 {
+		port = int(listener.Port)
+	}
+
+	if len(listener.AdvertisedPorts) > 1 {
+		port = int(listener.AdvertisedPorts[i])
+	} else if len(listener.AdvertisedPorts) == 1 {
+		port = int(listener.AdvertisedPorts[0])
+	}
+
+	return port
+}
+
+func advertisedHost(dot *helmette.Dot, i int) string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	address := fmt.Sprintf("%s-%d", Fullname(dot), int(i))
+	if ptr.Deref(values.External.Domain, "") != "" {
+		// TODO: TPL DOES NOT WORK. Maybe tpl call could be removed
+		address = fmt.Sprintf("%s.%s", address, helmette.Tpl(*values.External.Domain, dot))
+	}
+
+	if len(values.External.Addresses) <= 0 {
+		return address
+	}
+
+	if len(values.External.Addresses) == 1 {
+		address = values.External.Addresses[0]
+	} else {
+		address = values.External.Addresses[i]
+	}
+
+	if ptr.Deref(values.External.Domain, "") != "" {
+		address = fmt.Sprintf("%s.%s", address, *values.External.Domain)
+	}
+
+	return address
+}
+
+func getFistExternalKafkaListener(dot *helmette.Dot) string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	keys := helmette.Keys(values.Listeners.Kafka.External)
+
+	helmette.SortAlpha(keys)
+
+	return helmette.First(keys).(string)
+}
+
+func rpkConfiguration(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	brokerList := []string{}
+	r := values.Statefulset.Replicas
+	for i := 0; i < r; i++ {
+		brokerList = append(brokerList, fmt.Sprintf("%s-%d.%s:%d", Fullname(dot), i, InternalDomain(dot), int(values.Listeners.Kafka.Port)))
+	}
+
+	var adminTLS map[string]any
+	if tls := adminTLSConfiguration(dot); len(tls) > 0 {
+		adminTLS = tls
+	}
+
+	var brokerTLS map[string]any
+	if tls := brokersTLSConfiguration(dot); len(tls) > 0 {
+		brokerTLS = tls
+	}
+
+	result := map[string]any{
+		"overprovisioned":        ptr.Deref(values.Resources.CPU.Overprovisioned, false),
+		"enable_memory_locking":  ptr.Deref(values.Resources.Memory.EnableMemoryLocking, false),
+		"additional_start_flags": RedpandaAdditionalStartFlags(dot, RedpandaSMP(dot)),
+		"kafka_api": map[string]any{
+			"brokers": brokerList,
+			"tls":     brokerTLS,
+		},
+		"admin_api": map[string]any{
+			"addresses": values.Listeners.AdminList(values.Statefulset.Replicas, Fullname(dot), InternalDomain(dot)),
+			"tls":       adminTLS,
+		},
+	}
+
+	result = helmette.Merge(result, values.Tuning.Translate())
+	result = helmette.Merge(result, values.Config.CreateRPKConfiguration())
+
+	return result
+}
+
+func brokersTLSConfiguration(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	result := map[string]any{}
+	k := values.Listeners.Kafka.TLS
+	if !ptr.Deref(k.Enabled, true) {
+		return result
+	}
+
+	if !values.TLS.Enabled || k.Cert == "" {
+		return result
+	}
+
+	certName := k.Cert
+
+	if cert, ok := values.TLS.Certs[certName]; ok && cert.CAEnabled {
+		result["truststore_file"] = fmt.Sprintf("/etc/tls/certs/%s/ca.crt", values.Listeners.Kafka.TLS.Cert)
+	}
+	if values.Listeners.Kafka.TLS.RequireClientAuth {
+		result["cert_file"] = fmt.Sprintf("/etc/tls/certs/%s-client/tls.crt", Fullname(dot))
+		result["key_file"] = fmt.Sprintf("/etc/tls/certs/%s-client/tls.key", Fullname(dot))
+
+	}
+
+	return result
+}
+
+func adminTLSConfiguration(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	result := map[string]any{}
+	if !values.TLS.Enabled || values.Listeners.Admin.TLS.Cert == "" {
+		// if !values.TLS.Enabled || (values.Listeners.Admin.TLS.Cert == nil || values.Listeners.Admin.TLS.Cert != nil && *values.Listeners.Admin.TLS.Cert == "") {
+		return result
+	}
+
+	certName := values.Listeners.Admin.TLS.Cert
+
+	if cert, ok := values.TLS.Certs[certName]; ok && cert.CAEnabled {
+		result["truststore_file"] = fmt.Sprintf("/etc/tls/certs/%s/ca.crt", values.Listeners.Admin.TLS.Cert)
+	}
+
+	if values.Listeners.Admin.TLS.RequireClientAuth {
+		result["cert_file"] = fmt.Sprintf("/etc/tls/certs/%s-client/tls.crt", Fullname(dot))
+		result["key_file"] = fmt.Sprintf("/etc/tls/certs/%s-client/tls.key", Fullname(dot))
+
+	}
+
+	return result
+}
+
+func kafkaClient(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	brokerList := []map[string]any{}
+	for i := 0; i < values.Statefulset.Replicas; i++ {
+		brokerList = append(brokerList, map[string]any{
+			"address": fmt.Sprintf("%s-%d.%s", Fullname(dot), i, InternalDomain(dot)),
+			"port":    values.Listeners.Kafka.Port,
+		})
+	}
+
+	kafkaTLS := values.Listeners.Kafka.TLS
+
+	var brokerTLS map[string]any
+	if isInternalListenerTLSAvailable(values.TLS.Enabled, values.Listeners.Kafka.TLS) {
+		brokerTLS = map[string]any{
+			"enabled":             true,
+			"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", kafkaTLS.Cert),
+			"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", kafkaTLS.Cert),
+			"require_client_auth": kafkaTLS.RequireClientAuth,
+			"truststore_file":     getCertificate(&values.TLS.Certs, kafkaTLS.Cert),
+		}
+	}
+
+	cfg := map[string]any{
+		"brokers": brokerList,
+	}
+	if len(brokerTLS) > 0 {
+		cfg["broker_tls"] = brokerTLS
+	}
+
+	return cfg
+}
+
+func configureListeners(redpanda map[string]any, dot *helmette.Dot) {
+	redpanda["admin"] = adminListeners(dot)
+	redpanda["admin_api_tls"] = nil
+	tls := adminListenersTLS(dot)
+	if len(tls) > 0 {
+		redpanda["admin_api_tls"] = tls
+	}
+	redpanda["kafka_api"] = kafkaListeners(dot)
+	redpanda["kafka_api_tls"] = nil
+	tls = kafkaListenersTLS(dot)
+	if len(tls) > 0 {
+		redpanda["kafka_api_tls"] = tls
+	}
+	redpanda["rpc_server"] = rpcListeners(dot)
+	rpcTLS := rpcListenersTLS(dot)
+	if len(rpcTLS) > 0 {
+		redpanda["rpc_server_tls"] = rpcTLS
+	}
+}
+
+func pandaProxyListener(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	pandaProxy := map[string]any{}
+
+	pandaProxy["pandaproxy_api"] = values.Listeners.HTTP.Listeners(values.Auth.IsSASLEnabled())
+	tls := pandaProxyListenersTLS(dot)
+	pandaProxy["pandaproxy_api_tls"] = nil
+	if len(tls) > 0 {
+		pandaProxy["pandaproxy_api_tls"] = tls
+	}
+	return pandaProxy
+}
+
+func pandaProxyListenersTLS(dot *helmette.Dot) []map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	pp := []map[string]any{}
+
+	internal := createInternalListenerTLSCfg(values.TLS.Enabled, values.Listeners.HTTP.TLS, &values.TLS.Certs)
+	if len(internal) > 0 {
+		pp = append(pp, internal)
+	}
+
+	for k, l := range values.Listeners.HTTP.External {
+		if !isListenerTLSCfgAvailable(
+			l.Enabled,
+			l.TLS.IsEnabled(),
+			values.Listeners.HTTP.TLS.Enabled,
+			values.TLS.Enabled,
+			values.Listeners.HTTP.TLS.Cert,
+			l.TLS.GetCert(),
+			values.TLS.Certs) {
+			continue
+		}
+
+		certName := ptr.Deref(l.TLS.GetCert(), values.Listeners.HTTP.TLS.Cert)
+
+		pp = append(pp, map[string]any{
+			"name":                k,
+			"enabled":             true,
+			"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", certName),
+			"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", certName),
+			"require_client_auth": ptr.Deref(l.TLS.RequireClientAuth, false),
+			"truststore_file":     getCertificate(&values.TLS.Certs, certName),
+		})
+	}
+	return pp
+}
+
+func schemaRegistry(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	schemaReg := map[string]any{}
+
+	schemaReg["schema_registry_api"] = values.Listeners.SchemaRegistry.Listeners(values.Auth.IsSASLEnabled())
+	tls := schemaRegistryListenersTLS(dot)
+	schemaReg["schema_registry_api_tls"] = nil
+	if len(tls) > 0 {
+		schemaReg["schema_registry_api_tls"] = tls
+	}
+	return schemaReg
+}
+
+func schemaRegistryListenersTLS(dot *helmette.Dot) []map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	sr := []map[string]any{}
+
+	internal := createInternalListenerTLSCfg(values.TLS.Enabled, values.Listeners.SchemaRegistry.TLS, &values.TLS.Certs)
+	if len(internal) > 0 {
+		sr = append(sr, internal)
+	}
+
+	for k, l := range values.Listeners.SchemaRegistry.External {
+		if !isListenerTLSCfgAvailable(
+			l.Enabled,
+			l.TLS.IsEnabled(),
+			values.Listeners.SchemaRegistry.TLS.Enabled,
+			values.TLS.Enabled,
+			values.Listeners.SchemaRegistry.TLS.Cert,
+			l.TLS.GetCert(),
+			values.TLS.Certs) {
+			continue
+		}
+
+		certName := ptr.Deref(l.TLS.GetCert(), values.Listeners.SchemaRegistry.TLS.Cert)
+
+		sr = append(sr, map[string]any{
+			"name":                k,
+			"enabled":             true,
+			"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", certName),
+			"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", certName),
+			"require_client_auth": ptr.Deref(l.TLS.RequireClientAuth, false),
+			"truststore_file":     getCertificate(&values.TLS.Certs, certName),
+		})
+	}
+	return sr
+}
+
+// `internalTLSEnabled` is a parameter from SchemaRegistryListeners definition
+func isListenerTLSCfgAvailable(
+	listenerEnabled, listenerTLSEnabled, internalTLSEnabled *bool,
+	globalTLSEnabled bool,
+	internalCertName string, listenerCertName *string, certMap TLSCertMap,
+) bool {
+	// SchemaRegistryExternal listener could have enabled flag defined. If the flag is provided,
+	// then check it. If the flag is missing, then allow such config.
+	if !ptr.Deref(listenerEnabled, true) {
+		return false
+	}
+
+	// listener TLS enabled exist
+	if !ptr.Deref(listenerTLSEnabled, true) {
+		return false
+	}
+
+	// When TLS.Enabled is not defined, then internalTLSEnabled flag could disable TLS generation
+	if listenerTLSEnabled == nil && internalTLSEnabled != nil && !*internalTLSEnabled {
+		return false
+	}
+
+	// When TLS.Enabled is not defined, then  flag could disable TLS generation
+	if listenerTLSEnabled == nil && internalTLSEnabled == nil && !globalTLSEnabled {
+		return false
+	}
+
+	certName := internalCertName
+
+	if listenerCertName != nil {
+		certName = *listenerCertName
+	}
+
+	_, ok := certMap[certName]
+	return ok
+}
+
+func rpcListenersTLS(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	r := values.Listeners.RPC
+
+	if r.TLS.Enabled == nil && !values.TLS.Enabled {
+		return map[string]any{}
+	}
+
+	if r.TLS.Enabled != nil && !*r.TLS.Enabled {
+		if !values.TLS.Enabled {
+			return map[string]any{}
+		}
+	}
+
+	certName := r.TLS.Cert
+	if certName == "" {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		"enabled":             true,
+		"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", certName),
+		"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", certName),
+		"require_client_auth": r.TLS.RequireClientAuth,
+		"truststore_file":     getCertificate(&values.TLS.Certs, certName),
+	}
+}
+
+func rpcListeners(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	return map[string]any{
+		"address": "0.0.0.0",
+		"port":    values.Listeners.RPC.Port,
+	}
+}
+
+func kafkaListenersTLS(dot *helmette.Dot) []map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	kafka := []map[string]any{}
+
+	internal := createInternalListenerTLSCfg(values.TLS.Enabled, values.Listeners.Kafka.TLS, &values.TLS.Certs)
+	if len(internal) > 0 {
+		kafka = append(kafka, internal)
+	}
+
+	for k, l := range values.Listeners.Kafka.External {
+		if !isListenerTLSCfgAvailable(
+			l.Enabled,
+			l.TLS.IsEnabled(),
+			values.Listeners.Kafka.TLS.Enabled,
+			values.TLS.Enabled,
+			values.Listeners.Kafka.TLS.Cert,
+			l.TLS.GetCert(),
+			values.TLS.Certs) {
+			continue
+		}
+
+		certName := ptr.Deref(l.TLS.GetCert(), values.Listeners.Kafka.TLS.Cert)
+
+		kafka = append(kafka, map[string]any{
+			"name":                k,
+			"enabled":             true,
+			"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", certName),
+			"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", certName),
+			"require_client_auth": ptr.Deref(l.TLS.RequireClientAuth, false),
+			"truststore_file":     getCertificate(&values.TLS.Certs, certName),
+		})
+	}
+	return kafka
+}
+
+func getCertificate(certs *TLSCertMap, certName string) string {
+	defaultTruststorePath := "/etc/ssl/certs/ca-certificates.crt"
+	// TLSCertMap is not defined inside each listener as TLSCertMap can be shared
+	// between each listener.
+	if certs == nil {
+		panic("TLS map is not defined")
+	}
+	if certName == "" {
+		return defaultTruststorePath
+	}
+	c := *certs
+	// TLSCert can overwrite ca/truststore path in the configuration
+	if crt, ok := c[certName]; ok && crt.CAEnabled {
+		return fmt.Sprintf("/etc/tls/certs/%s/ca.crt", certName)
+	} else if !ok {
+		panic(fmt.Sprintf("Certificate name reference (%s) defined in listener, but not found in the tls.certs map", certName))
+	}
+	return defaultTruststorePath
+}
+
+func kafkaListeners(dot *helmette.Dot) []map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	kf := values.Listeners.Kafka
+	internal := createInternalListenerCfg(values.Listeners.Kafka.Port)
+
+	if values.Auth.IsSASLEnabled() {
+		internal["authentication_method"] = "sasl"
+	}
+
+	if am := ptr.Deref(kf.AuthenticationMethod, ""); am != "" {
+		internal["authentication_method"] = am
+	}
+
+	kafka := []map[string]any{
+		internal,
+	}
+
+	for k, l := range kf.External {
+		if !(ptr.Deref(l.Enabled, true) && int(l.Port) > 0) {
+			continue
+		}
+
+		listener := map[string]any{
+			"name":    k,
+			"port":    l.Port,
+			"address": "0.0.0.0",
+		}
+
+		if values.Auth.IsSASLEnabled() {
+			listener["authentication_method"] = "sasl"
+		}
+
+		if am := ptr.Deref(l.AuthenticationMethod, ""); am != "" {
+			listener["authentication_method"] = am
+		}
+
+		kafka = append(kafka, listener)
+	}
+	return kafka
+}
+
+func adminListenersTLS(dot *helmette.Dot) []map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	admin := []map[string]any{}
+
+	internal := createInternalListenerTLSCfg(values.TLS.Enabled, values.Listeners.Admin.TLS, &values.TLS.Certs)
+	if len(internal) > 0 {
+		admin = append(admin, internal)
+	}
+
+	for k, l := range values.Listeners.Admin.External {
+		if !isListenerTLSCfgAvailable(
+			l.Enabled,
+			l.TLS.IsEnabled(),
+			values.Listeners.Admin.TLS.Enabled,
+			values.TLS.Enabled,
+			values.Listeners.Admin.TLS.Cert,
+			l.TLS.GetCert(),
+			values.TLS.Certs) {
+			continue
+		}
+
+		certName := ptr.Deref(l.TLS.GetCert(), values.Listeners.Admin.TLS.Cert)
+
+		admin = append(admin, map[string]any{
+			"name":                k,
+			"enabled":             true,
+			"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", certName),
+			"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", certName),
+			"require_client_auth": ptr.Deref(l.TLS.RequireClientAuth, false),
+			"truststore_file":     getCertificate(&values.TLS.Certs, certName),
+		})
+	}
+	return admin
+}
+
+func isInternalListenerTLSAvailable(defaultTLSEnabled bool, externalTLS InternalTLS) bool {
+	if externalTLS.Enabled == nil && !defaultTLSEnabled {
+		return false
+	}
+
+	if externalTLS.Enabled != nil && !*externalTLS.Enabled {
+		return false
+	}
+
+	if externalTLS.Cert == "" {
+		// if externalTLS.Cert == nil || externalTLS.Cert != nil && *externalTLS.Cert == "" {
+		return false
+	}
+	return true
+}
+
+// First parameter defaultTLSEnabled must come from `values.tls.enabled`.
+func createInternalListenerTLSCfg(defaultTLSEnabled bool, externalTLS InternalTLS, certs *TLSCertMap) map[string]any {
+	if !isInternalListenerTLSAvailable(defaultTLSEnabled, externalTLS) {
+		return map[string]any{}
+	}
+
+	return map[string]any{
+		"name":                "internal",
+		"enabled":             true,
+		"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", externalTLS.Cert),
+		"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", externalTLS.Cert),
+		"require_client_auth": externalTLS.RequireClientAuth,
+		"truststore_file":     getCertificate(certs, externalTLS.Cert),
+	}
+}
+
+func createInternalListenerCfg(port int) map[string]any {
+	return map[string]any{
+		"name":    "internal",
+		"address": "0.0.0.0",
+		"port":    port,
+	}
+}
+
+func adminListeners(dot *helmette.Dot) []map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	admin := []map[string]any{
+		createInternalListenerCfg(values.Listeners.Admin.Port),
+	}
+	for k, l := range values.Listeners.Admin.External {
+		if !(ptr.Deref(l.Enabled, true) && int(l.Port) > 0) {
+			continue
+		}
+
+		admin = append(admin, map[string]any{
+			"name":    k,
+			"port":    l.Port,
+			"address": "0.0.0.0",
+		})
+	}
+	return admin
+}
 
 // RedpandaAdditionalStartFlags returns a string list of flags suitable for use
 // as `additional_start_flags`. User provided flags will override any of those
 // set by default.
-func RedpandaAdditionalStartFlags(dot *helmette.Dot, smp string) []string {
+func RedpandaAdditionalStartFlags(dot *helmette.Dot, smp int) []string {
 	values := helmette.Unwrap[Values](dot.Values)
 
 	// All `additional_start_flags` that are set by the chart.
 	chartFlags := map[string]string{
-		"smp": smp,
+		"smp": fmt.Sprintf("%d", int(smp)),
 		// TODO: The transpiled go template will return float64 from both RedpandaMemory and RedpandaReserveMemory
 		// By wrapping return value from that function the sprintf will work as expected
 		// https://github.com/redpanda-data/helm-charts/issues/1249

--- a/charts/redpanda/post_install_upgrade_job.tpl.go
+++ b/charts/redpanda/post_install_upgrade_job.tpl.go
@@ -44,15 +44,11 @@ func PostInstallUpgradeEnvironmentVariables(dot *helmette.Dot) []corev1.EnvVar {
 		})
 	}
 
-	tieredStorageConfig := values.Storage.Tiered.Config
-
-	if len(values.Storage.TieredConfig) > 0 {
-		tieredStorageConfig = values.Storage.TieredConfig
-	}
-
-	if !IsTieredStorageEnabled(tieredStorageConfig) {
+	if !values.Storage.IsTieredStorageEnabled() {
 		return envars
 	}
+
+	tieredStorageConfig := values.Storage.GetTieredStorageConfig()
 
 	ac, azureContainerExists := tieredStorageConfig["cloud_storage_azure_container"]
 	asa, azureStorageAccountExists := tieredStorageConfig["cloud_storage_azure_storage_account"]
@@ -216,11 +212,4 @@ func GetLicenseSecretReference(dot *helmette.Dot) *corev1.SecretKeySelector {
 		}
 	}
 	return nil
-}
-
-func IsTieredStorageEnabled(tieredStorageConfig TieredStorageConfig) bool {
-	if b, ok := tieredStorageConfig["cloud_storage_enabled"]; ok && b.(bool) {
-		return true
-	}
-	return false
 }

--- a/charts/redpanda/service.nodeport.go
+++ b/charts/redpanda/service.nodeport.go
@@ -40,7 +40,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 	ports := []corev1.ServicePort{}
 
 	for name, listener := range values.Listeners.Admin.External {
-		if listener.Enabled != nil && !*listener.Enabled {
+		if !listener.IsEnabled() {
 			continue
 		}
 
@@ -58,7 +58,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 	}
 
 	for name, listener := range values.Listeners.Kafka.External {
-		if listener.Enabled != nil && !*listener.Enabled {
+		if !listener.IsEnabled() {
 			continue
 		}
 
@@ -76,7 +76,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 	}
 
 	for name, listener := range values.Listeners.HTTP.External {
-		if listener.Enabled != nil && !*listener.Enabled {
+		if !listener.IsEnabled() {
 			continue
 		}
 
@@ -94,7 +94,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 	}
 
 	for name, listener := range values.Listeners.SchemaRegistry.External {
-		if listener.Enabled != nil && !*listener.Enabled {
+		if !listener.IsEnabled() {
 			continue
 		}
 

--- a/charts/redpanda/templates/_configmap.go.tpl
+++ b/charts/redpanda/templates/_configmap.go.tpl
@@ -1,11 +1,600 @@
 {{- /* Generated from "configmap.tpl.go" */ -}}
 
+{{- define "redpanda.ConfigMap" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $bootstrap := (dict "kafka_enable_authorization" (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") "enable_sasl" (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") "enable_rack_awareness" $values.rackAwareness.enabled "storage_min_free_bytes" (get (fromJson (include "redpanda.Storage.StorageMinFreeBytes" (dict "a" (list $values.storage) ))) "r") ) -}}
+{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.AuditLogging.Translate" (dict "a" (list $values.auditLogging $dot (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
+{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.Logging.Translate" (dict "a" (list $values.logging) ))) "r")) -}}
+{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.TunableConfig.Translate" (dict "a" (list $values.config.tunable) ))) "r")) -}}
+{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.ClusterConfig.Translate" (dict "a" (list $values.config.cluster ($values.statefulset.replicas | int) false) ))) "r")) -}}
+{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.Auth.Translate" (dict "a" (list $values.auth (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
+{{- $redpanda := (dict "kafka_enable_authorization" (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") "enable_sasl" (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") "empty_seed_starts_cluster" false "storage_min_free_bytes" (get (fromJson (include "redpanda.Storage.StorageMinFreeBytes" (dict "a" (list $values.storage) ))) "r") "seed_servers" (get (fromJson (include "redpanda.Listeners.CreateSeedServers" (dict "a" (list $values.listeners ($values.statefulset.replicas | int) (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) ))) "r") ) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.AuditLogging.Translate" (dict "a" (list $values.auditLogging $dot (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.Logging.Translate" (dict "a" (list $values.logging) ))) "r")) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.TunableConfig.Translate" (dict "a" (list $values.config.tunable) ))) "r")) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.ClusterConfig.Translate" (dict "a" (list $values.config.cluster ($values.statefulset.replicas | int) true) ))) "r")) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.Auth.Translate" (dict "a" (list $values.auth (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.NodeConfig.Translate" (dict "a" (list $values.config.node) ))) "r")) -}}
+{{- $_ := (get (fromJson (include "redpanda.configureListeners" (dict "a" (list $redpanda $dot) ))) "r") -}}
+{{- $redpandaYaml := (dict "redpanda" $redpanda "schema_registry" (get (fromJson (include "redpanda.schemaRegistry" (dict "a" (list $dot) ))) "r") "schema_registry_client" (get (fromJson (include "redpanda.kafkaClient" (dict "a" (list $dot) ))) "r") "pandaproxy" (get (fromJson (include "redpanda.pandaProxyListener" (dict "a" (list $dot) ))) "r") "pandaproxy_client" (get (fromJson (include "redpanda.kafkaClient" (dict "a" (list $dot) ))) "r") "rpk" (get (fromJson (include "redpanda.rpkConfiguration" (dict "a" (list $dot) ))) "r") "config_file" "/etc/redpanda/redpanda.yaml" ) -}}
+{{- if (and (and (get (fromJson (include "redpanda.RedpandaAtLeast_23_3_0" (dict "a" (list $dot) ))) "r") $values.auditLogging.enabled) (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) -}}
+{{- $_ := (set $redpandaYaml "audit_log_client" (get (fromJson (include "redpanda.kafkaClient" (dict "a" (list $dot) ))) "r")) -}}
+{{- end -}}
+{{- $redpandaYaml = (merge (dict ) $redpandaYaml (get (fromJson (include "redpanda.Storage.Translate" (dict "a" (list $values.storage) ))) "r")) -}}
+{{- $cms := (list (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "kind" "ConfigMap" "apiVersion" "v1" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "data" (dict "bootstrap.yaml" (toYaml $bootstrap) "redpanda.yaml" (toYaml $redpandaYaml) ) ))) -}}
+{{- if $values.external.enabled -}}
+{{- $cms = (mustAppend $cms (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "kind" "ConfigMap" "apiVersion" "v1" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%s-rpk" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "data" (dict "profile" (toYaml (get (fromJson (include "redpanda.rpkProfile" (dict "a" (list $dot) ))) "r")) ) ))) -}}
+{{- end -}}
+{{- (dict "r" $cms) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.rpkProfile" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $brokerList := (list ) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
+{{- $brokerList = (mustAppend $brokerList (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedKafkaPort" (dict "a" (list $dot $i) ))) "r") | int) | int))) -}}
+{{- end -}}
+{{- $adminAdvertisedList := (list ) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
+{{- $adminAdvertisedList = (mustAppend $adminAdvertisedList (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedAdminPort" (dict "a" (list $dot $i) ))) "r") | int) | int))) -}}
+{{- end -}}
+{{- $kafkaTLS := (get (fromJson (include "redpanda.brokersTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $kafkaTLS "truststore_file" (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_1 := $tmp_tuple_1.T2 -}}
+{{- if $ok_1 -}}
+{{- $_ := (set $kafkaTLS "ca_file" "ca.crt") -}}
+{{- $_ := (unset $kafkaTLS "truststore_file") -}}
+{{- end -}}
+{{- $adminTLS := (get (fromJson (include "redpanda.adminTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $adminTLS "truststore_file" (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_2 := $tmp_tuple_2.T2 -}}
+{{- if $ok_2 -}}
+{{- $_ := (set $adminTLS "ca_file" "ca.crt") -}}
+{{- $_ := (unset $adminTLS "truststore_file") -}}
+{{- end -}}
+{{- $ka := (dict "brokers" $brokerList "tls" (coalesce nil) ) -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $kafkaTLS) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $ka "tls" $kafkaTLS) -}}
+{{- end -}}
+{{- $aa := (dict "addresses" $adminAdvertisedList "tls" (coalesce nil) ) -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $adminTLS) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $aa "tls" $adminTLS) -}}
+{{- end -}}
+{{- $result := (dict "name" (get (fromJson (include "redpanda.getFistExternalKafkaListener" (dict "a" (list $dot) ))) "r") "kafka_api" $ka "admin_api" $aa ) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.advertisedKafkaPort" -}}
+{{- $dot := (index .a 0) -}}
+{{- $i := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $externalKafkaListenerName := (get (fromJson (include "redpanda.getFistExternalKafkaListener" (dict "a" (list $dot) ))) "r") -}}
+{{- $listener := (index $values.listeners.kafka.external $externalKafkaListenerName) -}}
+{{- $port := (($values.listeners.kafka.port | int) | int) -}}
+{{- if (gt (($listener.port | int) | int) ((1 | int) | int)) -}}
+{{- $port = (($listener.port | int) | int) -}}
+{{- end -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (1 | int)) -}}
+{{- $port = ((index $listener.advertisedPorts $i) | int) -}}
+{{- else -}}{{- if (eq ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (1 | int)) -}}
+{{- $port = ((index $listener.advertisedPorts (0 | int)) | int) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $port) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.advertisedAdminPort" -}}
+{{- $dot := (index .a 0) -}}
+{{- $i := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $keys := (keys $values.listeners.admin.external) -}}
+{{- $_ := (sortAlpha $keys) -}}
+{{- $externalAdminListenerName := (first $keys) -}}
+{{- $listener := (index $values.listeners.admin.external (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $externalAdminListenerName) ))) "r")) -}}
+{{- $port := (($values.listeners.admin.port | int) | int) -}}
+{{- if (gt (($listener.port | int) | int) (1 | int)) -}}
+{{- $port = (($listener.port | int) | int) -}}
+{{- end -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (1 | int)) -}}
+{{- $port = ((index $listener.advertisedPorts $i) | int) -}}
+{{- else -}}{{- if (eq ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (1 | int)) -}}
+{{- $port = ((index $listener.advertisedPorts (0 | int)) | int) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $port) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.advertisedHost" -}}
+{{- $dot := (index .a 0) -}}
+{{- $i := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $address := (printf "%s-%d" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") ($i | int)) -}}
+{{- if (ne (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.external.domain "") ))) "r") "") -}}
+{{- $address = (printf "%s.%s" $address (tpl $values.external.domain $dot)) -}}
+{{- end -}}
+{{- if (le ((get (fromJson (include "_shims.len" (dict "a" (list $values.external.addresses) ))) "r") | int) (0 | int)) -}}
+{{- (dict "r" $address) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (eq ((get (fromJson (include "_shims.len" (dict "a" (list $values.external.addresses) ))) "r") | int) (1 | int)) -}}
+{{- $address = (index $values.external.addresses (0 | int)) -}}
+{{- else -}}
+{{- $address = (index $values.external.addresses $i) -}}
+{{- end -}}
+{{- if (ne (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.external.domain "") ))) "r") "") -}}
+{{- $address = (printf "%s.%s" $address $values.external.domain) -}}
+{{- end -}}
+{{- (dict "r" $address) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.getFistExternalKafkaListener" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $keys := (keys $values.listeners.kafka.external) -}}
+{{- $_ := (sortAlpha $keys) -}}
+{{- (dict "r" (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" (first $keys)) ))) "r")) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.rpkConfiguration" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $brokerList := (list ) -}}
+{{- $r := ($values.statefulset.replicas | int) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
+{{- $brokerList = (mustAppend $brokerList (printf "%s-%d.%s:%d" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r") (($values.listeners.kafka.port | int) | int))) -}}
+{{- end -}}
+{{- $adminTLS := (coalesce nil) -}}
+{{- $tls_3 := (get (fromJson (include "redpanda.adminTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_3) ))) "r") | int) (0 | int)) -}}
+{{- $adminTLS = $tls_3 -}}
+{{- end -}}
+{{- $brokerTLS := (coalesce nil) -}}
+{{- $tls_4 := (get (fromJson (include "redpanda.brokersTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_4) ))) "r") | int) (0 | int)) -}}
+{{- $brokerTLS = $tls_4 -}}
+{{- end -}}
+{{- $result := (dict "overprovisioned" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.resources.cpu.overprovisioned false) ))) "r") "enable_memory_locking" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.resources.memory.enable_memory_locking false) ))) "r") "additional_start_flags" (get (fromJson (include "redpanda.RedpandaAdditionalStartFlags" (dict "a" (list $dot ((get (fromJson (include "redpanda.RedpandaSMP" (dict "a" (list $dot) ))) "r") | int)) ))) "r") "kafka_api" (dict "brokers" $brokerList "tls" $brokerTLS ) "admin_api" (dict "addresses" (get (fromJson (include "redpanda.Listeners.AdminList" (dict "a" (list $values.listeners ($values.statefulset.replicas | int) (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) ))) "r") "tls" $adminTLS ) ) -}}
+{{- $result = (merge (dict ) $result (get (fromJson (include "redpanda.Tuning.Translate" (dict "a" (list $values.tuning) ))) "r")) -}}
+{{- $result = (merge (dict ) $result (get (fromJson (include "redpanda.Config.CreateRPKConfiguration" (dict "a" (list $values.config) ))) "r")) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.brokersTLSConfiguration" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $result := (dict ) -}}
+{{- $k := $values.listeners.kafka.tls -}}
+{{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $k.enabled true) ))) "r")) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (or (not $values.tls.enabled) (eq $k.cert "")) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $certName := $k.cert -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.tls.certs $certName (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_6 := $tmp_tuple_3.T2 -}}
+{{- $cert_5 := $tmp_tuple_3.T1 -}}
+{{- if (and $ok_6 $cert_5.caEnabled) -}}
+{{- $_ := (set $result "truststore_file" (printf "/etc/tls/certs/%s/ca.crt" $values.listeners.kafka.tls.cert)) -}}
+{{- end -}}
+{{- if $values.listeners.kafka.tls.requireClientAuth -}}
+{{- $_ := (set $result "cert_file" (printf "/etc/tls/certs/%s-client/tls.crt" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) -}}
+{{- $_ := (set $result "key_file" (printf "/etc/tls/certs/%s-client/tls.key" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.adminTLSConfiguration" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $result := (dict ) -}}
+{{- if (or (not $values.tls.enabled) (eq $values.listeners.admin.tls.cert "")) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $certName := $values.listeners.admin.tls.cert -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.tls.certs $certName (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_8 := $tmp_tuple_4.T2 -}}
+{{- $cert_7 := $tmp_tuple_4.T1 -}}
+{{- if (and $ok_8 $cert_7.caEnabled) -}}
+{{- $_ := (set $result "truststore_file" (printf "/etc/tls/certs/%s/ca.crt" $values.listeners.admin.tls.cert)) -}}
+{{- end -}}
+{{- if $values.listeners.admin.tls.requireClientAuth -}}
+{{- $_ := (set $result "cert_file" (printf "/etc/tls/certs/%s-client/tls.crt" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) -}}
+{{- $_ := (set $result "key_file" (printf "/etc/tls/certs/%s-client/tls.key" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.kafkaClient" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $brokerList := (list ) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
+{{- $brokerList = (mustAppend $brokerList (dict "address" (printf "%s-%d.%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) "port" ($values.listeners.kafka.port | int) )) -}}
+{{- end -}}
+{{- $kafkaTLS := $values.listeners.kafka.tls -}}
+{{- $brokerTLS := (coalesce nil) -}}
+{{- if (get (fromJson (include "redpanda.isInternalListenerTLSAvailable" (dict "a" (list $values.tls.enabled $values.listeners.kafka.tls) ))) "r") -}}
+{{- $brokerTLS = (dict "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $kafkaTLS.cert) "key_file" (printf "/etc/tls/certs/%s/tls.key" $kafkaTLS.cert) "require_client_auth" $kafkaTLS.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $values.tls.certs $kafkaTLS.cert) ))) "r") ) -}}
+{{- end -}}
+{{- $cfg := (dict "brokers" $brokerList ) -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $brokerTLS) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $cfg "broker_tls" $brokerTLS) -}}
+{{- end -}}
+{{- (dict "r" $cfg) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.configureListeners" -}}
+{{- $redpanda := (index .a 0) -}}
+{{- $dot := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $_ := (set $redpanda "admin" (get (fromJson (include "redpanda.adminListeners" (dict "a" (list $dot) ))) "r")) -}}
+{{- $_ := (set $redpanda "admin_api_tls" (coalesce nil)) -}}
+{{- $tls := (get (fromJson (include "redpanda.adminListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "admin_api_tls" $tls) -}}
+{{- end -}}
+{{- $_ := (set $redpanda "kafka_api" (get (fromJson (include "redpanda.kafkaListeners" (dict "a" (list $dot) ))) "r")) -}}
+{{- $_ := (set $redpanda "kafka_api_tls" (coalesce nil)) -}}
+{{- $tls = (get (fromJson (include "redpanda.kafkaListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "kafka_api_tls" $tls) -}}
+{{- end -}}
+{{- $_ := (set $redpanda "rpc_server" (get (fromJson (include "redpanda.rpcListeners" (dict "a" (list $dot) ))) "r")) -}}
+{{- $rpcTLS := (get (fromJson (include "redpanda.rpcListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $rpcTLS) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "rpc_server_tls" $rpcTLS) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.pandaProxyListener" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $pandaProxy := (dict ) -}}
+{{- $_ := (set $pandaProxy "pandaproxy_api" (get (fromJson (include "redpanda.HTTPListeners.Listeners" (dict "a" (list $values.listeners.http (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
+{{- $tls := (get (fromJson (include "redpanda.pandaProxyListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- $_ := (set $pandaProxy "pandaproxy_api_tls" (coalesce nil)) -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $pandaProxy "pandaproxy_api_tls" $tls) -}}
+{{- end -}}
+{{- (dict "r" $pandaProxy) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.pandaProxyListenersTLS" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $pp := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $values.tls.enabled $values.listeners.http.tls $values.tls.certs) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $pp = (mustAppend $pp $internal) -}}
+{{- end -}}
+{{- range $k, $l := $values.listeners.http.external -}}
+{{- if (not (get (fromJson (include "redpanda.isListenerTLSCfgAvailable" (dict "a" (list $l.enabled (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $l.tls) ))) "r") $values.listeners.http.tls.enabled $values.tls.enabled $values.listeners.http.tls.cert (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.tls.certs) ))) "r")) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.listeners.http.tls.cert) ))) "r") -}}
+{{- $pp = (mustAppend $pp (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $values.tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $pp) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.schemaRegistry" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $schemaReg := (dict ) -}}
+{{- $_ := (set $schemaReg "schema_registry_api" (get (fromJson (include "redpanda.SchemaRegistryListeners.Listeners" (dict "a" (list $values.listeners.schemaRegistry (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
+{{- $tls := (get (fromJson (include "redpanda.schemaRegistryListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- $_ := (set $schemaReg "schema_registry_api_tls" (coalesce nil)) -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $schemaReg "schema_registry_api_tls" $tls) -}}
+{{- end -}}
+{{- (dict "r" $schemaReg) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.schemaRegistryListenersTLS" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $sr := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $values.tls.enabled $values.listeners.schemaRegistry.tls $values.tls.certs) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $sr = (mustAppend $sr $internal) -}}
+{{- end -}}
+{{- range $k, $l := $values.listeners.schemaRegistry.external -}}
+{{- if (not (get (fromJson (include "redpanda.isListenerTLSCfgAvailable" (dict "a" (list $l.enabled (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $l.tls) ))) "r") $values.listeners.schemaRegistry.tls.enabled $values.tls.enabled $values.listeners.schemaRegistry.tls.cert (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.tls.certs) ))) "r")) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.listeners.schemaRegistry.tls.cert) ))) "r") -}}
+{{- $sr = (mustAppend $sr (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $values.tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $sr) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.isListenerTLSCfgAvailable" -}}
+{{- $listenerEnabled := (index .a 0) -}}
+{{- $listenerTLSEnabled := (index .a 1) -}}
+{{- $internalTLSEnabled := (index .a 2) -}}
+{{- $globalTLSEnabled := (index .a 3) -}}
+{{- $internalCertName := (index .a 4) -}}
+{{- $listenerCertName := (index .a 5) -}}
+{{- $certMap := (index .a 6) -}}
+{{- range $_ := (list 1) -}}
+{{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listenerEnabled true) ))) "r")) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listenerTLSEnabled true) ))) "r")) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (and (and (eq $listenerTLSEnabled (coalesce nil)) (ne $internalTLSEnabled (coalesce nil))) (not $internalTLSEnabled)) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (and (and (eq $listenerTLSEnabled (coalesce nil)) (eq $internalTLSEnabled (coalesce nil))) (not $globalTLSEnabled)) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $certName := $internalCertName -}}
+{{- if (ne $listenerCertName (coalesce nil)) -}}
+{{- $certName = $listenerCertName -}}
+{{- end -}}
+{{- $tmp_tuple_5 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $certMap $certName (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_5.T2 -}}
+{{- (dict "r" $ok) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.rpcListenersTLS" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $r := $values.listeners.rpc -}}
+{{- if (and (eq $r.tls.enabled (coalesce nil)) (not $values.tls.enabled)) -}}
+{{- (dict "r" (dict )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (and (ne $r.tls.enabled (coalesce nil)) (not $r.tls.enabled)) -}}
+{{- if (not $values.tls.enabled) -}}
+{{- (dict "r" (dict )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- $certName := $r.tls.cert -}}
+{{- if (eq $certName "") -}}
+{{- (dict "r" (dict )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (dict "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" $r.tls.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $values.tls.certs $certName) ))) "r") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.rpcListeners" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- (dict "r" (dict "address" "0.0.0.0" "port" ($values.listeners.rpc.port | int) )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.kafkaListenersTLS" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $kafka := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $values.tls.enabled $values.listeners.kafka.tls $values.tls.certs) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $kafka = (mustAppend $kafka $internal) -}}
+{{- end -}}
+{{- range $k, $l := $values.listeners.kafka.external -}}
+{{- if (not (get (fromJson (include "redpanda.isListenerTLSCfgAvailable" (dict "a" (list $l.enabled (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $l.tls) ))) "r") $values.listeners.kafka.tls.enabled $values.tls.enabled $values.listeners.kafka.tls.cert (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.tls.certs) ))) "r")) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.listeners.kafka.tls.cert) ))) "r") -}}
+{{- $kafka = (mustAppend $kafka (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $values.tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $kafka) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.getCertificate" -}}
+{{- $certs := (index .a 0) -}}
+{{- $certName := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $defaultTruststorePath := "/etc/ssl/certs/ca-certificates.crt" -}}
+{{- if (eq $certs (coalesce nil)) -}}
+{{- $_ := (fail "TLS map is not defined") -}}
+{{- end -}}
+{{- if (eq $certName "") -}}
+{{- (dict "r" $defaultTruststorePath) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $c := $certs -}}
+{{- $tmp_tuple_6 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $c $certName (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_10 := $tmp_tuple_6.T2 -}}
+{{- $crt_9 := $tmp_tuple_6.T1 -}}
+{{- if (and $ok_10 $crt_9.caEnabled) -}}
+{{- (dict "r" (printf "/etc/tls/certs/%s/ca.crt" $certName)) | toJson -}}
+{{- break -}}
+{{- else -}}{{- if (not $ok_10) -}}
+{{- $_ := (fail (printf "Certificate name reference (%s) defined in listener, but not found in the tls.certs map" $certName)) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $defaultTruststorePath) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.kafkaListeners" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $kf := $values.listeners.kafka -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerCfg" (dict "a" (list ($values.listeners.kafka.port | int)) ))) "r") -}}
+{{- if (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") -}}
+{{- $_ := (set $internal "authentication_method" "sasl") -}}
+{{- end -}}
+{{- $am_11 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $kf.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_11 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_11) -}}
+{{- end -}}
+{{- $kafka := (list $internal) -}}
+{{- range $k, $l := $kf.external -}}
+{{- if (not ((and (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.enabled true) ))) "r") (gt (($l.port | int) | int) (0 | int))))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $listener := (dict "name" $k "port" ($l.port | int) "address" "0.0.0.0" ) -}}
+{{- if (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") -}}
+{{- $_ := (set $listener "authentication_method" "sasl") -}}
+{{- end -}}
+{{- $am_12 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_12 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_12) -}}
+{{- end -}}
+{{- $kafka = (mustAppend $kafka $listener) -}}
+{{- end -}}
+{{- (dict "r" $kafka) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.adminListenersTLS" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $admin := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $values.tls.enabled $values.listeners.admin.tls $values.tls.certs) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $admin = (mustAppend $admin $internal) -}}
+{{- end -}}
+{{- range $k, $l := $values.listeners.admin.external -}}
+{{- if (not (get (fromJson (include "redpanda.isListenerTLSCfgAvailable" (dict "a" (list $l.enabled (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $l.tls) ))) "r") $values.listeners.admin.tls.enabled $values.tls.enabled $values.listeners.admin.tls.cert (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.tls.certs) ))) "r")) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $l.tls) ))) "r") $values.listeners.admin.tls.cert) ))) "r") -}}
+{{- $admin = (mustAppend $admin (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $values.tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $admin) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.isInternalListenerTLSAvailable" -}}
+{{- $defaultTLSEnabled := (index .a 0) -}}
+{{- $externalTLS := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (eq $externalTLS.enabled (coalesce nil)) (not $defaultTLSEnabled)) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (and (ne $externalTLS.enabled (coalesce nil)) (not $externalTLS.enabled)) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (eq $externalTLS.cert "") -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.createInternalListenerTLSCfg" -}}
+{{- $defaultTLSEnabled := (index .a 0) -}}
+{{- $externalTLS := (index .a 1) -}}
+{{- $certs := (index .a 2) -}}
+{{- range $_ := (list 1) -}}
+{{- if (not (get (fromJson (include "redpanda.isInternalListenerTLSAvailable" (dict "a" (list $defaultTLSEnabled $externalTLS) ))) "r")) -}}
+{{- (dict "r" (dict )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (dict "name" "internal" "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $externalTLS.cert) "key_file" (printf "/etc/tls/certs/%s/tls.key" $externalTLS.cert) "require_client_auth" $externalTLS.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $certs $externalTLS.cert) ))) "r") )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.createInternalListenerCfg" -}}
+{{- $port := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (dict "name" "internal" "address" "0.0.0.0" "port" $port )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.adminListeners" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $admin := (list (get (fromJson (include "redpanda.createInternalListenerCfg" (dict "a" (list ($values.listeners.admin.port | int)) ))) "r")) -}}
+{{- range $k, $l := $values.listeners.admin.external -}}
+{{- if (not ((and (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.enabled true) ))) "r") (gt (($l.port | int) | int) (0 | int))))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $admin = (mustAppend $admin (dict "name" $k "port" ($l.port | int) "address" "0.0.0.0" )) -}}
+{{- end -}}
+{{- (dict "r" $admin) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda.RedpandaAdditionalStartFlags" -}}
 {{- $dot := (index .a 0) -}}
 {{- $smp := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $chartFlags := (dict "smp" $smp "memory" (printf "%dM" (((get (fromJson (include "redpanda.RedpandaMemory" (dict "a" (list $dot) ))) "r") | int) | int)) "reserve-memory" (printf "%dM" (((get (fromJson (include "redpanda.RedpandaReserveMemory" (dict "a" (list $dot) ))) "r") | int) | int)) "default-log-level" $values.logging.logLevel ) -}}
+{{- $chartFlags := (dict "smp" (printf "%d" ($smp | int)) "memory" (printf "%dM" (((get (fromJson (include "redpanda.RedpandaMemory" (dict "a" (list $dot) ))) "r") | int) | int)) "reserve-memory" (printf "%dM" (((get (fromJson (include "redpanda.RedpandaReserveMemory" (dict "a" (list $dot) ))) "r") | int) | int)) "default-log-level" $values.logging.logLevel ) -}}
 {{- if (eq (index $values.config.node "developer_mode") true) -}}
 {{- $_ := (unset $chartFlags "reserve-memory") -}}
 {{- end -}}

--- a/charts/redpanda/templates/_post-install-upgrade-job.go.tpl
+++ b/charts/redpanda/templates/_post-install-upgrade-job.go.tpl
@@ -13,14 +13,11 @@
 {{- $envars = (mustAppend $envars (mustMergeOverwrite (dict "name" "" ) (dict "name" "REDPANDA_LICENSE" "valueFrom" (mustMergeOverwrite (dict ) (dict "secretKeyRef" $secretReference_2 )) ))) -}}
 {{- end -}}
 {{- end -}}
-{{- $tieredStorageConfig := $values.storage.tiered.config -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $values.storage.tieredConfig) ))) "r") | int) (0 | int)) -}}
-{{- $tieredStorageConfig = $values.storage.tieredConfig -}}
-{{- end -}}
-{{- if (not (get (fromJson (include "redpanda.IsTieredStorageEnabled" (dict "a" (list $tieredStorageConfig) ))) "r")) -}}
+{{- if (not (get (fromJson (include "redpanda.Storage.IsTieredStorageEnabled" (dict "a" (list $values.storage) ))) "r")) -}}
 {{- (dict "r" $envars) | toJson -}}
 {{- break -}}
 {{- end -}}
+{{- $tieredStorageConfig := (get (fromJson (include "redpanda.Storage.GetTieredStorageConfig" (dict "a" (list $values.storage) ))) "r") -}}
 {{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $tieredStorageConfig "cloud_storage_azure_container" (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $azureContainerExists := $tmp_tuple_1.T2 -}}
 {{- $ac := $tmp_tuple_1.T1 -}}
@@ -150,21 +147,6 @@
 {{- end -}}
 {{- end -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}
-{{- break -}}
-{{- end -}}
-{{- end -}}
-
-{{- define "redpanda.IsTieredStorageEnabled" -}}
-{{- $tieredStorageConfig := (index .a 0) -}}
-{{- range $_ := (list 1) -}}
-{{- $tmp_tuple_8 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $tieredStorageConfig "cloud_storage_enabled" (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- $ok_17 := $tmp_tuple_8.T2 -}}
-{{- $b_16 := $tmp_tuple_8.T1 -}}
-{{- if (and $ok_17 (get (fromJson (include "_shims.typeassertion" (dict "a" (list "bool" $b_16) ))) "r")) -}}
-{{- (dict "r" true) | toJson -}}
-{{- break -}}
-{{- end -}}
-{{- (dict "r" false) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/templates/configmap.yaml
+++ b/charts/redpanda/templates/configmap.yaml
@@ -14,29 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "redpanda.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
-data: {{ include "full-configmap" . | nindent 2 }}
-
-{{- if .Values.external.enabled }}
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ include "redpanda.fullname" . }}-rpk
-  namespace: {{ .Release.Namespace | quote }}
-  labels:
-{{- with include "full.labels" . }}
-  {{- . | nindent 4 }}
-{{- end }}
-data:
-  profile: | {{ include "rpk-config-external" . | nindent 4 }}
-{{- end }}
+{{- $cms := (get ((include "redpanda.ConfigMap" (dict "a" (list .))) | fromJson) "r") -}}
+{{- range $cm := $cms -}}
+{{ printf "\n---" }}
+{{toYaml $cm}}
+{{- end -}}

--- a/charts/redpanda/templates/service.nodeport.go.tpl
+++ b/charts/redpanda/templates/service.nodeport.go.tpl
@@ -14,7 +14,7 @@
 {{- end -}}
 {{- $ports := (list ) -}}
 {{- range $name, $listener := $values.listeners.admin.external -}}
-{{- if (and (ne $listener.enabled (coalesce nil)) (not $listener.enabled)) -}}
+{{- if (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
 {{- $nodePort := ($listener.port | int) -}}
@@ -24,7 +24,7 @@
 {{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "admin-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.kafka.external -}}
-{{- if (and (ne $listener.enabled (coalesce nil)) (not $listener.enabled)) -}}
+{{- if (not (get (fromJson (include "redpanda.KafkaExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
 {{- $nodePort := ($listener.port | int) -}}
@@ -34,7 +34,7 @@
 {{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "kafka-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.http.external -}}
-{{- if (and (ne $listener.enabled (coalesce nil)) (not $listener.enabled)) -}}
+{{- if (not (get (fromJson (include "redpanda.HTTPExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
 {{- $nodePort := ($listener.port | int) -}}
@@ -44,7 +44,7 @@
 {{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "http-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.schemaRegistry.external -}}
-{{- if (and (ne $listener.enabled (coalesce nil)) (not $listener.enabled)) -}}
+{{- if (not (get (fromJson (include "redpanda.SchemaRegistryExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
 {{- $nodePort := ($listener.port | int) -}}

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -1,0 +1,433 @@
+{{- /* Generated from "values.go" */ -}}
+
+{{- define "redpanda.AuditLogging.Translate" -}}
+{{- $a := (index .a 0) -}}
+{{- $dot := (index .a 1) -}}
+{{- $isSASLEnabled := (index .a 2) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- if (not (get (fromJson (include "redpanda.RedpandaAtLeast_23_3_0" (dict "a" (list $dot) ))) "r")) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $enabled := (and $a.enabled $isSASLEnabled) -}}
+{{- $_ := (set $result "audit_enabled" $enabled) -}}
+{{- if (not $enabled) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (ne (($a.clientMaxBufferSize | int) | int) (16777216 | int)) -}}
+{{- $_ := (set $result "audit_client_max_buffer_size" ($a.clientMaxBufferSize | int)) -}}
+{{- end -}}
+{{- if (ne (($a.queueDrainIntervalMs | int) | int) (500 | int)) -}}
+{{- $_ := (set $result "audit_queue_drain_interval_ms" ($a.queueDrainIntervalMs | int)) -}}
+{{- end -}}
+{{- if (ne (($a.queueMaxBufferSizePerShard | int) | int) (1048576 | int)) -}}
+{{- $_ := (set $result "audit_queue_max_buffer_size_per_shard" ($a.queueMaxBufferSizePerShard | int)) -}}
+{{- end -}}
+{{- if (ne (($a.partitions | int) | int) (12 | int)) -}}
+{{- $_ := (set $result "audit_log_num_partitions" ($a.partitions | int)) -}}
+{{- end -}}
+{{- if (ne ($a.replicationFactor | int) (0 | int)) -}}
+{{- $_ := (set $result "audit_log_replication_factor" ($a.replicationFactor | int)) -}}
+{{- end -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $a.enabledEventTypes) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $result "audit_enabled_event_types" $a.enabledEventTypes) -}}
+{{- end -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $a.excludedTopics) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $result "audit_excluded_topics" $a.excludedTopics) -}}
+{{- end -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $a.excludedPrincipals) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $result "audit_excluded_principals" $a.excludedPrincipals) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Auth.IsSASLEnabled" -}}
+{{- $a := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (eq $a.sasl (coalesce nil)) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $a.sasl.enabled) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Auth.Translate" -}}
+{{- $a := (index .a 0) -}}
+{{- $isSASLEnabled := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- if (or (eq $a.sasl (coalesce nil)) (not $isSASLEnabled)) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (eq ((get (fromJson (include "_shims.len" (dict "a" (list $a.sasl.users) ))) "r") | int) (0 | int)) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $users := (list ) -}}
+{{- range $_, $u := $a.sasl.users -}}
+{{- $users = (mustAppend $users $u.name) -}}
+{{- end -}}
+{{- $_ := (set $result "superusers" $users) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Logging.Translate" -}}
+{{- $l := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- $clusterID_1 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.usageStats.clusterId "") ))) "r") -}}
+{{- if (ne $clusterID_1 "") -}}
+{{- $_ := (set $result "cluster_id" $clusterID_1) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Storage.Translate" -}}
+{{- $s := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- if (not (get (fromJson (include "redpanda.Storage.IsTieredStorageEnabled" (dict "a" (list $s) ))) "r")) -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $tieredStorageConfig := (get (fromJson (include "redpanda.Storage.GetTieredStorageConfig" (dict "a" (list $s) ))) "r") -}}
+{{- range $k, $v := $tieredStorageConfig -}}
+{{- if (or (eq $v (coalesce nil)) (empty $v)) -}}
+{{- continue -}}
+{{- end -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "string" $v "") ))) "r")) ))) "r") -}}
+{{- $isStr_3 := $tmp_tuple_3.T2 -}}
+{{- $asStr_2 := $tmp_tuple_3.T1 -}}
+{{- if (and (and (eq $k "cloud_storage_cache_size") $isStr_3) (ne $asStr_2 "")) -}}
+{{- $_ := (set $result $k (toJson ((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $v) ))) "r")) ))) "r") | int))) -}}
+{{- continue -}}
+{{- end -}}
+{{- if (eq $k "cloud_storage_cache_size") -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "string" $v "") ))) "r")) ))) "r") -}}
+{{- $isStr_5 := $tmp_tuple_4.T2 -}}
+{{- $str_4 := $tmp_tuple_4.T1 -}}
+{{- $tmp_tuple_5 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $isFloat_7 := $tmp_tuple_5.T2 -}}
+{{- $f_6 := ($tmp_tuple_5.T1 | float64) -}}
+{{- if (and $isStr_5 (ne $str_4 "")) -}}
+{{- $_ := (set $result $k (toJson ((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list $str_4) ))) "r") | int))) -}}
+{{- else -}}{{- if $isFloat_7 -}}
+{{- $_ := (set $result $k (toJson ((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list (toString ($f_6 | int))) ))) "r") | int))) -}}
+{{- end -}}
+{{- end -}}
+{{- continue -}}
+{{- end -}}
+{{- $tmp_tuple_6 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "string" $v "") ))) "r")) ))) "r") -}}
+{{- $ok_9 := $tmp_tuple_6.T2 -}}
+{{- $str_8 := $tmp_tuple_6.T1 -}}
+{{- $tmp_tuple_7 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
+{{- $ok_11 := $tmp_tuple_7.T2 -}}
+{{- $b_10 := $tmp_tuple_7.T1 -}}
+{{- $tmp_tuple_8 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $isFloat_13 := $tmp_tuple_8.T2 -}}
+{{- $f_12 := ($tmp_tuple_8.T1 | float64) -}}
+{{- if $ok_9 -}}
+{{- $_ := (set $result $k $str_8) -}}
+{{- else -}}{{- if $ok_11 -}}
+{{- $_ := (set $result $k $b_10) -}}
+{{- else -}}{{- if $isFloat_13 -}}
+{{- $_ := (set $result $k ($f_12 | int)) -}}
+{{- else -}}
+{{- $_ := (set $result $k (mustToJson $v)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Storage.IsTieredStorageEnabled" -}}
+{{- $s := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $conf := (get (fromJson (include "redpanda.Storage.GetTieredStorageConfig" (dict "a" (list $s) ))) "r") -}}
+{{- $tmp_tuple_9 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $conf "cloud_storage_enabled" (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_9.T2 -}}
+{{- $b := $tmp_tuple_9.T1 -}}
+{{- (dict "r" (and $ok (get (fromJson (include "_shims.typeassertion" (dict "a" (list "bool" $b) ))) "r"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Storage.GetTieredStorageConfig" -}}
+{{- $s := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := $s.tiered.config -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $s.tieredConfig) ))) "r") | int) (0 | int)) -}}
+{{- $result = $s.tieredConfig -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Storage.StorageMinFreeBytes" -}}
+{{- $s := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (and (ne $s.persistentVolume (coalesce nil)) (not $s.persistentVolume.enabled)) -}}
+{{- (dict "r" (5368709120 | int)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $minimumFreeBytes := ((mulf (((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list (toString $s.persistentVolume.size)) ))) "r") | int) | float64) 0.05) | float64) -}}
+{{- (dict "r" (min (5368709120 | int) ($minimumFreeBytes | int))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Tuning.Translate" -}}
+{{- $t := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- $s := (toJson $t) -}}
+{{- $tune := (fromJson $s) -}}
+{{- $tmp_tuple_11 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $tune (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_11.T2 -}}
+{{- $m := $tmp_tuple_11.T1 -}}
+{{- if (not $ok) -}}
+{{- (dict "r" (dict )) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- range $k, $v := $m -}}
+{{- $_ := (set $result $k $v) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Listeners.CreateSeedServers" -}}
+{{- $l := (index .a 0) -}}
+{{- $replicas := (index .a 1) -}}
+{{- $fullname := (index .a 2) -}}
+{{- $internalDomain := (index .a 3) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (list ) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) ($replicas|int) (1|int) -}}
+{{- $result = (mustAppend $result (dict "host" (dict "address" (printf "%s-%d.%s" $fullname $i $internalDomain) "port" ($l.rpc.port | int) ) )) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Listeners.AdminList" -}}
+{{- $l := (index .a 0) -}}
+{{- $replicas := (index .a 1) -}}
+{{- $fullname := (index .a 2) -}}
+{{- $internalDomain := (index .a 3) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (list ) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) ($replicas|int) (1|int) -}}
+{{- $result = (mustAppend $result (printf "%s-%d.%s:%d" $fullname $i $internalDomain (($l.admin.port | int) | int))) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Config.CreateRPKConfiguration" -}}
+{{- $c := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- range $k, $v := $c.rpk -}}
+{{- $_ := (set $result $k $v) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.HTTPListeners.Listeners" -}}
+{{- $l := (index .a 0) -}}
+{{- $saslEnabled := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerCfg" (dict "a" (list ($l.port | int)) ))) "r") -}}
+{{- if $saslEnabled -}}
+{{- $_ := (set $internal "authentication_method" "http_basic") -}}
+{{- end -}}
+{{- $am_14 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_14 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_14) -}}
+{{- end -}}
+{{- $result := (list $internal) -}}
+{{- range $k, $l := $l.external -}}
+{{- if (not ((and (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.enabled true) ))) "r") (gt (($l.port | int) | int) (0 | int))))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $listener := (dict "name" $k "port" ($l.port | int) "address" "0.0.0.0" ) -}}
+{{- if $saslEnabled -}}
+{{- $_ := (set $listener "authentication_method" "http_basic") -}}
+{{- end -}}
+{{- $am_15 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_15 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_15) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $listener) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.ExternalTLS.IsEnabled" -}}
+{{- $e := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (eq $e (coalesce nil)) -}}
+{{- (dict "r" false) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $e.enabled) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.ExternalTLS.GetCert" -}}
+{{- $e := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (eq $e (coalesce nil)) -}}
+{{- (dict "r" (coalesce nil)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" $e.cert) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.SchemaRegistryListeners.Listeners" -}}
+{{- $sr := (index .a 0) -}}
+{{- $saslEnabled := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerCfg" (dict "a" (list ($sr.port | int)) ))) "r") -}}
+{{- if $saslEnabled -}}
+{{- $_ := (set $internal "authentication_method" "http_basic") -}}
+{{- end -}}
+{{- $am_16 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $sr.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_16 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_16) -}}
+{{- end -}}
+{{- $result := (list $internal) -}}
+{{- range $k, $l := $sr.external -}}
+{{- if (not ((and (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.enabled true) ))) "r") (gt (($l.port | int) | int) (0 | int))))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $listener := (dict "name" $k "port" ($l.port | int) "address" "0.0.0.0" ) -}}
+{{- if $saslEnabled -}}
+{{- $_ := (set $listener "authentication_method" "http_basic") -}}
+{{- end -}}
+{{- $am_17 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_17 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_17) -}}
+{{- end -}}
+{{- $result = (mustAppend $result $listener) -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.TunableConfig.Translate" -}}
+{{- $c := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (eq $c (coalesce nil)) -}}
+{{- (dict "r" (coalesce nil)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- $result := (dict ) -}}
+{{- range $k, $v := $c -}}
+{{- if (not (empty $v)) -}}
+{{- $_ := (set $result $k $v) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.NodeConfig.Translate" -}}
+{{- $c := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- range $k, $v := $c -}}
+{{- if (not (empty $v)) -}}
+{{- $_ := (set $result $k (toYaml $v)) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.ClusterConfig.Translate" -}}
+{{- $c := (index .a 0) -}}
+{{- $replicas := (index .a 1) -}}
+{{- $skipDefaultTopic := (index .a 2) -}}
+{{- range $_ := (list 1) -}}
+{{- $result := (dict ) -}}
+{{- range $k, $v := $c -}}
+{{- if (and (eq $k "default_topic_replications") (not $skipDefaultTopic)) -}}
+{{- $r := ($replicas | int) -}}
+{{- $input := ($r | int) -}}
+{{- $tmp_tuple_16 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_19 := $tmp_tuple_16.T2 -}}
+{{- $num_18 := ($tmp_tuple_16.T1 | int) -}}
+{{- if $ok_19 -}}
+{{- $input = $num_18 -}}
+{{- end -}}
+{{- $tmp_tuple_17 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_21 := $tmp_tuple_17.T2 -}}
+{{- $f_20 := ($tmp_tuple_17.T1 | float64) -}}
+{{- if $ok_21 -}}
+{{- $input = ($f_20 | int) -}}
+{{- end -}}
+{{- $_ := (set $result $k (min $input ((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $tmp_tuple_18 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
+{{- $ok_23 := $tmp_tuple_18.T2 -}}
+{{- $b_22 := $tmp_tuple_18.T1 -}}
+{{- if $ok_23 -}}
+{{- $_ := (set $result $k $b_22) -}}
+{{- continue -}}
+{{- end -}}
+{{- if (not (empty $v)) -}}
+{{- $_ := (set $result $k $v) -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.TieredStorageCredentials.IsAccessKeyReferenceValid" -}}
+{{- $tsc := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (and (and (ne $tsc.accessKey (coalesce nil)) (ne $tsc.accessKey.name "")) (ne $tsc.accessKey.key ""))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.TieredStorageCredentials.IsSecretKeyReferenceValid" -}}
+{{- $tsc := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (and (and (ne $tsc.secretKey (coalesce nil)) (ne $tsc.secretKey.name "")) (ne $tsc.secretKey.key ""))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -311,6 +311,42 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "redpanda.AdminListeners.Listeners" -}}
+{{- $l := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $admin := (list (get (fromJson (include "redpanda.createInternalListenerCfg" (dict "a" (list ($l.port | int)) ))) "r")) -}}
+{{- range $k, $lis := $l.external -}}
+{{- if (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) -}}
+{{- continue -}}
+{{- end -}}
+{{- $admin = (mustAppend $admin (dict "name" $k "port" ($lis.port | int) "address" "0.0.0.0" )) -}}
+{{- end -}}
+{{- (dict "r" $admin) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.AdminListeners.ListenersTLS" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $admin := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $admin = (mustAppend $admin $internal) -}}
+{{- end -}}
+{{- range $k, $lis := $l.external -}}
+{{- if (or (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
+{{- $admin = (mustAppend $admin (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $admin) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda.AdminExternal.IsEnabled" -}}
 {{- $l := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
@@ -351,10 +387,84 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "redpanda.HTTPListeners.ListenersTLS" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $pp := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $pp = (mustAppend $pp $internal) -}}
+{{- end -}}
+{{- range $k, $lis := $l.external -}}
+{{- if (or (not (get (fromJson (include "redpanda.HTTPExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
+{{- $pp = (mustAppend $pp (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $pp) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda.HTTPExternal.IsEnabled" -}}
 {{- $l := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (and (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.enabled true) ))) "r") (gt ($l.port | int) (0 | int)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.KafkaListeners.Listeners" -}}
+{{- $l := (index .a 0) -}}
+{{- $auth := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerCfg" (dict "a" (list ($l.port | int)) ))) "r") -}}
+{{- if (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $auth) ))) "r") -}}
+{{- $_ := (set $internal "authentication_method" "sasl") -}}
+{{- end -}}
+{{- $am_16 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_16 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_16) -}}
+{{- end -}}
+{{- $kafka := (list $internal) -}}
+{{- range $k, $l := $l.external -}}
+{{- if (not (get (fromJson (include "redpanda.KafkaExternal.IsEnabled" (dict "a" (list $l) ))) "r")) -}}
+{{- continue -}}
+{{- end -}}
+{{- $listener := (dict "name" $k "port" ($l.port | int) "address" "0.0.0.0" ) -}}
+{{- if (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $auth) ))) "r") -}}
+{{- $_ := (set $listener "authentication_method" "sasl") -}}
+{{- end -}}
+{{- $am_17 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_17 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_17) -}}
+{{- end -}}
+{{- $kafka = (mustAppend $kafka $listener) -}}
+{{- end -}}
+{{- (dict "r" $kafka) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.KafkaListeners.ListenersTLS" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $kafka := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $kafka = (mustAppend $kafka $internal) -}}
+{{- end -}}
+{{- range $k, $lis := $l.external -}}
+{{- if (or (not (get (fromJson (include "redpanda.KafkaExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
+{{- $kafka = (mustAppend $kafka (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $kafka) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -375,9 +485,9 @@
 {{- if $saslEnabled -}}
 {{- $_ := (set $internal "authentication_method" "http_basic") -}}
 {{- end -}}
-{{- $am_16 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $sr.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_16 "") -}}
-{{- $_ := (set $internal "authentication_method" $am_16) -}}
+{{- $am_18 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $sr.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_18 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_18) -}}
 {{- end -}}
 {{- $result := (list $internal) -}}
 {{- range $k, $l := $sr.external -}}
@@ -388,13 +498,34 @@
 {{- if $saslEnabled -}}
 {{- $_ := (set $listener "authentication_method" "http_basic") -}}
 {{- end -}}
-{{- $am_17 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_17 "") -}}
-{{- $_ := (set $listener "authentication_method" $am_17) -}}
+{{- $am_19 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_19 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_19) -}}
 {{- end -}}
 {{- $result = (mustAppend $result $listener) -}}
 {{- end -}}
 {{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.SchemaRegistryListeners.ListenersTLS" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $listeners := (list ) -}}
+{{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
+{{- $listeners = (mustAppend $listeners $internal) -}}
+{{- end -}}
+{{- range $k, $lis := $l.external -}}
+{{- if (or (not (get (fromJson (include "redpanda.SchemaRegistryExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
+{{- $listeners = (mustAppend $listeners (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.getCertificate" (dict "a" (list $tls.certs $certName) ))) "r") )) -}}
+{{- end -}}
+{{- (dict "r" $listeners) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -450,25 +581,25 @@
 {{- $r := ($replicas | int) -}}
 {{- $input := ($r | int) -}}
 {{- $tmp_tuple_17 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_19 := $tmp_tuple_17.T2 -}}
-{{- $num_18 := ($tmp_tuple_17.T1 | int) -}}
-{{- if $ok_19 -}}
-{{- $input = $num_18 -}}
+{{- $ok_21 := $tmp_tuple_17.T2 -}}
+{{- $num_20 := ($tmp_tuple_17.T1 | int) -}}
+{{- if $ok_21 -}}
+{{- $input = $num_20 -}}
 {{- end -}}
 {{- $tmp_tuple_18 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_21 := $tmp_tuple_18.T2 -}}
-{{- $f_20 := ($tmp_tuple_18.T1 | float64) -}}
-{{- if $ok_21 -}}
-{{- $input = ($f_20 | int) -}}
+{{- $ok_23 := $tmp_tuple_18.T2 -}}
+{{- $f_22 := ($tmp_tuple_18.T1 | float64) -}}
+{{- if $ok_23 -}}
+{{- $input = ($f_22 | int) -}}
 {{- end -}}
 {{- $_ := (set $result $k (min $input ((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $tmp_tuple_19 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
-{{- $ok_23 := $tmp_tuple_19.T2 -}}
-{{- $b_22 := $tmp_tuple_19.T1 -}}
-{{- if $ok_23 -}}
-{{- $_ := (set $result $k $b_22) -}}
+{{- $ok_25 := $tmp_tuple_19.T2 -}}
+{{- $b_24 := $tmp_tuple_19.T1 -}}
+{{- if $ok_25 -}}
+{{- $_ := (set $result $k $b_24) -}}
 {{- continue -}}
 {{- end -}}
 {{- if (not (empty $v)) -}}

--- a/charts/redpanda/testdata/ci/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/01-default-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -218,144 +218,113 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-    testlabel: exercise_common_labels_template
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 1
-    retention_local_target_ms_default: 21600000
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 1
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
+    retention_local_target_ms_default: 21600000
     storage_min_free_bytes: 161061273
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      retention_local_target_ms_default: 21600000
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 161061273
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-  
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls: null
     pandaproxy_client:
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls: null
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-        tls:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls: null
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      retention_local_target_ms_default: 21600000
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 161061273
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-        tls:
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls: null
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls: null
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls: null
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
@@ -363,17 +332,34 @@ metadata:
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
     testlabel: exercise_common_labels_template
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-      tls:
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-      tls:
+      addresses:
+      - redpanda-0:31644
+      tls: null
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      tls: null
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+    testlabel: exercise_common_labels_template
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -214,228 +214,214 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 1
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 1
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 161061273
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 161061273
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 161061273
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
+      addresses:
+      - redpanda-0:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -323,167 +323,154 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: true
-    enable_sasl: true
-    enable_rack_awareness: false
-    superusers: 
-      - admin
-          
-    default_topic_replications: 1
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 1
+    enable_rack_awareness: false
+    enable_sasl: true
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: true
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 161061273
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    superusers:
+    - admin
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: true
-      enable_sasl: true
-      superusers: ["admin"]
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 161061273
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-          authentication_method: sasl
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-          authentication_method: sasl
-      kafka_api_tls:
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-          authentication_method: http_basic
-      schema_registry_api_tls:
-  
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8083
+      pandaproxy_api_tls: null
     pandaproxy_client:
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-          authentication_method: http_basic
-      pandaproxy_api_tls:
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls: null
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: true
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-        tls:
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: default
+        port: 9094
+      kafka_api_tls: null
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: true
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 161061273
+      superusers:
+      - admin
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-        tls:
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls: null
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls: null
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8084
+      schema_registry_api_tls: null
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-      tls:
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-      tls:
+      addresses:
+      - redpanda-0:31644
+      tls: null
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      tls: null
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -323,248 +323,234 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: true
-    enable_sasl: true
-    enable_rack_awareness: false
-    superusers: 
-      - admins
-          
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
+    compacted_log_segment_size: 67108864
     default_topic_replications: 1
-        
+    enable_rack_awareness: false
+    enable_sasl: true
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: true
     kafka_nodelete_topics:
     - audit
     - consumer_offsets
     - _schemas
     - my_sample_topic
-    
-    compacted_log_segment_size: 67108864
-    group_topic_partitions: 16
-    kafka_batch_max_bytes: 1048576
-    kafka_connection_rate_limit: 1000
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 161061273
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    superusers:
+    - admins
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: true
-      enable_sasl: true
-      superusers: ["admins"]
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
       default_topic_replications: 3
-      kafka_nodelete_topics: 
+      empty_seed_starts_cluster: false
+      enable_sasl: true
+      group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: true
+      kafka_nodelete_topics:
       - audit
       - consumer_offsets
       - _schemas
       - my_sample_topic
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 161061273
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-          authentication_method: sasl
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-          authentication_method: sasl
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 161061273
+      superusers:
+      - admins
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-          authentication_method: http_basic
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-          authentication_method: http_basic
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
+      addresses:
+      - redpanda-0:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
@@ -244,157 +244,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -402,92 +432,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
@@ -277,163 +277,52 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-        - name: ext2
-          address: 0.0.0.0
-          port: 19094
-        - name: ext3
-          address: 0.0.0.0
-          port: 29094
-      kafka_api_tls:
-        - name: ext2
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: ext3
-          enabled: true
-          cert_file: /etc/tls/certs/cert2/tls.crt
-          key_file: /etc/tls/certs/cert2/tls.key
-          require_client_auth: true
-          
-          truststore_file: /etc/ssl/certs/ca-certificates.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      - address: 0.0.0.0
+        name: ext2
+        port: 18083
+      - address: 0.0.0.0
+        name: ext3
+        port: 28083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
         enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
         key_file: /etc/tls/certs/default/tls.key
+        name: ext2
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-        - name: ext2
-          address: 0.0.0.0
-          port: 18081
-        - name: ext3
-          address: 0.0.0.0
-          port: 28081
-      schema_registry_api_tls:
-        - name: ext2
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: ext3
-          enabled: true
-          cert_file: /etc/tls/certs/cert2/tls.crt
-          key_file: /etc/tls/certs/cert2/tls.key
-          require_client_auth: true
-          truststore_file: /etc/ssl/certs/ca-certificates.crt
-  
+      - cert_file: /etc/tls/certs/cert2/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/cert2/tls.key
+        name: ext3
+        require_client_auth: true
+        truststore_file: /etc/ssl/certs/ca-certificates.crt
     pandaproxy_client:
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
@@ -442,90 +331,186 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-        - name: ext2
-          address: 0.0.0.0
-          port: 18083
-        - name: ext3
-          address: 0.0.0.0
-          port: 28083
-      pandaproxy_api_tls:
-        - name: ext2
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: ext3
-          enabled: true
-          cert_file: /etc/tls/certs/cert2/tls.crt
-          key_file: /etc/tls/certs/cert2/tls.key
-          require_client_auth: true
-          truststore_file: /etc/ssl/certs/ca-certificates.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      - address: 0.0.0.0
+        name: ext2
+        port: 19094
+      - address: 0.0.0.0
+        name: ext3
+        port: 29094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: ext2
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/cert2/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/cert2/tls.key
+        name: ext3
+        require_client_auth: true
+        truststore_file: /etc/ssl/certs/ca-certificates.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls: null
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      - address: 0.0.0.0
+        name: ext2
+        port: 18081
+      - address: 0.0.0.0
+        name: ext3
+        port: 28081
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: ext2
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/cert2/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/cert2/tls.key
+        name: ext3
+        require_client_auth: true
+        truststore_file: /etc/ssl/certs/ca-certificates.crt
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls: null
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
@@ -279,157 +279,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -437,92 +467,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-1.my-domain:31092
-          - 127.0.0.1.my-domain:31092
-          - 192.168.0.1.my-domain:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-1.my-domain:31644
-          - 127.0.0.1.my-domain:31644
-          - 192.168.0.1.my-domain:31644
+      addresses:
+      - redpanda-1.my-domain:31644
+      - 127.0.0.1.my-domain:31644
+      - 192.168.0.1.my-domain:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-1.my-domain:31092
+      - 127.0.0.1.my-domain:31092
+      - 192.168.0.1.my-domain:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
@@ -337,167 +337,203 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: true
-    enable_sasl: true
-    enable_rack_awareness: false
-    superusers: 
-      - admin
-      - user1
-      - someuser
-      - anotherme
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: true
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: true
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    superusers:
+    - admin
+    - user1
+    - someuser
+    - anotherme
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: true
-      enable_sasl: true
-      superusers: ["admin","user1","someuser","anotherme"]
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: true
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: true
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-          authentication_method: sasl
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-          authentication_method: sasl
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      superusers:
+      - admin
+      - user1
+      - someuser
+      - anotherme
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-          authentication_method: http_basic
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -505,94 +541,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-          authentication_method: http_basic
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0.random-domain:30090
-          - redpanda-1.random-domain:30090
-          - redpanda-2.random-domain:30090
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0.random-domain:31644
-          - redpanda-1.random-domain:31644
-          - redpanda-2.random-domain:31644
+      addresses:
+      - redpanda-0.random-domain:31644
+      - redpanda-1.random-domain:31644
+      - redpanda-2.random-domain:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0.random-domain:30090
+      - redpanda-1.random-domain:30090
+      - redpanda-2.random-domain:30090
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0.random-domain:31092
-          - redpanda-1.random-domain:31092
-          - redpanda-2.random-domain:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0.random-domain:31644
-          - redpanda-1.random-domain:31644
-          - redpanda-2.random-domain:31644
+      addresses:
+      - redpanda-0.random-domain:31644
+      - redpanda-1.random-domain:31644
+      - redpanda-2.random-domain:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0.random-domain:31092
+      - redpanda-1.random-domain:31092
+      - redpanda-2.random-domain:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
@@ -225,108 +225,34 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-  
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls: null
     pandaproxy_client:
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
@@ -335,70 +261,130 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls: null
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls: null
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls: null
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls: null
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls: null
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
-      tls:
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
+      tls: null
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls: null
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2000M
+      - --reserve-memory=0M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2000M
-        - --reserve-memory=0M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - $PREFIX_TEMPLATE.my-domain:31092
-          - $PREFIX_TEMPLATE.my-domain:31092
-          - $PREFIX_TEMPLATE.my-domain:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - $PREFIX_TEMPLATE.my-domain:31644
-          - $PREFIX_TEMPLATE.my-domain:31644
-          - $PREFIX_TEMPLATE.my-domain:31644
+      addresses:
+      - $PREFIX_TEMPLATE.my-domain:31644
+      - $PREFIX_TEMPLATE.my-domain:31644
+      - $PREFIX_TEMPLATE.my-domain:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - $PREFIX_TEMPLATE.my-domain:31092
+      - $PREFIX_TEMPLATE.my-domain:31092
+      - $PREFIX_TEMPLATE.my-domain:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: ${AWS_ACCESS_KEY_ID}
     cloud_storage_bucket: ${TEST_BUCKET}
     cloud_storage_cache_size: "5368709120"
@@ -395,137 +300,218 @@ data:
     cloud_storage_region: ${AWS_REGION}
     cloud_storage_secret_key: ${AWS_SECRET_ACCESS_KEY}
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
     cloud_storage_api_endpoint: storage.googleapis.com
     cloud_storage_bucket: ${TEST_BUCKET}
@@ -396,137 +301,218 @@ data:
     cloud_storage_region: US-WEST1
     cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
     cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
@@ -394,137 +299,218 @@ data:
     cloud_storage_enable_remote_write: true
     cloud_storage_enabled: true
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -225,119 +225,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
     cloud_storage_azure_storage_account: TestForStringThatShouldNotBeWrappedWithQuotes
@@ -347,137 +252,218 @@ data:
     cloud_storage_enable_remote_write: true
     cloud_storage_enabled: true
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: ${AWS_ACCESS_KEY_ID}
     cloud_storage_bucket: ${TEST_BUCKET}
     cloud_storage_cache_size: "5368709120"
@@ -395,137 +300,218 @@ data:
     cloud_storage_region: ${AWS_REGION}
     cloud_storage_secret_key: ${AWS_SECRET_ACCESS_KEY}
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
     cloud_storage_api_endpoint: storage.googleapis.com
     cloud_storage_bucket: ${TEST_BUCKET}
@@ -396,137 +301,218 @@ data:
     cloud_storage_region: US-WEST1
     cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
     cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
@@ -394,137 +299,218 @@ data:
     cloud_storage_enable_remote_write: true
     cloud_storage_enabled: true
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -225,119 +225,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
     cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
@@ -347,137 +252,218 @@ data:
     cloud_storage_enable_remote_write: true
     cloud_storage_enabled: true
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: ${AWS_ACCESS_KEY_ID}
     cloud_storage_bucket: ${TEST_BUCKET}
     cloud_storage_cache_size: "5368709120"
@@ -395,137 +300,218 @@ data:
     cloud_storage_region: ${AWS_REGION}
     cloud_storage_secret_key: ${AWS_SECRET_ACCESS_KEY}
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: ${GCP_ACCESS_KEY_ID}
     cloud_storage_api_endpoint: storage.googleapis.com
     cloud_storage_bucket: ${TEST_BUCKET}
@@ -396,137 +301,218 @@ data:
     cloud_storage_region: US-WEST1
     cloud_storage_secret_key: ${GCP_SECRET_ACCESS_KEY}
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -272,119 +272,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
     cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
@@ -394,137 +299,218 @@ data:
     cloud_storage_enable_remote_write: true
     cloud_storage_enabled: true
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -225,119 +225,24 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_azure_container: ${TEST_STORAGE_CONTAINER}
     cloud_storage_azure_shared_key: ${TEST_AZURE_SHARED_KEY}
     cloud_storage_azure_storage_account: ${TEST_STORAGE_ACCOUNT}
@@ -347,137 +252,218 @@ data:
     cloud_storage_enable_remote_write: true
     cloud_storage_enabled: true
     cloud_storage_segment_max_upload_interval_sec: 1
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=1024M
-        - --reserve-memory=100M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=1024M
+      - --reserve-memory=100M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --smp=99
+      - --reserve-memory=9999
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --smp=99
-        - --reserve-memory=9999
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
@@ -295,149 +295,40 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-        - name: ext2
-          address: 0.0.0.0
-          port: 22229
-        - name: ext3
-          address: 0.0.0.0
-          port: 33339
-      kafka_api_tls:
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-3.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-3.redpanda.default.svc.cluster.local.
-        port: 9093
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      - address: 0.0.0.0
+        name: ext4
+        port: 44449
+      - address: 0.0.0.0
+        name: ext5
+        port: 55559
+      pandaproxy_api_tls: null
     pandaproxy_client:
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
@@ -448,82 +339,177 @@ data:
         port: 9093
       - address: redpanda-3.redpanda.default.svc.cluster.local.
         port: 9093
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-        - name: ext4
-          address: 0.0.0.0
-          port: 44449
-        - name: ext5
-          address: 0.0.0.0
-          port: 55559
-      pandaproxy_api_tls:
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-          - redpanda-3.redpanda.default.svc.cluster.local.:9093
-        tls:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      - address: 0.0.0.0
+        name: ext2
+        port: 22229
+      - address: 0.0.0.0
+        name: ext3
+        port: 33339
+      kafka_api_tls: null
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-3.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-          - redpanda-3.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        - redpanda-3.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        - redpanda-3.redpanda.default.svc.cluster.local.:9093
+        tls: null
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-3.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-          - redpanda-3:31092
-      tls:
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
-          - redpanda-3:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
+      - redpanda-3:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      - redpanda-3:31092
+      tls: null
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
@@ -228,157 +228,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -386,92 +416,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
@@ -279,157 +279,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -437,92 +467,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
@@ -381,164 +381,27 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
+data:
+  bootstrap.yaml: |-
+    audit_enabled: true
     cluster_id: cluster-id-test
-    kafka_enable_authorization: true
-    enable_sasl: true
-    enable_rack_awareness: false
-    superusers: 
-      - admin
-          
-    default_topic_replications: 3
-    
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: true
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: true
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: true
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      cluster_id: cluster-id-test
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: true
-      enable_sasl: true
-      superusers: ["admin"]
-      default_topic_replications: 3
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: true
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-          authentication_method: sasl
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-          authentication_method: sasl
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-          authentication_method: http_basic
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
+    superusers:
+    - admin
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     audit_log_client:
       broker_tls:
         cert_file: /etc/tls/certs/default/tls.crt
@@ -553,8 +416,37 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-  
+    config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
     pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -562,94 +454,189 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
         enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
         key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-          authentication_method: http_basic
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-          authentication_method: http_basic
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: true
+      cluster_id: cluster-id-test
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: true
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        authentication_method: sasl
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: true
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      superusers:
+      - admin
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        authentication_method: http_basic
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
@@ -272,157 +272,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -430,92 +460,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -225,121 +225,25 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
+    compacted_log_segment_size: 67108864
     default_topic_replications: 3
     enable_idempotence: false
-    
-    compacted_log_segment_size: 67108864
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
-    config_file: /etc/redpanda/redpanda.yaml
-    redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
-      enable_idempotence: false
-      compacted_log_segment_size: 67108864
-      group_topic_partitions: 16
-      kafka_batch_max_bytes: 1048576
-      kafka_connection_rate_limit: 1000
-      log_segment_size: 134217728
-      log_segment_size_max: 268435456
-      log_segment_size_min: 16777216
-      max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      rpc_server:
-        address: 0.0.0.0
-        port: 33145
-      rpc_server_tls:
-        enabled: true
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        require_client_auth: false
-        truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     cloud_storage_access_key: test
     cloud_storage_bucket: test
     cloud_storage_cache_size: "11000000000"
@@ -349,137 +253,219 @@ data:
     cloud_storage_enabled: true
     cloud_storage_region: test
     cloud_storage_secret_key: test
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    schema_registry:
-      schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
-      schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+    config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
       pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_idempotence: false
+      enable_sasl: false
+      group_topic_partitions: 16
       kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
       admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
@@ -225,153 +225,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -379,92 +411,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
@@ -272,153 +272,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -426,92 +458,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
@@ -231,153 +231,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -385,92 +417,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
@@ -225,155 +225,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -381,92 +411,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
@@ -272,155 +272,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -428,92 +458,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
@@ -231,155 +231,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -387,92 +417,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
@@ -225,155 +225,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -381,92 +411,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
@@ -272,155 +272,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -428,92 +458,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
@@ -231,155 +231,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -387,92 +417,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
@@ -225,155 +225,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -381,92 +411,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
@@ -272,155 +272,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -428,92 +458,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
@@ -231,155 +231,185 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -387,92 +417,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
@@ -272,157 +272,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -430,92 +460,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
@@ -231,157 +231,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -389,92 +419,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
@@ -272,157 +272,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -430,92 +460,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
@@ -231,157 +231,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -389,92 +419,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
@@ -225,157 +225,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 7777
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 99999
     log_segment_size_min: 100
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 7777
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 99999
       log_segment_size_min: 100
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -383,92 +413,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
@@ -272,157 +272,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: false
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -430,92 +460,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
@@ -231,157 +231,187 @@ stringData:
 ---
 # Source: redpanda/templates/configmap.yaml
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda
-  namespace: "default"
-  labels:
-    app.kubernetes.io/component: redpanda
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/managed-by: Helm
-    app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.8
-data: 
-  
-  bootstrap.yaml: |
-    kafka_enable_authorization: false
-    enable_sasl: false
-    enable_rack_awareness: true
-          
-    default_topic_replications: 3
-    
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
     compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: true
+    enable_sasl: false
     group_topic_partitions: 16
     kafka_batch_max_bytes: 1048576
     kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
     log_segment_size: 134217728
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    topic_partitions_per_shard: 1000
     storage_min_free_bytes: 1073741824
-  
-    audit_enabled: false
-  
-  redpanda.yaml: |
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
     redpanda:
-      empty_seed_starts_cluster: false
-      kafka_enable_authorization: false
-      enable_sasl: false
-      default_topic_replications: 3
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
       compacted_log_segment_size: 67108864
+      crash_loop_limit: "5"
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
       group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
       log_segment_size: 134217728
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      topic_partitions_per_shard: 1000
-      storage_min_free_bytes: 1073741824
-        
-      crash_loop_limit: "5"
-      audit_enabled: false
-  
-  
-      admin:
-        - name: internal
-          address: 0.0.0.0
-          port: 9644
-        - name: default
-          address: 0.0.0.0
-          port: 9645
-      admin_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-      kafka_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 9093
-        - name: default
-          address: 0.0.0.0
-          port: 9094
-      kafka_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
       rpc_server:
         address: 0.0.0.0
         port: 33145
       rpc_server_tls:
-        enabled: true
         cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
         key_file: /etc/tls/certs/default/tls.key
         require_client_auth: false
         truststore_file: /etc/tls/certs/default/ca.crt
-      seed_servers: 
-        - host:
-            address: redpanda-0.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-1.redpanda.default.svc.cluster.local.
-            port: 33145
-        - host:
-            address: redpanda-2.redpanda.default.svc.cluster.local.
-            port: 33145
-  
-    schema_registry_client:
-      brokers:
-      - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-1.redpanda.default.svc.cluster.local.
-        port: 9093
-      - address: redpanda-2.redpanda.default.svc.cluster.local.
-        port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
     schema_registry:
       schema_registry_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8081
-        - name: default
-          address: 0.0.0.0
-          port: 8084
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
       schema_registry_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    pandaproxy_client:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
         port: 9093
@@ -389,92 +419,48 @@ data:
         port: 9093
       - address: redpanda-2.redpanda.default.svc.cluster.local.
         port: 9093
-      broker_tls:
-        enabled: true
-        require_client_auth: false
-        cert_file: /etc/tls/certs/default/tls.crt
-        key_file: /etc/tls/certs/default/tls.key
-        truststore_file: /etc/tls/certs/default/ca.crt
-    pandaproxy:
-      pandaproxy_api:
-        - name: internal
-          address: 0.0.0.0
-          port: 8082
-        - name: default
-          address: 0.0.0.0
-          port: 8083
-      pandaproxy_api_tls:
-        - name: internal
-          enabled: true
-          cert_file: /etc/tls/certs/default/tls.crt
-          key_file: /etc/tls/certs/default/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/default/ca.crt
-        - name: default
-          enabled: true
-          cert_file: /etc/tls/certs/external/tls.crt
-          key_file: /etc/tls/certs/external/tls.key
-          require_client_auth: false
-          truststore_file: /etc/tls/certs/external/ca.crt
-  
-    
-    rpk:
-      # redpanda server configuration
-      overprovisioned: false
-      enable_memory_locking: false
-      additional_start_flags:
-        - --default-log-level=info
-        - --memory=2048M
-        - --reserve-memory=205M
-        - --smp=1
-      # rpk tune entries
-      tune_aio_events: true
-    
-      # kafka connection configuration
-      kafka_api:
-        brokers: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9093
-          - redpanda-1.redpanda.default.svc.cluster.local.:9093
-          - redpanda-2.redpanda.default.svc.cluster.local.:9093
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
-      admin_api:
-        addresses: 
-          - redpanda-0.redpanda.default.svc.cluster.local.:9644
-          - redpanda-1.redpanda.default.svc.cluster.local.:9644
-          - redpanda-2.redpanda.default.svc.cluster.local.:9644
-        tls:
-          truststore_file: /etc/tls/certs/default/ca.crt
----
-# Source: redpanda/templates/configmap.yaml
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: redpanda-rpk
-  namespace: "default"
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.8
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
 data:
-  profile: | 
-    name: default
-    kafka_api:
-      brokers: 
-          - redpanda-0:31092
-          - redpanda-1:31092
-          - redpanda-2:31092
-      tls:
-        ca_file: ca.crt
+  profile: |-
     admin_api:
-      addresses: 
-          - redpanda-0:31644
-          - redpanda-1:31644
-          - redpanda-2:31644
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls:
         ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.8
+  name: redpanda-rpk
+  namespace: default
 ---
 # Source: redpanda/templates/console/configmap-and-deployment.yaml
 ---

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -386,6 +386,20 @@
                     },
                     "port": {
                       "type": "integer"
+                    },
+                    "tls": {
+                      "properties": {
+                        "cert": {
+                          "type": "string"
+                        },
+                        "enabled": {
+                          "type": "boolean"
+                        },
+                        "requireClientAuth": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
                     }
                   },
                   "required": [
@@ -792,8 +806,14 @@
         },
         "usageStats": {
           "properties": {
+            "clusterId": {
+              "type": "string"
+            },
             "enabled": {
               "type": "boolean"
+            },
+            "organization": {
+              "type": "string"
             }
           },
           "required": [
@@ -1895,7 +1915,6 @@
           "type": "string"
         },
         "persistentVolume": {
-          "deprecated": true,
           "properties": {
             "annotations": {
               "additionalProperties": {
@@ -2129,7 +2148,6 @@
           "type": "object"
         },
         "tieredConfig": {
-          "deprecated": true,
           "properties": {
             "cloud_storage_access_key": {
               "type": "string"
@@ -2227,14 +2245,17 @@
               "type": "integer"
             }
           },
+          "required": [
+            "cloud_storage_enabled",
+            "cloud_storage_bucket",
+            "cloud_storage_region"
+          ],
           "type": "object"
         },
         "tieredStorageHostPath": {
-          "deprecated": true,
           "type": "string"
         },
         "tieredStoragePersistentVolume": {
-          "deprecated": true,
           "properties": {
             "annotations": {
               "additionalProperties": {

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -392,16 +392,12 @@ type PartialPandaProxyClient struct {
 }
 
 type PartialTLSCert struct {
-	Enabled               *bool                     `json:"enabled,omitempty"`
-	CAEnabled             *bool                     `json:"caEnabled,omitempty" jsonschema:"required"`
-	ApplyInternalDNSNames *bool                     `json:"applyInternalDNSNames,omitempty"`
-	Duration              *string                   `json:"duration,omitempty" jsonschema:"pattern=.*[smh]$"`
-	IssuerRef             *cmmeta.ObjectReference   `json:"issuerRef,omitempty"`
-	SecretRef             *PartialNameOnlySecretRef `json:"secretRef,omitempty"`
-}
-
-type PartialNameOnlySecretRef struct {
-	Name *string `json:"name,omitempty"`
+	Enabled               *bool                        `json:"enabled,omitempty"`
+	CAEnabled             *bool                        `json:"caEnabled,omitempty" jsonschema:"required"`
+	ApplyInternalDNSNames *bool                        `json:"applyInternalDNSNames,omitempty"`
+	Duration              *string                      `json:"duration,omitempty" jsonschema:"pattern=.*[smh]$"`
+	IssuerRef             *cmmeta.ObjectReference      `json:"issuerRef,omitempty"`
+	SecretRef             *corev1.LocalObjectReference `json:"secretRef,omitempty"`
 }
 
 type PartialTLSCertMap map[string]PartialTLSCert
@@ -420,14 +416,14 @@ type PartialSASLAuth struct {
 }
 
 type PartialInternalTLS struct {
-	Cert              *string `json:"cert,omitempty" jsonschema:"required"`
 	Enabled           *bool   `json:"enabled,omitempty"`
+	Cert              *string `json:"cert,omitempty" jsonschema:"required"`
 	RequireClientAuth *bool   `json:"requireClientAuth,omitempty" jsonschema:"required"`
 }
 
 type PartialExternalTLS struct {
-	Cert              *string `json:"cert,omitempty"`
 	Enabled           *bool   `json:"enabled,omitempty"`
+	Cert              *string `json:"cert,omitempty"`
 	RequireClientAuth *bool   `json:"requireClientAuth,omitempty"`
 }
 

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -135,7 +135,9 @@ type PartialExternalConfig struct {
 type PartialLogging struct {
 	LogLevel    *string `json:"logLevel,omitempty" jsonschema:"required,pattern=^(error|warn|info|debug|trace)$"`
 	UseageStats struct {
-		Enabled *bool `json:"enabled,omitempty" jsonschema:"required"`
+		Enabled      *bool   `json:"enabled,omitempty" jsonschema:"required"`
+		Organization *string `json:"organization,omitempty"`
+		ClusterID    *string `json:"clusterId,omitempty"`
 	} `json:"usageStats,omitempty" jsonschema:"required"`
 }
 
@@ -436,9 +438,10 @@ type PartialAdminListeners struct {
 }
 
 type PartialAdminExternal struct {
-	AdvertisedPorts []int32 `json:"advertisedPorts,omitempty" jsonschema:"minItems=1"`
-	Enabled         *bool   `json:"enabled,omitempty"`
-	Port            *int32  `json:"port,omitempty" jsonschema:"required"`
+	AdvertisedPorts []int32             `json:"advertisedPorts,omitempty" jsonschema:"minItems=1"`
+	Enabled         *bool               `json:"enabled,omitempty"`
+	Port            *int32              `json:"port,omitempty" jsonschema:"required"`
+	TLS             *PartialExternalTLS `json:"tls,omitempty"`
 }
 
 type PartialHTTPListeners struct {

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -17,20 +17,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// ToYAML is the go equivalent of helm's `toYaml`.
-//
-// Reference
-// https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L51
-// https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L78-L89
-// +gotohelm:builtin=toYaml
-func ToYaml(value any) string {
-	marshalled, err := yaml.Marshal(value)
-	if err != nil {
-		return ""
-	}
-	return string(marshalled)
-}
-
 // Min is the go equivalent of sprig's `min`
 // +gotohelm:builtin=min
 func Min(in ...int) int {
@@ -327,4 +313,24 @@ func ToString(input any) string {
 func SemverCompare(constraint, version string) (bool, error) {
 	fn := sprig.FuncMap()["semverCompare"].(func(string, string) (bool, error))
 	return fn(constraint, version)
+}
+
+// +gotohelm:builtin=regexReplaceAll
+func RegexReplaceAll(regex, s, repl string) string {
+	r := regexp.MustCompile(regex)
+	return r.ReplaceAllString(s, repl)
+}
+
+// ToYAML is the go equivalent of helm's `toYaml`.
+//
+// Reference
+// https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L51
+// https://github.com/helm/helm/blob/e90b456d655e78d7c72a32a52a9b70bc1984c33f/pkg/engine/funcs.go#L78-L89
+// +gotohelm:builtin=toYaml
+func ToYaml(value any) string {
+	marshalled, err := yaml.Marshal(value)
+	if err != nil {
+		return ""
+	}
+	return string(marshalled)
 }

--- a/pkg/gotohelm/rewrite.go
+++ b/pkg/gotohelm/rewrite.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"go/types"
+	"strings"
 
 	"github.com/cockroachdb/errors"
 
@@ -143,10 +144,18 @@ func typeToNode(pkg *packages.Package, typ types.Type) ast.Expr {
 
 	expr, err := parser.ParseExpr(s)
 	if err != nil {
-		panic(err)
+		panic(fmt.Sprintf("pkg errors (%s): %v", JoinPackagesErrors(pkg.Errors), err))
 	}
 
 	return expr
+}
+
+func JoinPackagesErrors[T error](errors []T) string {
+	result := []string{}
+	for _, e := range errors {
+		result = append(result, e.Error())
+	}
+	return strings.Join(result, "; ")
 }
 
 // rewriteMultiValueReturns rewrites instances of multi-value returns into an

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -207,40 +207,40 @@ func binaryExprs() []bool {
 	return result
 }
 
-func forExpr(interation int) [][]string {
+func forExpr(iteration int) [][]string {
 	result := [][]string{}
 
 	// ["0","1","2","3","4","5","6","7","8","9"]
 	test := []string{}
-	for i := 0; i < interation; i++ {
+	for i := 0; i < iteration; i++ {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// ["2","3","4","5","6","7","8","9"]
 	test = []string{}
-	for i := 2; i < interation; i++ {
+	for i := 2; i < iteration; i++ {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// ["2","4","6","8"]
 	test = []string{}
-	for i := 2; i < interation; i += 2 {
+	for i := 2; i < iteration; i += 2 {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// ["17","15","13","11"]
 	test = []string{}
-	for i := 17; i > interation; i -= 2 {
+	for i := 17; i > iteration; i -= 2 {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// This for loop is noop as the condition should be greater than. The test array will be empty.
 	test = []string{}
-	for i := 17; i < interation; i -= 2 {
+	for i := 17; i < iteration; i -= 2 {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -210,40 +210,40 @@ func binaryExprs() []bool {
 	return result
 }
 
-func forExpr(interation int) [][]string {
+func forExpr(iteration int) [][]string {
 	result := [][]string{}
 
 	// ["0","1","2","3","4","5","6","7","8","9"]
 	test := []string{}
-	for i := 0; i < interation; i++ {
+	for i := 0; i < iteration; i++ {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// ["2","3","4","5","6","7","8","9"]
 	test = []string{}
-	for i := 2; i < interation; i++ {
+	for i := 2; i < iteration; i++ {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// ["2","4","6","8"]
 	test = []string{}
-	for i := 2; i < interation; i += 2 {
+	for i := 2; i < iteration; i += 2 {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// ["17","15","13","11"]
 	test = []string{}
-	for i := 17; i > interation; i -= 2 {
+	for i := 17; i > iteration; i -= 2 {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)
 
 	// This for loop is noop as the condition should be greater than. The test array will be empty.
 	test = []string{}
-	for i := 17; i < interation; i -= 2 {
+	for i := 17; i < iteration; i -= 2 {
 		test = append(test, fmt.Sprintf("%d", i))
 	}
 	result = append(result, test)

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -163,31 +163,31 @@
 {{- end -}}
 
 {{- define "syntax.forExpr" -}}
-{{- $interation := (index .a 0) -}}
+{{- $iteration := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $result := (list ) -}}
 {{- $test := (list ) -}}
-{{- range $_, $i := untilStep ((0 | int)|int) ($interation|int) (1|int) -}}
+{{- range $_, $i := untilStep ((0 | int)|int) ($iteration|int) (1|int) -}}
 {{- $test = (mustAppend $test (printf "%d" $i)) -}}
 {{- end -}}
 {{- $result = (mustAppend $result $test) -}}
 {{- $test = (list ) -}}
-{{- range $_, $i := untilStep ((2 | int)|int) ($interation|int) (1|int) -}}
+{{- range $_, $i := untilStep ((2 | int)|int) ($iteration|int) (1|int) -}}
 {{- $test = (mustAppend $test (printf "%d" $i)) -}}
 {{- end -}}
 {{- $result = (mustAppend $result $test) -}}
 {{- $test = (list ) -}}
-{{- range $_, $i := untilStep ((2 | int)|int) ($interation|int) ((2 | int)|int) -}}
+{{- range $_, $i := untilStep ((2 | int)|int) ($iteration|int) ((2 | int)|int) -}}
 {{- $test = (mustAppend $test (printf "%d" $i)) -}}
 {{- end -}}
 {{- $result = (mustAppend $result $test) -}}
 {{- $test = (list ) -}}
-{{- range $_, $i := untilStep ((17 | int)|int) ($interation|int) ((-2 | int)|int) -}}
+{{- range $_, $i := untilStep ((17 | int)|int) ($iteration|int) ((-2 | int)|int) -}}
 {{- $test = (mustAppend $test (printf "%d" $i)) -}}
 {{- end -}}
 {{- $result = (mustAppend $result $test) -}}
 {{- $test = (list ) -}}
-{{- range $_, $i := untilStep ($interation|int) ((17 | int)|int) ((-2 | int)|int) -}}
+{{- range $_, $i := untilStep ($iteration|int) ((17 | int)|int) ((-2 | int)|int) -}}
 {{- $test = (mustAppend $test (printf "%d" $i)) -}}
 {{- end -}}
 {{- $result = (mustAppend $result $test) -}}

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -137,6 +137,10 @@ func (t *Transpiler) transpileFile(f *ast.File) *File {
 		}
 
 		funcDirectives := parseDirectives(fn.Doc.Text())
+		if v, ok := funcDirectives["skip"]; ok && v == "true" {
+			continue
+		}
+
 		// To not clash with the same method name in the same package
 		// which can be declared in multiple struct the package and function
 		// name could be separated with the name of the struct type.
@@ -379,26 +383,48 @@ func (t *Transpiler) transpileStatement(stmt ast.Stmt) Node {
 		if b, ok := stmt.Cond.(*ast.BinaryExpr); ok {
 			switch b.Op {
 			case token.LSS, token.LEQ:
-				if declaration, ok := b.X.(*ast.Ident).Obj.Decl.(*ast.AssignStmt); ok {
-					start = t.transpileExpr(declaration.Rhs[0])
-				} else {
+				if _, ok := b.X.(*ast.SelectorExpr); ok {
 					start = t.transpileExpr(b.X)
-				}
-				if declaration, ok := b.Y.(*ast.Ident).Obj.Decl.(*ast.AssignStmt); ok {
-					stop = t.transpileExpr(declaration.Rhs[0])
 				} else {
+					switch declaration := b.X.(*ast.Ident).Obj.Decl.(type) {
+					case *ast.AssignStmt:
+						start = t.transpileExpr(declaration.Rhs[0])
+					case *ast.Field:
+						start = t.transpileExpr(declaration.Names[0])
+					}
+				}
+
+				if _, ok := b.Y.(*ast.SelectorExpr); ok {
 					stop = t.transpileExpr(b.Y)
+				} else {
+					switch declaration := b.Y.(*ast.Ident).Obj.Decl.(type) {
+					case *ast.AssignStmt:
+						stop = t.transpileExpr(declaration.Rhs[0])
+					case *ast.Field:
+						stop = t.transpileExpr(declaration.Names[0])
+					}
 				}
 			case token.GTR, token.GEQ:
-				if declaration, ok := b.X.(*ast.Ident).Obj.Decl.(*ast.AssignStmt); ok {
-					stop = t.transpileExpr(declaration.Rhs[0])
-				} else {
+				if _, ok := b.X.(*ast.SelectorExpr); ok {
 					stop = t.transpileExpr(b.X)
-				}
-				if declaration, ok := b.Y.(*ast.Ident).Obj.Decl.(*ast.AssignStmt); ok {
-					start = t.transpileExpr(declaration.Rhs[0])
 				} else {
+					switch declaration := b.X.(*ast.Ident).Obj.Decl.(type) {
+					case *ast.AssignStmt:
+						stop = t.transpileExpr(declaration.Rhs[0])
+					case *ast.Field:
+						stop = t.transpileExpr(declaration.Names[0])
+					}
+				}
+
+				if _, ok := b.Y.(*ast.SelectorExpr); ok {
 					start = t.transpileExpr(b.Y)
+				} else {
+					switch declaration := b.Y.(*ast.Ident).Obj.Decl.(type) {
+					case *ast.AssignStmt:
+						start = t.transpileExpr(declaration.Rhs[0])
+					case *ast.Field:
+						start = t.transpileExpr(declaration.Names[0])
+					}
 				}
 			default:
 				panic(&Unsupported{
@@ -438,6 +464,13 @@ func (t *Transpiler) transpileStatement(stmt ast.Stmt) Node {
 			})
 		}
 
+		if stop == nil || start == nil || step == nil {
+			panic(&Unsupported{
+				Node: stmt,
+				Fset: t.Fset,
+				Msg:  fmt.Sprintf("start: %v; stop: %v; step: %v", start, stop, step),
+			})
+		}
 		return &Range{
 			Key:   &Ident{Name: "_"},
 			Value: &Literal{Value: fmt.Sprintf("$%s", stmt.Init.(*ast.AssignStmt).Lhs[0].(*ast.Ident).Name)},
@@ -1022,6 +1055,14 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.Merge":
 		dict := DictLiteral{}
 		return &BuiltInCall{FuncName: "merge", Arguments: append([]Node{&dict}, args...)}
+	case "gopkg.in/yaml.v3.Marshal":
+		return &BuiltInCall{
+			FuncName: "list",
+			Arguments: []Node{
+				&BuiltInCall{FuncName: "toYaml", Arguments: args},
+				&Literal{Value: "nil"},
+			},
+		}
 
 	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.Lookup":
 		// Super ugly but it's fairly safe to assume that the return type of


### PR DESCRIPTION
These two commits encapsulate some of the more difficult checks of `Enabled` fields and migrates most config generation onto the listener structs. This is in preparation for allowing customization of the `truststore_file`.