### PR TITLE
Handle overprovisioned flag based on CPU values

### DIFF
--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -94,6 +94,10 @@
 {{- define "redpanda.RedpandaResources.GetOverProvisionValue" -}}
 {{- $rr := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
+{{- if (lt ((get (fromJson (include "redpanda.RedpandaResources.RedpandaCoresInMillis" (dict "a" (list $rr) ))) "r") | int) (1000 | int)) -}}
+{{- (dict "r" true) | toJson -}}
+{{- break -}}
+{{- end -}}
 {{- (dict "r" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $rr.cpu.overprovisioned false) ))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}

--- a/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -440,7 +440,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -837,7 +837,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 1cc7884b92933481a095e466b4f69f7d0ed19947b9482eecbdbb0fd24a2c152e
+        config.redpanda.com/checksum: d401e46afc7979d910715f333dd94f93090889fa4640c92b2c83952cf842ff6a
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -438,7 +438,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -835,7 +835,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: afd6fd7e69c771954827a10a78e67d558f453f61eb30d40a15be331595c053ed
+        config.redpanda.com/checksum: 90ee0e92d6eb93d675e20940faef0e3b47058da35c89f5a3b9651cb9afb0d859
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -391,7 +391,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -772,7 +772,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 93b6388b695d547c9800b2ff21447974f0fa62e39da08e575cebb3db7dd7d613
+        config.redpanda.com/checksum: 27874e85dd8a9f013b7e585ef5173abc48c3991ad28f4c4f97620250e5812915
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -440,7 +440,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -837,7 +837,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 1cc7884b92933481a095e466b4f69f7d0ed19947b9482eecbdbb0fd24a2c152e
+        config.redpanda.com/checksum: d401e46afc7979d910715f333dd94f93090889fa4640c92b2c83952cf842ff6a
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -438,7 +438,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -835,7 +835,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: afd6fd7e69c771954827a10a78e67d558f453f61eb30d40a15be331595c053ed
+        config.redpanda.com/checksum: 90ee0e92d6eb93d675e20940faef0e3b47058da35c89f5a3b9651cb9afb0d859
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -391,7 +391,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -772,7 +772,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: afd6fd7e69c771954827a10a78e67d558f453f61eb30d40a15be331595c053ed
+        config.redpanda.com/checksum: 90ee0e92d6eb93d675e20940faef0e3b47058da35c89f5a3b9651cb9afb0d859
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -440,7 +440,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -837,7 +837,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 1cc7884b92933481a095e466b4f69f7d0ed19947b9482eecbdbb0fd24a2c152e
+        config.redpanda.com/checksum: d401e46afc7979d910715f333dd94f93090889fa4640c92b2c83952cf842ff6a
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -438,7 +438,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -835,7 +835,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: afd6fd7e69c771954827a10a78e67d558f453f61eb30d40a15be331595c053ed
+        config.redpanda.com/checksum: 90ee0e92d6eb93d675e20940faef0e3b47058da35c89f5a3b9651cb9afb0d859
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -391,7 +391,7 @@ data:
         - redpanda-2.redpanda.default.svc.cluster.local.:9093
         tls:
           truststore_file: /etc/tls/certs/default/ca.crt
-      overprovisioned: false
+      overprovisioned: true
       tune_aio_events: true
     schema_registry:
       schema_registry_api:
@@ -772,7 +772,7 @@ spec:
         helm.sh/chart: redpanda-5.8.8
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: afd6fd7e69c771954827a10a78e67d558f453f61eb30d40a15be331595c053ed
+        config.redpanda.com/checksum: 90ee0e92d6eb93d675e20940faef0e3b47058da35c89f5a3b9651cb9afb0d859
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -345,18 +345,10 @@ type RedpandaResources struct {
 }
 
 func (rr *RedpandaResources) GetOverProvisionValue() bool {
-	// TODO restore this implementation after release.
-	// The RedpandaSMP function can be executed after this function, so that
-	// overprovisoned flag might not be set
-	//if rr.CPU.Overprovisioned == nil {
-	//	return false
-	//}
-	//
-	//if int(rr.RedpandaCoresInMillis()) < 1000 {
-	//	return true
-	//}
-	//
-	//return *rr.CPU.Overprovisioned
+	if int(rr.RedpandaCoresInMillis()) < 1000 {
+		return true
+	}
+
 	return ptr.Deref(rr.CPU.Overprovisioned, false)
 }
 


### PR DESCRIPTION
Overprovisioned till Redpanda chart version 5.8.8 should be
set to `true` when Statefulset CPU request value is bellow 1000 mili cores.

Function `redpanda-smp`, that should overwrite `overprovisioned` flag,
was not called before setting `overprovisioned` flag.

Reference

redpanda-smp template - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_helpers.tpl#L187
redpanda-smp template invocation - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_configmap.tpl#L610
overprovisioned flag - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_configmap.tpl#L607