### PR TITLE
gotohelm: fix namespacing and function name overrides

### DIFF
--- a/pkg/gotohelm/testdata/src/example/directives/directives.go
+++ b/pkg/gotohelm/testdata/src/example/directives/directives.go
@@ -1,5 +1,9 @@
+//+gotohelm:namespace=_directives
 package directives
 
 func Directives() bool {
+	// Calling Noop does nothing but asserts that it's referenced correctly
+	// with the correct namespacing.
+	Noop()
 	return true
 }

--- a/pkg/gotohelm/testdata/src/example/directives/directives.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/directives/directives.rewritten.go
@@ -1,6 +1,10 @@
 //go:build rewrites
+// +gotohelm:namespace=_directives
 package directives
 
 func Directives() bool {
+	// Calling Noop does nothing but asserts that it's referenced correctly
+	// with the correct namespacing.
+	Noop()
 	return true
 }

--- a/pkg/gotohelm/testdata/src/example/directives/directives.yaml
+++ b/pkg/gotohelm/testdata/src/example/directives/directives.yaml
@@ -1,7 +1,8 @@
 {{- /* Generated from "directives.go" */ -}}
 
-{{- define "directives.Directives" -}}
+{{- define "_directives.Directives" -}}
 {{- range $_ := (list 1) -}}
+{{- $_ := (get (fromJson (include "_directives.does-something" (dict "a" (list ) ))) "r") -}}
 {{- (dict "r" true) | toJson -}}
 {{- break -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/directives/overridden.yaml
+++ b/pkg/gotohelm/testdata/src/example/directives/overridden.yaml
@@ -1,6 +1,6 @@
 {{- /* Generated from "nameoverride.go" */ -}}
 
-{{- define "directives.does-something" -}}
+{{- define "_directives.does-something" -}}
 {{- range $_ := (list 1) -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Prior to this commit, there were subtle bugs with both package namespacing and function name overriding that could result in template eval time errors.

This was due to directives only being parsed at the top loop of pkg.Syntax and never being associated with objects later on. The ideal solution would be to factor out a dedicated struct and cache for accessing directive information but a temporary solution is being put in place for now.

The core issue was primarily only noticeable when calling bootstrap functions from other bootstrap functions but a latent issue with name override also existed. This commit adds a namespace and function naming cache that lazily evaluate and cache their results that is now used in place of manually constructing names.