### PR TITLE
gotohelm: add partial support for `resource.Quantity`

### DIFF
--- a/charts/redpanda/templates/_shims.tpl
+++ b/charts/redpanda/templates/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -240,7 +240,7 @@
 {{- break -}}
 {{- end -}}
 {{- $minimumFreeBytes := ((mulf (((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list (toString $s.persistentVolume.size)) ))) "r") | int) | float64) 0.05) | float64) -}}
-{{- (dict "r" (min (5368709120 | int) ($minimumFreeBytes | int))) | toJson -}}
+{{- (dict "r" (min (5368709120 | int) ($minimumFreeBytes | int64))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -672,7 +672,7 @@
 {{- if $ok_29 -}}
 {{- $input = ($f_28 | int) -}}
 {{- end -}}
-{{- $_ := (set $result $k (min $input ((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int))) -}}
+{{- $_ := (set $result $k (min ($input | int64) (((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int) | int64))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $tmp_tuple_24 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -469,14 +469,14 @@ func (s *Storage) Translate() map[string]any {
 	return result
 }
 
-func (s *Storage) StorageMinFreeBytes() int {
+func (s *Storage) StorageMinFreeBytes() int64 {
 	if s.PersistentVolume != nil && !s.PersistentVolume.Enabled {
 		// Five GiB literal
 		return fiveGiB
 	}
 
 	minimumFreeBytes := float64(SIToBytes(string(s.PersistentVolume.Size))) * 0.05
-	return helmette.Min(fiveGiB, int(minimumFreeBytes))
+	return helmette.Min(fiveGiB, int64(minimumFreeBytes))
 }
 
 type PostInstallJob struct {
@@ -1328,7 +1328,7 @@ func (c *ClusterConfig) Translate(replicas int, skipDefaultTopic bool) map[strin
 				input = int(f)
 			}
 
-			result[k] = helmette.Min(input, r+(r%2)-1)
+			result[k] = helmette.Min(int64(input), int64(r+(r%2)-1))
 			continue
 		}
 

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -1505,12 +1505,15 @@
                                       "type": "string"
                                     },
                                     "divisor": {
-                                      "properties": {
-                                        "Format": {
+                                      "oneOf": [
+                                        {
+                                          "type": "integer"
+                                        },
+                                        {
+                                          "pattern": "^[0-9]+(\\.[0-9]){0,1}(m|k|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$",
                                           "type": "string"
                                         }
-                                      },
-                                      "type": "object"
+                                      ]
                                     },
                                     "resource": {
                                       "type": "string"

--- a/cmd/genschema/main.go
+++ b/cmd/genschema/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/redpanda-data/helm-charts/charts/redpanda"
 	"github.com/redpanda-data/helm-charts/pkg/valuesutil"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 )
 
 func Must[T any](value T, err error) T {
@@ -56,6 +57,13 @@ func main() {
 				return &jsonschema.Schema{
 					Type:    "string",
 					Pattern: "^(0|(([0-9]+)y)?(([0-9]+)w)?(([0-9]+)d)?(([0-9]+)h)?(([0-9]+)m)?(([0-9]+)s)?(([0-9]+)ms)?)$",
+				}
+			case *resource.Quantity:
+				return &jsonschema.Schema{
+					OneOf: []*jsonschema.Schema{
+						{Type: "integer"},
+						{Type: "string", Pattern: "^[0-9]+(\\.[0-9]){0,1}(m|k|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$"},
+					},
 				}
 			default:
 				return nil

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -33,8 +33,8 @@ func ToYaml(value any) string {
 
 // Min is the go equivalent of sprig's `min`
 // +gotohelm:builtin=min
-func Min(in ...int) int {
-	result := math.MaxInt
+func Min(in ...int64) int64 {
+	result := int64(math.MaxInt64)
 	for _, i := range in {
 		if i < result {
 			result = i

--- a/pkg/gotohelm/internal/bootstrap/bootstrap.go
+++ b/pkg/gotohelm/internal/bootstrap/bootstrap.go
@@ -22,6 +22,22 @@ import (
 	"fmt"
 )
 
+const (
+	// For reference: https://physics.nist.gov/cuu/Units/binary.html
+	milli = 0.001
+	kilo  = 1000
+	mega  = kilo * kilo
+	giga  = kilo * kilo * kilo
+	terra = kilo * kilo * kilo * kilo
+	peta  = kilo * kilo * kilo * kilo * kilo
+
+	kibi = 1024
+	mebi = kibi * kibi
+	gibi = kibi * kibi * kibi
+	tebi = kibi * kibi * kibi * kibi
+	pebi = kibi * kibi * kibi * kibi * kibi
+)
+
 // typeatest is the implementation of the go syntax `_, _ := m.(t)`.
 func typetest(typ string, value, zero any) []any {
 	if TypeIs(typ, value) {
@@ -64,7 +80,9 @@ func deref(ptr any) any {
 	return ptr
 }
 
-func len(m map[string]any) int {
+// +gotohelm:name=len
+func _len(m any) int {
+	// Handle empty/nil maps and lists as sprig does not.
 	if m == nil {
 		return 0
 	}
@@ -128,4 +146,88 @@ func asintegral(value any) (any, bool) {
 	}
 
 	return 0, false
+}
+
+func parseResource(repr any) (float64, float64) {
+	if TypeIs("float64", repr) {
+		return Float64(repr), 1
+	}
+
+	if !TypeIs("string", repr) {
+		panic(fmt.Sprintf("invalid Quantity expected string or float64 got: %T (%v)", repr, repr))
+	}
+
+	// TODO add an upper bound on the total amount of digits?
+	if !RegexMatch(`^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$`, repr) {
+		// TODO write a longer message about support for quantities.
+		// NB: Negative values are intentionally not supported.
+		panic(fmt.Sprintf("invalid Quantity: %q", repr))
+	}
+
+	// Type cast would work but that relies on bootstrap to work so use sprig
+	// functions.
+	reprStr := ToString(repr)
+
+	unit := RegexFind("(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$", repr)
+
+	numeric := Float64(Substr(0, len(reprStr)-len(unit), reprStr))
+
+	// No switch statements, so index into a map instead.
+	scale, ok := map[string]float64{
+		"":   1,
+		"m":  milli,
+		"k":  kilo,
+		"M":  mega,
+		"G":  giga,
+		"T":  terra,
+		"P":  peta,
+		"Ki": kibi,
+		"Mi": mebi,
+		"Gi": gibi,
+		"Ti": tebi,
+		"Pi": pebi,
+	}[unit]
+	if !ok {
+		panic(fmt.Sprintf("unknown unit: %q", unit))
+	}
+
+	return numeric, scale
+}
+
+// pseudo implementation of k8s.io/apimachinery/pkg/api/resource.MustParse.
+func resource_MustParse(repr any) any {
+	numeric, scale := parseResource(repr)
+
+	// No support for switches or maps with non-string keys.
+	// So we fake a map[float64]string with two slices and a for loop.
+	strs := []string{"", "m", "k", "M", "G", "T", "P", "Ki", "Mi", "Gi", "Ti", "Pi"}
+	scales := []float64{1.0, milli, kilo, mega, giga, terra, peta, kibi, mebi, gibi, tebi, pebi}
+
+	idx := -1
+	for i, s := range scales {
+		if float64(s) == float64(scale) {
+			// Ideally this would be an early return but https://github.com/redpanda-data/helm-charts/issues/1331
+			idx = i
+			break
+		}
+	}
+
+	if idx == -1 {
+		panic(fmt.Sprintf("unknown scale: %v", scale))
+	}
+
+	// NB: ToString is used here because it prints out float64's in a reasonable format.
+	// As far as I can tell, go's Sprintf can't print floats without trailing
+	// zero or truncating precision.
+	return fmt.Sprintf("%s%s", ToString(numeric), strs[idx])
+}
+
+func resource_Value(repr any) int64 {
+	numeric, scale := parseResource(repr)
+	return Int64(Ceil(numeric * scale))
+}
+
+func resource_MilliValue(repr any) int64 {
+	numeric, scale := parseResource(repr)
+	return Int64(Ceil(numeric * 1000 * scale))
 }

--- a/pkg/gotohelm/internal/bootstrap/sprig.go
+++ b/pkg/gotohelm/internal/bootstrap/sprig.go
@@ -43,3 +43,43 @@ func Mulf(any, any) float64 {
 func Floor(any) float64 {
 	panic("not implemented")
 }
+
+// +gotohelm:builtin=ceil
+func Ceil(any) string {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=int
+func Int(any) int {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=int64
+func Int64(any) int64 {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=float64
+func Float64(any) float64 {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=regexMatch
+func RegexMatch(string, any) bool {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=regexFind
+func RegexFind(string, any) string {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=substr
+func Substr(int, int, any) string {
+	panic("not implemented")
+}
+
+// +gotohelm:builtin=toString
+func ToString(any) string {
+	panic("not implemented")
+}

--- a/pkg/gotohelm/testdata/src/example/astrewrites/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/astrewrites/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/changing_inputs/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/directives/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/directives/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/flowcontrol/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/flowcontrol/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/go.mod
+++ b/pkg/gotohelm/testdata/src/example/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cockroachdb/errors v1.11.1 // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect
 	github.com/cockroachdb/redact v1.1.5 // indirect
@@ -34,10 +36,12 @@ require (
 	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.16 // indirect
+	github.com/invopop/jsonschema v0.12.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mitchellh/copystructure v1.2.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
@@ -51,9 +55,11 @@ require (
 	github.com/onsi/gomega v1.31.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect
+	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/spf13/cast v1.5.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	golang.org/x/crypto v0.23.0 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/oauth2 v0.15.0 // indirect

--- a/pkg/gotohelm/testdata/src/example/go.sum
+++ b/pkg/gotohelm/testdata/src/example/go.sum
@@ -7,6 +7,10 @@ github.com/Masterminds/sprig/v3 v3.2.3 h1:eL2fZNezLomi0uOLqjQoN6BfsDD+fyLtgbJMAj
 github.com/Masterminds/sprig/v3 v3.2.3/go.mod h1:rXcFaZ2zZbLRJv/xSysmlgIM1u11eBaRMhvYXJNkGuM=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cockroachdb/errors v1.11.1 h1:xSEW75zKaKCWzR3OfxXUxgrk/NtT4G1MiOv5lWZazG8=
 github.com/cockroachdb/errors v1.11.1/go.mod h1:8MUxA3Gi6b25tYlFEBGLf+D8aISL+M4MIpiWMSNRfxw=
 github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b h1:r6VH0faHjZeQy818SGhaone5OnYfxFR/+AzdY3sf5aE=
@@ -71,6 +75,8 @@ github.com/huandu/xstrings v1.4.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/invopop/jsonschema v0.12.0 h1:6ovsNSuvn9wEQVOyc72aycBMVQFKz7cPdMJn10CvzRI=
+github.com/invopop/jsonschema v0.12.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
@@ -81,6 +87,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb h1:w1g9wNDIE/pHSTmAaUhv4TZQuPBS6GV3mMz5hkgziIU=
+github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb/go.mod h1:5ELEyG+X8f+meRWHuqUOewBOhvHkl7M76pdGEansxW4=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=
@@ -117,6 +125,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH
 github.com/rogpeppe/go-internal v1.9.0/go.mod h1:WtVeX8xhTBvf0smdhujwtBcq4Qrzq/fJaraNFVN+nFs=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0 h1:uIkTLo0AGRc8l7h5l9r+GcYi9qfVPt6lD4/bhmzfiKo=
+github.com/santhosh-tekuri/jsonschema/v5 v5.3.0/go.mod h1:FKdcjfQW6rpZSnxxUvEA5H/cDPdvJ/SZJQLWWXWGrZ0=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shopspring/decimal v1.3.1 h1:2Usl1nmF/WZucqkFZhnfFYxxxu8LG21F6nPQBE5gKV8=
 github.com/shopspring/decimal v1.3.1/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
@@ -131,6 +141,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=

--- a/pkg/gotohelm/testdata/src/example/inputs/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/inputs/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/k8s/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/k8s/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.go
@@ -7,10 +7,15 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 )
+
+type Values struct {
+	Quantity *resource.Quantity
+}
 
 func K8s(dot *helmette.Dot) map[string]any {
 	return map[string]any{
@@ -41,7 +46,8 @@ func K8s(dot *helmette.Dot) map[string]any {
 			ptr.Equal(nil, ptr.To(3)),
 			ptr.Equal(ptr.To(3), ptr.To(3)),
 		},
-		"lookup": lookup(dot),
+		"lookup":   lookup(dot),
+		"quantity": quantity(dot),
 	}
 }
 
@@ -94,4 +100,56 @@ func lookup(dot *helmette.Dot) []any {
 	sts, ok2 := helmette.Lookup[appsv1.StatefulSet](dot, "spacename", "eman")
 
 	return []any{svc, ok1, sts, ok2}
+}
+
+func quantity(dot *helmette.Dot) map[string]any {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	inputs := []string{
+		"10",
+		"100m", // 100 "milicores"
+		"10G",
+		"8Gi",
+		"55Mi",
+		"140k",
+		// NB: Fractional values are intentionally left disabled as
+		// resource.Quantity will rewrite these values to a normalized integral
+		// form. This behavior is not required for correctness and therefore is
+		// not (currently) being implemented.
+		// "0.5",
+		// "0.5Gi",
+	}
+
+	var quantities []resource.Quantity
+	for _, in := range inputs {
+		quantities = append(quantities, resource.MustParse(in))
+	}
+
+	if values.Quantity != nil {
+		// NB: This is a bit of a hack. gotohelm's Unwrap will leave .Values
+		// untouched as we expect it to a correct JSON representation of
+		// .Values. This test receives a float64 as input for values.Quantity
+		// which is a valid JSON representation as far as
+		// resource.Quantity.UnmarshalJSON is concerned. However,
+		// resource.Quantity.MarshalJSON always returns a string. To prevent
+		// the test fixture from complaining about the difference, we copy the
+		// quantity so gotohelm will actually transform the value to the go
+		// equivalent.
+		quantities = append(quantities, values.Quantity.DeepCopy())
+	}
+
+	var millis []int64
+	var strs []string
+	var value []int64
+	for _, q := range quantities {
+		millis = append(millis, q.MilliValue())
+		strs = append(strs, q.String())
+		value = append(value, q.Value())
+	}
+
+	return map[string]any{
+		"MustParse": quantities,
+		"Value":     value,
+		"String":    strs,
+	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
@@ -3,7 +3,7 @@
 {{- define "k8s.K8s" -}}
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list (10 | int) (11 | int) "12") "ptr.Deref" (list ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (3 | int) (4 | int)) ))) "r") | int) ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") | int) (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list "" "oh?") ))) "r")) "ptr.To" (list "hello" (0 | int) (dict )) "ptr.Equal" (list (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (coalesce nil)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (3 | int) (3 | int)) ))) "r")) "lookup" (get (fromJson (include "k8s.lookup" (dict "a" (list $dot) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list (10 | int) (11 | int) "12") "ptr.Deref" (list ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (3 | int) (4 | int)) ))) "r") | int) ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") | int) (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list "" "oh?") ))) "r")) "ptr.To" (list "hello" (0 | int) (dict )) "ptr.Equal" (list (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (coalesce nil)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (3 | int) (3 | int)) ))) "r")) "lookup" (get (fromJson (include "k8s.lookup" (dict "a" (list $dot) ))) "r") "quantity" (get (fromJson (include "k8s.quantity" (dict "a" (list $dot) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -43,6 +43,31 @@
 {{- $ok2 := $tmp_tuple_2.T2 -}}
 {{- $sts := $tmp_tuple_2.T1 -}}
 {{- (dict "r" (list $svc $ok1 $sts $ok2)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "k8s.quantity" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $inputs := (list "10" "100m" "10G" "8Gi" "55Mi" "140k") -}}
+{{- $quantities := (coalesce nil) -}}
+{{- range $_, $in := $inputs -}}
+{{- $quantities = (concat (default (list ) $quantities) (list (get (fromJson (include "_shims.resource_MustParse" (dict "a" (list $in) ))) "r"))) -}}
+{{- end -}}
+{{- if (ne $values.Quantity (coalesce nil)) -}}
+{{- $quantities = (concat (default (list ) $quantities) (list (get (fromJson (include "_shims.resource_MustParse" (dict "a" (list $values.Quantity) ))) "r"))) -}}
+{{- end -}}
+{{- $millis := (coalesce nil) -}}
+{{- $strs := (coalesce nil) -}}
+{{- $value := (coalesce nil) -}}
+{{- range $_, $q := $quantities -}}
+{{- $millis = (concat (default (list ) $millis) (list ((get (fromJson (include "_shims.resource_MilliValue" (dict "a" (list $q) ))) "r") | int64))) -}}
+{{- $strs = (concat (default (list ) $strs) (list (get (fromJson (include "_shims.resource_MustParse" (dict "a" (list $q) ))) "r"))) -}}
+{{- $value = (concat (default (list ) $value) (list ((get (fromJson (include "_shims.resource_Value" (dict "a" (list $q) ))) "r") | int64))) -}}
+{{- end -}}
+{{- (dict "r" (dict "MustParse" $quantities "Value" $value "String" $strs )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/labels/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/labels/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/mutability/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/mutability/_shims.tpl
@@ -1,5 +1,13 @@
 {{- /* Generated from "bootstrap.go" */ -}}
 
+{{- define "_shims.isIntLikeFloat" -}}
+{{- $value := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (and (typeIs "float64" $value) (eq (((subf (float64 $value) (floor $value)) | float64)) (0.0 | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "_shims.typetest" -}}
 {{- $typ := (index .a 0) -}}
 {{- $value := (index .a 1) -}}
@@ -63,7 +71,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "_shims.len" -}}
+{{- define "_shims._len" -}}
 {{- $m := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- if (eq $m (coalesce nil)) -}}
@@ -149,6 +157,114 @@
 {{- break -}}
 {{- end -}}
 {{- (dict "r" (list (0 | int) false)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T" $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims._len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims._len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $scale := (float64 0) -}}
+{{- if (eq $unit "") -}}
+{{- $scale = 1.0 -}}
+{{- else -}}{{- if (eq $unit "m") -}}
+{{- $scale = 0.001 -}}
+{{- else -}}{{- if (eq $unit "k") -}}
+{{- $scale = ((1000 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "M") -}}
+{{- $scale = ((1000000 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "G") -}}
+{{- $scale = ((1000000000 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "T") -}}
+{{- $scale = ((1000000000000 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "P") -}}
+{{- $scale = ((1000000000000000 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "Ki") -}}
+{{- $scale = ((1024 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "Mi") -}}
+{{- $scale = ((1048576 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "Gi") -}}
+{{- $scale = ((1073741824 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "Ti") -}}
+{{- $scale = ((1099511627776 | int) | float64) -}}
+{{- else -}}{{- if (eq $unit "Pi") -}}
+{{- $scale = ((1125899906842624 | int) | float64) -}}
+{{- else -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_1.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_1.T1 | float64) -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $strs := (list "" "m" "K" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_AsInt64" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list ((mulf $numeric $scale) | float64)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_4.T2 -}}
+{{- $asInt := $tmp_tuple_4.T1 -}}
+{{- (dict "r" (list $asInt $ok)) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/sprig/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -77,8 +77,8 @@ func trim() []string {
 	}
 }
 
-func minFunc() []int {
-	return []int{
+func minFunc() []int64 {
+	return []int64{
 		// spig Min function does not allow to not pass parameters. Error returned from helm template:
 		// wrong number of args for min: want at least 1 got 0
 		// helmette.Min(),

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -78,8 +78,8 @@ func trim() []string {
 	}
 }
 
-func minFunc() []int {
-	return []int{
+func minFunc() []int64 {
+	return []int64{
 		// spig Min function does not allow to not pass parameters. Error returned from helm template:
 		// wrong number of args for min: want at least 1 got 0
 		// helmette.Min(),

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -38,7 +38,7 @@
 
 {{- define "sprig.minFunc" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (list (min -1 (0 | int) (1 | int)) (min (1 | int)) (min (2 | int) (1 | int)) (min (1 | int) (1 | int) (2 | int)))) | toJson -}}
+{{- (dict "r" (list (min -1 (0 | int64) (1 | int64)) (min (1 | int64)) (min (2 | int64) (1 | int64)) (min (1 | int64) (1 | int64) (2 | int64)))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/syntax/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/syntax/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/pkg/gotohelm/testdata/src/example/typing/_shims.tpl
+++ b/pkg/gotohelm/testdata/src/example/typing/_shims.tpl
@@ -153,3 +153,75 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "_shims.parseResource" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (typeIs "float64" $repr) -}}
+{{- (dict "r" (list (float64 $repr) 1.0)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (not (typeIs "string" $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity expected string or float64 got: %T (%v)" $repr $repr)) -}}
+{{- end -}}
+{{- if (not (regexMatch `^[0-9]+(\.[0-9]{0,6})?(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)?$` $repr)) -}}
+{{- $_ := (fail (printf "invalid Quantity: %q" $repr)) -}}
+{{- end -}}
+{{- $reprStr := (toString $repr) -}}
+{{- $unit := (regexFind "(k|m|M|G|T|P|Ki|Mi|Gi|Ti|Pi)$" $repr) -}}
+{{- $numeric := (float64 (substr (0 | int) ((sub ((get (fromJson (include "_shims.len" (dict "a" (list $reprStr) ))) "r") | int) ((get (fromJson (include "_shims.len" (dict "a" (list $unit) ))) "r") | int)) | int) $reprStr)) -}}
+{{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list (dict "" 1.0 "m" 0.001 "k" (1000 | int) "M" (1000000 | int) "G" (1000000000 | int) "T" (1000000000000 | int) "P" (1000000000000000 | int) "Ki" (1024 | int) "Mi" (1048576 | int) "Gi" (1073741824 | int) "Ti" (1099511627776 | int) "Pi" (1125899906842624 | int) ) $unit (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_1.T2 -}}
+{{- $scale := ($tmp_tuple_1.T1 | float64) -}}
+{{- if (not $ok) -}}
+{{- $_ := (fail (printf "unknown unit: %q" $unit)) -}}
+{{- end -}}
+{{- (dict "r" (list $numeric $scale)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MustParse" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_2.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_2.T1 | float64) -}}
+{{- $strs := (list "" "m" "k" "M" "G" "T" "P" "Ki" "Mi" "Gi" "Ti" "Pi") -}}
+{{- $scales := (list 1.0 0.001 (1000 | int) (1000000 | int) (1000000000 | int) (1000000000000 | int) (1000000000000000 | int) (1024 | int) (1048576 | int) (1073741824 | int) (1099511627776 | int) (1125899906842624 | int)) -}}
+{{- $idx := -1 -}}
+{{- range $i, $s := $scales -}}
+{{- if (eq ($s | float64) ($scale | float64)) -}}
+{{- $idx = $i -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- if (eq $idx -1) -}}
+{{- $_ := (fail (printf "unknown scale: %v" $scale)) -}}
+{{- end -}}
+{{- (dict "r" (printf "%s%s" (toString $numeric) (index $strs $idx))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_Value" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_3.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_3.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf $numeric $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "_shims.resource_MilliValue" -}}
+{{- $repr := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.parseResource" (dict "a" (list $repr) ))) "r")) ))) "r") -}}
+{{- $scale := ($tmp_tuple_4.T2 | float64) -}}
+{{- $numeric := ($tmp_tuple_4.T1 | float64) -}}
+{{- (dict "r" (int64 (ceil ((mulf ((mulf $numeric 1000.0) | float64) $scale) | float64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+


### PR DESCRIPTION
This commit adds partial support for Kubernetes' `resource.Quantity` type into gotohelm. The supported methods are:
- `resource.MustParse`
- `resource.(*Quantity).AsInt64`
- `resource.(*Quantity).Value`
- `resource.(*Quantity).DeepCopy`

It is also possible to include a `resource.Quantity` type on a Values struct and interact with it as you would any other `resource.Quantity` provided that the value is a numeric or a valid `resource.Quantity` string.