### PR TITLE
gotohelm: support go's append semantics

### DIFF
--- a/charts/redpanda/certs.go
+++ b/charts/redpanda/certs.go
@@ -24,13 +24,13 @@ func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
 	ns := dot.Release.Namespace
 	domain := strings.TrimSuffix(values.ClusterDomain, ".")
 
-	certs := []certmanagerv1.Certificate{}
+	var certs []certmanagerv1.Certificate
 	for name, data := range values.TLS.Certs {
 		if !helmette.Empty(data.SecretRef) || !ptr.Deref(data.Enabled, true) {
 			continue
 		}
 
-		names := []string{}
+		var names []string
 		if data.IssuerRef == nil || ptr.Deref(data.ApplyInternalDNSNames, false) {
 			names = append(names, fmt.Sprintf("%s-cluster.%s.%s.svc.%s", fullname, service, ns, domain))
 			names = append(names, fmt.Sprintf("%s-cluster.%s.%s.svc", fullname, service, ns))

--- a/charts/redpanda/service.loadbalancer.go
+++ b/charts/redpanda/service.loadbalancer.go
@@ -49,7 +49,7 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 
 	selector := StatefulSetPodLabelsSelector(dot)
 
-	services := []*corev1.Service{}
+	var services []*corev1.Service
 	replicas := values.Statefulset.Replicas // TODO fix me once the transpiler is fixed.
 	for i := 0; i < replicas; i++ {
 		podname := fmt.Sprintf("%s-%d", Fullname(dot), i)
@@ -81,8 +81,7 @@ func LoadBalancerServices(dot *helmette.Dot) []*corev1.Service {
 
 		podSelector["statefulset.kubernetes.io/pod-name"] = podname
 
-		ports := []corev1.ServicePort{}
-
+		var ports []corev1.ServicePort
 		for name, listener := range values.Listeners.Admin.External {
 			if !ptr.Deref(listener.Enabled, values.External.Enabled) {
 				continue

--- a/charts/redpanda/service.nodeport.go
+++ b/charts/redpanda/service.nodeport.go
@@ -35,10 +35,7 @@ func NodePortService(dot *helmette.Dot) *corev1.Service {
 		return nil
 	}
 
-	// NB: As of writing, `mustAppend` appears to not work with nil values.
-	// Hence ports is defined as an empty list rather than a zero list.
-	ports := []corev1.ServicePort{}
-
+	var ports []corev1.ServicePort
 	for name, listener := range values.Listeners.Admin.External {
 		if !listener.IsEnabled() {
 			continue

--- a/charts/redpanda/statefulset.go
+++ b/charts/redpanda/statefulset.go
@@ -43,7 +43,7 @@ func StatefulSetRedpandaEnv(dot *helmette.Dot) []corev1.EnvVar {
 	// we're moving the chart into go in a piecemeal fashion there isn't a "top
 	// level" location to perform the merge so we're instead required to
 	// Implement aspects of the SMP by hand.
-	userEnv := []corev1.EnvVar{}
+	var userEnv []corev1.EnvVar
 	for _, container := range values.Statefulset.PodTemplate.Spec.Containers {
 		if container.Name == RedpandaContainerName {
 			userEnv = container.Env

--- a/charts/redpanda/templates/_configmap.go.tpl
+++ b/charts/redpanda/templates/_configmap.go.tpl
@@ -4,7 +4,7 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $cms := (list (get (fromJson (include "redpanda.RedpandaConfigMap" (dict "a" (list $dot true) ))) "r")) -}}
-{{- $cms = (concat $cms (get (fromJson (include "redpanda.RPKProfile" (dict "a" (list $dot) ))) "r")) -}}
+{{- $cms = (concat (default (list ) $cms) (default (list ) (get (fromJson (include "redpanda.RPKProfile" (dict "a" (list $dot) ))) "r"))) -}}
 {{- (dict "r" $cms) | toJson -}}
 {{- break -}}
 {{- end -}}
@@ -14,7 +14,7 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $cms := (list (get (fromJson (include "redpanda.RedpandaConfigMap" (dict "a" (list $dot false) ))) "r")) -}}
-{{- $cms = (concat $cms (get (fromJson (include "redpanda.RPKProfile" (dict "a" (list $dot) ))) "r")) -}}
+{{- $cms = (concat (default (list ) $cms) (default (list ) (get (fromJson (include "redpanda.RPKProfile" (dict "a" (list $dot) ))) "r"))) -}}
 {{- (dict "r" $cms) | toJson -}}
 {{- break -}}
 {{- end -}}
@@ -89,11 +89,11 @@
 {{- $values := $dot.Values.AsMap -}}
 {{- $brokerList := (list ) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
-{{- $brokerList = (mustAppend $brokerList (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedKafkaPort" (dict "a" (list $dot $i) ))) "r") | int) | int))) -}}
+{{- $brokerList = (concat (default (list ) $brokerList) (list (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedKafkaPort" (dict "a" (list $dot $i) ))) "r") | int) | int)))) -}}
 {{- end -}}
 {{- $adminAdvertisedList := (list ) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
-{{- $adminAdvertisedList = (mustAppend $adminAdvertisedList (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedAdminPort" (dict "a" (list $dot $i) ))) "r") | int) | int))) -}}
+{{- $adminAdvertisedList = (concat (default (list ) $adminAdvertisedList) (list (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedAdminPort" (dict "a" (list $dot $i) ))) "r") | int) | int)))) -}}
 {{- end -}}
 {{- $kafkaTLS := (get (fromJson (include "redpanda.brokersTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
 {{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $kafkaTLS "truststore_file" (coalesce nil)) ))) "r")) ))) "r") -}}
@@ -213,7 +213,7 @@
 {{- $brokerList := (list ) -}}
 {{- $r := ($values.statefulset.replicas | int) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
-{{- $brokerList = (mustAppend $brokerList (printf "%s-%d.%s:%d" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r") (($values.listeners.kafka.port | int) | int))) -}}
+{{- $brokerList = (concat (default (list ) $brokerList) (list (printf "%s-%d.%s:%d" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r") (($values.listeners.kafka.port | int) | int)))) -}}
 {{- end -}}
 {{- $adminTLS := (coalesce nil) -}}
 {{- $tls_3 := (get (fromJson (include "redpanda.adminTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
@@ -289,7 +289,7 @@
 {{- $values := $dot.Values.AsMap -}}
 {{- $brokerList := (list ) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
-{{- $brokerList = (mustAppend $brokerList (dict "address" (printf "%s-%d.%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) "port" ($values.listeners.kafka.port | int) )) -}}
+{{- $brokerList = (concat (default (list ) $brokerList) (list (dict "address" (printf "%s-%d.%s" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) "port" ($values.listeners.kafka.port | int) ))) -}}
 {{- end -}}
 {{- $kafkaTLS := $values.listeners.kafka.tls -}}
 {{- $brokerTLS := (coalesce nil) -}}
@@ -430,9 +430,9 @@
 {{- $_ := (sortAlpha $keys) -}}
 {{- $flags := (list ) -}}
 {{- range $_, $key := $keys -}}
-{{- $flags = (mustAppend $flags (printf "--%s=%s" $key (index $chartFlags $key))) -}}
+{{- $flags = (concat (default (list ) $flags) (list (printf "--%s=%s" $key (index $chartFlags $key)))) -}}
 {{- end -}}
-{{- (dict "r" (concat $flags $values.statefulset.additionalRedpandaCmdFlags)) | toJson -}}
+{{- (dict "r" (concat (default (list ) $flags) (default (list ) $values.statefulset.additionalRedpandaCmdFlags))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/templates/_helpers.go.tpl
+++ b/charts/redpanda/templates/_helpers.go.tpl
@@ -171,7 +171,7 @@
 {{- define "redpanda.DefaultMounts" -}}
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (concat (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "config" "mountPath" "/etc/redpanda" ))) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r"))) | toJson -}}
+{{- (dict "r" (concat (default (list ) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "config" "mountPath" "/etc/redpanda" )))) (default (list ) (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r")))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -183,16 +183,16 @@
 {{- $mounts := (list ) -}}
 {{- $sasl_5 := $values.auth.sasl -}}
 {{- if (and $sasl_5.enabled (ne $sasl_5.secretRef "")) -}}
-{{- $mounts = (mustAppend $mounts (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "users" "mountPath" "/etc/secrets/users" "readOnly" true ))) -}}
+{{- $mounts = (concat (default (list ) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "users" "mountPath" "/etc/secrets/users" "readOnly" true )))) -}}
 {{- end -}}
 {{- if (get (fromJson (include "redpanda.TLSEnabled" (dict "a" (list $dot) ))) "r") -}}
 {{- $certNames := (keys $values.tls.certs) -}}
 {{- $_ := (sortAlpha $certNames) -}}
 {{- range $_, $name := $certNames -}}
-{{- $mounts = (mustAppend $mounts (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" (printf "redpanda-%s-cert" $name) "mountPath" (printf "/etc/tls/certs/%s" $name) ))) -}}
+{{- $mounts = (concat (default (list ) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" (printf "redpanda-%s-cert" $name) "mountPath" (printf "/etc/tls/certs/%s" $name) )))) -}}
 {{- end -}}
 {{- if (get (fromJson (include "redpanda.ClientAuthRequired" (dict "a" (list $dot) ))) "r") -}}
-{{- $mounts = (mustAppend $mounts (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "mtls-client" "mountPath" (printf "/etc/tls/certs/%s-client" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) ))) -}}
+{{- $mounts = (concat (default (list ) $mounts) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "mtls-client" "mountPath" (printf "/etc/tls/certs/%s-client" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) )))) -}}
 {{- end -}}
 {{- end -}}
 {{- (dict "r" $mounts) | toJson -}}
@@ -203,7 +203,7 @@
 {{- define "redpanda.DefaultVolumes" -}}
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (concat (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "configMap" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") )) (dict )) )) (dict "name" "config" ))) (get (fromJson (include "redpanda.CommonVolumes" (dict "a" (list $dot) ))) "r"))) | toJson -}}
+{{- (dict "r" (concat (default (list ) (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "configMap" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") )) (dict )) )) (dict "name" "config" )))) (default (list ) (get (fromJson (include "redpanda.CommonVolumes" (dict "a" (list $dot) ))) "r")))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -218,15 +218,15 @@
 {{- $_ := (sortAlpha $certNames) -}}
 {{- range $_, $name := $certNames -}}
 {{- $cert := (index $values.tls.certs $name) -}}
-{{- $volumes = (mustAppend $volumes (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (get (fromJson (include "redpanda.CertSecretName" (dict "a" (list $dot $name $cert) ))) "r") "defaultMode" (0o440 | int) )) )) (dict "name" (printf "redpanda-%s-cert" $name) ))) -}}
+{{- $volumes = (concat (default (list ) $volumes) (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (get (fromJson (include "redpanda.CertSecretName" (dict "a" (list $dot $name $cert) ))) "r") "defaultMode" (0o440 | int) )) )) (dict "name" (printf "redpanda-%s-cert" $name) )))) -}}
 {{- end -}}
 {{- if (get (fromJson (include "redpanda.ClientAuthRequired" (dict "a" (list $dot) ))) "r") -}}
-{{- $volumes = (mustAppend $volumes (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%s-client" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) "defaultMode" (0o440 | int) )) )) (dict "name" "mtls-client" ))) -}}
+{{- $volumes = (concat (default (list ) $volumes) (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%s-client" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) "defaultMode" (0o440 | int) )) )) (dict "name" "mtls-client" )))) -}}
 {{- end -}}
 {{- end -}}
 {{- $sasl_6 := $values.auth.sasl -}}
 {{- if (and $sasl_6.enabled (ne $sasl_6.secretRef "")) -}}
-{{- $volumes = (mustAppend $volumes (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" $sasl_6.secretRef )) )) (dict "name" "users" ))) -}}
+{{- $volumes = (concat (default (list ) $volumes) (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" $sasl_6.secretRef )) )) (dict "name" "users" )))) -}}
 {{- end -}}
 {{- (dict "r" $volumes) | toJson -}}
 {{- break -}}

--- a/charts/redpanda/templates/_post-install-upgrade-job.go.tpl
+++ b/charts/redpanda/templates/_post-install-upgrade-job.go.tpl
@@ -8,9 +8,9 @@
 {{- $license_1 := (get (fromJson (include "redpanda.GetLicenseLiteral" (dict "a" (list $dot) ))) "r") -}}
 {{- $secretReference_2 := (get (fromJson (include "redpanda.GetLicenseSecretReference" (dict "a" (list $dot) ))) "r") -}}
 {{- if (ne $license_1 "") -}}
-{{- $envars = (mustAppend $envars (mustMergeOverwrite (dict "name" "" ) (dict "name" "REDPANDA_LICENSE" "value" $license_1 ))) -}}
+{{- $envars = (concat (default (list ) $envars) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" "REDPANDA_LICENSE" "value" $license_1 )))) -}}
 {{- else -}}{{- if (ne $secretReference_2 (coalesce nil)) -}}
-{{- $envars = (mustAppend $envars (mustMergeOverwrite (dict "name" "" ) (dict "name" "REDPANDA_LICENSE" "valueFrom" (mustMergeOverwrite (dict ) (dict "secretKeyRef" $secretReference_2 )) ))) -}}
+{{- $envars = (concat (default (list ) $envars) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" "REDPANDA_LICENSE" "valueFrom" (mustMergeOverwrite (dict ) (dict "secretKeyRef" $secretReference_2 )) )))) -}}
 {{- end -}}
 {{- end -}}
 {{- if (not (get (fromJson (include "redpanda.Storage.IsTieredStorageEnabled" (dict "a" (list $values.storage) ))) "r")) -}}
@@ -25,11 +25,11 @@
 {{- $azureStorageAccountExists := $tmp_tuple_2.T2 -}}
 {{- $asa := $tmp_tuple_2.T1 -}}
 {{- if (and (and (and $azureContainerExists (ne $ac (coalesce nil))) $azureStorageAccountExists) (ne $asa (coalesce nil))) -}}
-{{- $envars = (concat $envars (get (fromJson (include "redpanda.addAzureSharedKey" (dict "a" (list $tieredStorageConfig $values) ))) "r")) -}}
+{{- $envars = (concat (default (list ) $envars) (default (list ) (get (fromJson (include "redpanda.addAzureSharedKey" (dict "a" (list $tieredStorageConfig $values) ))) "r"))) -}}
 {{- else -}}
-{{- $envars = (concat $envars (get (fromJson (include "redpanda.addCloudStorageSecretKey" (dict "a" (list $tieredStorageConfig $values) ))) "r")) -}}
+{{- $envars = (concat (default (list ) $envars) (default (list ) (get (fromJson (include "redpanda.addCloudStorageSecretKey" (dict "a" (list $tieredStorageConfig $values) ))) "r"))) -}}
 {{- end -}}
-{{- $envars = (concat $envars (get (fromJson (include "redpanda.addCloudStorageAccessKey" (dict "a" (list $tieredStorageConfig $values) ))) "r")) -}}
+{{- $envars = (concat (default (list ) $envars) (default (list ) (get (fromJson (include "redpanda.addCloudStorageAccessKey" (dict "a" (list $tieredStorageConfig $values) ))) "r"))) -}}
 {{- range $k, $v := $tieredStorageConfig -}}
 {{- if (or (or (eq $k "cloud_storage_access_key") (eq $k "cloud_storage_secret_key")) (eq $k "cloud_storage_azure_shared_key")) -}}
 {{- continue -}}
@@ -41,16 +41,16 @@
 {{- $isStr_4 := $tmp_tuple_3.T2 -}}
 {{- $asStr_3 := $tmp_tuple_3.T1 -}}
 {{- if (and (and (eq $k "cloud_storage_cache_size") $isStr_4) (ne $asStr_3 "")) -}}
-{{- $envars = (mustAppend $envars (mustMergeOverwrite (dict "name" "" ) (dict "name" (printf "RPK_%s" (upper $k)) "value" (toJson ((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $v) ))) "r")) ))) "r") | int)) ))) -}}
+{{- $envars = (concat (default (list ) $envars) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" (printf "RPK_%s" (upper $k)) "value" (toJson ((get (fromJson (include "redpanda.SIToBytes" (dict "a" (list (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $v) ))) "r")) ))) "r") | int)) )))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "string" $v "") ))) "r")) ))) "r") -}}
 {{- $ok_6 := $tmp_tuple_4.T2 -}}
 {{- $str_5 := $tmp_tuple_4.T1 -}}
 {{- if $ok_6 -}}
-{{- $envars = (mustAppend $envars (mustMergeOverwrite (dict "name" "" ) (dict "name" (printf "RPK_%s" (upper $k)) "value" $str_5 ))) -}}
+{{- $envars = (concat (default (list ) $envars) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" (printf "RPK_%s" (upper $k)) "value" $str_5 )))) -}}
 {{- else -}}
-{{- $envars = (mustAppend $envars (mustMergeOverwrite (dict "name" "" ) (dict "name" (printf "RPK_%s" (upper $k)) "value" (mustToJson $v) ))) -}}
+{{- $envars = (concat (default (list ) $envars) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" (printf "RPK_%s" (upper $k)) "value" (mustToJson $v) )))) -}}
 {{- end -}}
 {{- end -}}
 {{- (dict "r" $envars) | toJson -}}

--- a/charts/redpanda/templates/_statefulset.go.tpl
+++ b/charts/redpanda/templates/_statefulset.go.tpl
@@ -4,13 +4,13 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $userEnv := (list ) -}}
+{{- $userEnv := (coalesce nil) -}}
 {{- range $_, $container := $values.statefulset.podTemplate.spec.containers -}}
 {{- if (eq $container.name "redpanda") -}}
 {{- $userEnv = $container.env -}}
 {{- end -}}
 {{- end -}}
-{{- (dict "r" (concat (list (mustMergeOverwrite (dict "name" "" ) (dict "name" "SERVICE_NAME" "valueFrom" (mustMergeOverwrite (dict ) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "" ) (dict "fieldPath" "metadata.name" )) )) )) (mustMergeOverwrite (dict "name" "" ) (dict "name" "POD_IP" "valueFrom" (mustMergeOverwrite (dict ) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "" ) (dict "fieldPath" "status.podIP" )) )) )) (mustMergeOverwrite (dict "name" "" ) (dict "name" "HOST_IP" "valueFrom" (mustMergeOverwrite (dict ) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "" ) (dict "fieldPath" "status.hostIP" )) )) ))) $userEnv)) | toJson -}}
+{{- (dict "r" (concat (default (list ) (list (mustMergeOverwrite (dict "name" "" ) (dict "name" "SERVICE_NAME" "valueFrom" (mustMergeOverwrite (dict ) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "" ) (dict "fieldPath" "metadata.name" )) )) )) (mustMergeOverwrite (dict "name" "" ) (dict "name" "POD_IP" "valueFrom" (mustMergeOverwrite (dict ) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "" ) (dict "fieldPath" "status.podIP" )) )) )) (mustMergeOverwrite (dict "name" "" ) (dict "name" "HOST_IP" "valueFrom" (mustMergeOverwrite (dict ) (dict "fieldRef" (mustMergeOverwrite (dict "fieldPath" "" ) (dict "fieldPath" "status.hostIP" )) )) )))) (default (list ) $userEnv))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -82,7 +82,7 @@
 {{- range $_ := (list 1) -}}
 {{- $volumes := (get (fromJson (include "redpanda.CommonVolumes" (dict "a" (list $dot) ))) "r") -}}
 {{- $fullname := (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") -}}
-{{- $volumes = (concat $volumes (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.50s-sts-lifecycle" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" "lifecycle-scripts" )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "configMap" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" $fullname )) (dict )) )) (dict "name" $fullname )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "emptyDir" (mustMergeOverwrite (dict ) (dict )) )) (dict "name" "config" )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.51s-configurator" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%.51s-configurator" $fullname) )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%s-config-watcher" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%s-config-watcher" $fullname) )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.49s-fs-validator" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%.49s-fs-validator" $fullname) )))) -}}
+{{- $volumes = (concat (default (list ) $volumes) (default (list ) (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.50s-sts-lifecycle" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" "lifecycle-scripts" )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "configMap" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" $fullname )) (dict )) )) (dict "name" $fullname )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "emptyDir" (mustMergeOverwrite (dict ) (dict )) )) (dict "name" "config" )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.51s-configurator" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%.51s-configurator" $fullname) )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%s-config-watcher" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%s-config-watcher" $fullname) )) (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" (printf "%.49s-fs-validator" $fullname) "defaultMode" (0o775 | int) )) )) (dict "name" (printf "%.49s-fs-validator" $fullname) ))))) -}}
 {{- (dict "r" $volumes) | toJson -}}
 {{- break -}}
 {{- end -}}
@@ -92,7 +92,7 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $mounts := (get (fromJson (include "redpanda.CommonMounts" (dict "a" (list $dot) ))) "r") -}}
-{{- $mounts = (concat $mounts (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "config" "mountPath" "/etc/redpanda" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") "mountPath" "/tmp/base-config" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "lifecycle-scripts" "mountPath" "/var/lifecycle" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "datadir" "mountPath" "/var/lib/redpanda/data" )))) -}}
+{{- $mounts = (concat (default (list ) $mounts) (default (list ) (list (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "config" "mountPath" "/etc/redpanda" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") "mountPath" "/tmp/base-config" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "lifecycle-scripts" "mountPath" "/var/lifecycle" )) (mustMergeOverwrite (dict "name" "" "mountPath" "" ) (dict "name" "datadir" "mountPath" "/var/lib/redpanda/data" ))))) -}}
 {{- (dict "r" $mounts) | toJson -}}
 {{- break -}}
 {{- end -}}

--- a/charts/redpanda/templates/certs.go.tpl
+++ b/charts/redpanda/templates/certs.go.tpl
@@ -12,33 +12,33 @@
 {{- $service := (get (fromJson (include "redpanda.ServiceName" (dict "a" (list $dot) ))) "r") -}}
 {{- $ns := $dot.Release.Namespace -}}
 {{- $domain := (trimSuffix "." $values.clusterDomain) -}}
-{{- $certs := (list ) -}}
+{{- $certs := (coalesce nil) -}}
 {{- range $name, $data := $values.tls.certs -}}
 {{- if (or (not (empty $data.secretRef)) (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $data.enabled true) ))) "r"))) -}}
 {{- continue -}}
 {{- end -}}
-{{- $names := (list ) -}}
+{{- $names := (coalesce nil) -}}
 {{- if (or (eq $data.issuerRef (coalesce nil)) (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $data.applyInternalDNSNames false) ))) "r")) -}}
-{{- $names = (mustAppend $names (printf "%s-cluster.%s.%s.svc.%s" $fullname $service $ns $domain)) -}}
-{{- $names = (mustAppend $names (printf "%s-cluster.%s.%s.svc" $fullname $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "%s-cluster.%s.%s" $fullname $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "*.%s-cluster.%s.%s.svc.%s" $fullname $service $ns $domain)) -}}
-{{- $names = (mustAppend $names (printf "*.%s-cluster.%s.%s.svc" $fullname $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "*.%s-cluster.%s.%s" $fullname $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "%s.%s.svc.%s" $service $ns $domain)) -}}
-{{- $names = (mustAppend $names (printf "%s.%s.svc" $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "%s.%s" $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "*.%s.%s.svc.%s" $service $ns $domain)) -}}
-{{- $names = (mustAppend $names (printf "*.%s.%s.svc" $service $ns)) -}}
-{{- $names = (mustAppend $names (printf "*.%s.%s" $service $ns)) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "%s-cluster.%s.%s.svc.%s" $fullname $service $ns $domain))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "%s-cluster.%s.%s.svc" $fullname $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "%s-cluster.%s.%s" $fullname $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "*.%s-cluster.%s.%s.svc.%s" $fullname $service $ns $domain))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "*.%s-cluster.%s.%s.svc" $fullname $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "*.%s-cluster.%s.%s" $fullname $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "%s.%s.svc.%s" $service $ns $domain))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "%s.%s.svc" $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "%s.%s" $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "*.%s.%s.svc.%s" $service $ns $domain))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "*.%s.%s.svc" $service $ns))) -}}
+{{- $names = (concat (default (list ) $names) (list (printf "*.%s.%s" $service $ns))) -}}
 {{- end -}}
 {{- if (ne $values.external.domain (coalesce nil)) -}}
-{{- $names = (mustAppend $names (tpl $values.external.domain $dot)) -}}
-{{- $names = (mustAppend $names (tpl (printf "*.%s" $values.external.domain) $dot)) -}}
+{{- $names = (concat (default (list ) $names) (list (tpl $values.external.domain $dot))) -}}
+{{- $names = (concat (default (list ) $names) (list (tpl (printf "*.%s" $values.external.domain) $dot))) -}}
 {{- end -}}
 {{- $duration := (default "43800h" $data.duration) -}}
 {{- $issuerRef := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $data.issuerRef (mustMergeOverwrite (dict "name" "" ) (dict "kind" "Issuer" "group" "cert-manager.io" "name" (printf "%s-%s-root-issuer" $fullname $name) ))) ))) "r") -}}
-{{- $certs = (mustAppend $certs (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "secretName" "" "issuerRef" (dict "name" "" ) ) "status" (dict ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "cert-manager.io/v1" "kind" "Certificate" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%s-%s-cert" $fullname $name) "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace )) "spec" (mustMergeOverwrite (dict "secretName" "" "issuerRef" (dict "name" "" ) ) (dict "dnsNames" $names "duration" $duration "isCA" false "issuerRef" $issuerRef "secretName" (printf "%s-%s-cert" $fullname $name) "privateKey" (mustMergeOverwrite (dict ) (dict "algorithm" "ECDSA" "size" (256 | int) )) )) ))) -}}
+{{- $certs = (concat (default (list ) $certs) (list (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "secretName" "" "issuerRef" (dict "name" "" ) ) "status" (dict ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "cert-manager.io/v1" "kind" "Certificate" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%s-%s-cert" $fullname $name) "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace )) "spec" (mustMergeOverwrite (dict "secretName" "" "issuerRef" (dict "name" "" ) ) (dict "dnsNames" $names "duration" $duration "isCA" false "issuerRef" $issuerRef "secretName" (printf "%s-%s-cert" $fullname $name) "privateKey" (mustMergeOverwrite (dict ) (dict "algorithm" "ECDSA" "size" (256 | int) )) )) )))) -}}
 {{- end -}}
 {{- $name := $values.listeners.kafka.tls.cert -}}
 {{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.tls.certs $name (coalesce nil)) ))) "r")) ))) "r") -}}
@@ -57,7 +57,7 @@
 {{- $_ := (set $issuerRef "group" "cert-manager.io") -}}
 {{- end -}}
 {{- $duration := (default "43800h" $data.duration) -}}
-{{- (dict "r" (mustAppend $certs (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "secretName" "" "issuerRef" (dict "name" "" ) ) "status" (dict ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "cert-manager.io/v1" "kind" "Certificate" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%s-client" $fullname) "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "spec" (mustMergeOverwrite (dict "secretName" "" "issuerRef" (dict "name" "" ) ) (dict "commonName" (printf "%s-client" $fullname) "duration" $duration "isCA" false "secretName" (printf "%s-client" $fullname) "privateKey" (mustMergeOverwrite (dict ) (dict "algorithm" "ECDSA" "size" (256 | int) )) "issuerRef" $issuerRef )) )))) | toJson -}}
+{{- (dict "r" (concat (default (list ) $certs) (list (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "secretName" "" "issuerRef" (dict "name" "" ) ) "status" (dict ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "cert-manager.io/v1" "kind" "Certificate" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%s-client" $fullname) "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "spec" (mustMergeOverwrite (dict "secretName" "" "issuerRef" (dict "name" "" ) ) (dict "commonName" (printf "%s-client" $fullname) "duration" $duration "isCA" false "secretName" (printf "%s-client" $fullname) "privateKey" (mustMergeOverwrite (dict ) (dict "algorithm" "ECDSA" "size" (256 | int) )) "issuerRef" $issuerRef )) ))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/templates/service.loadbalancer.go.tpl
+++ b/charts/redpanda/templates/service.loadbalancer.go.tpl
@@ -16,7 +16,7 @@
 {{- $labels := (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") -}}
 {{- $_ := (set $labels "repdanda.com/type" "loadbalancer") -}}
 {{- $selector := (get (fromJson (include "redpanda.StatefulSetPodLabelsSelector" (dict "a" (list $dot) ))) "r") -}}
-{{- $services := (list ) -}}
+{{- $services := (coalesce nil) -}}
 {{- $replicas := ($values.statefulset.replicas | int) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
 {{- $podname := (printf "%s-%d" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $i) -}}
@@ -37,37 +37,37 @@
 {{- $_ := (set $podSelector $k $v) -}}
 {{- end -}}
 {{- $_ := (set $podSelector "statefulset.kubernetes.io/pod-name" $podname) -}}
-{{- $ports := (list ) -}}
+{{- $ports := (coalesce nil) -}}
 {{- range $name, $listener := $values.listeners.admin.external -}}
 {{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.enabled $values.external.enabled) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
-{{- $fallbackPorts := (mustAppend $listener.advertisedPorts ($values.listeners.admin.port | int)) -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "admin-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) ))) -}}
+{{- $fallbackPorts := (concat (default (list ) $listener.advertisedPorts) (list ($values.listeners.admin.port | int))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "admin-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) )))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.kafka.external -}}
 {{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.enabled $values.external.enabled) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
-{{- $fallbackPorts := (mustAppend $listener.advertisedPorts ($listener.port | int)) -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "kafka-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) ))) -}}
+{{- $fallbackPorts := (concat (default (list ) $listener.advertisedPorts) (list ($listener.port | int))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "kafka-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) )))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.http.external -}}
 {{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.enabled $values.external.enabled) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
-{{- $fallbackPorts := (mustAppend $listener.advertisedPorts ($listener.port | int)) -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "http-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) ))) -}}
+{{- $fallbackPorts := (concat (default (list ) $listener.advertisedPorts) (list ($listener.port | int))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "http-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) )))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.schemaRegistry.external -}}
 {{- if (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.enabled $values.external.enabled) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
-{{- $fallbackPorts := (mustAppend $listener.advertisedPorts ($listener.port | int)) -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "schema-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) ))) -}}
+{{- $fallbackPorts := (concat (default (list ) $listener.advertisedPorts) (list ($listener.port | int))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "schema-%s" $name) "protocol" "TCP" "targetPort" ($listener.port | int) "port" ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $listener.nodePort (index $fallbackPorts (0 | int))) ))) "r") | int) )))) -}}
 {{- end -}}
 {{- $svc := (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict ) "status" (dict "loadBalancer" (dict ) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Service" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "lb-%s" $podname) "namespace" $dot.Release.Namespace "labels" $labels "annotations" $annotations )) "spec" (mustMergeOverwrite (dict ) (dict "externalTrafficPolicy" "Local" "loadBalancerSourceRanges" $values.external.sourceRanges "ports" $ports "publishNotReadyAddresses" true "selector" $podSelector "sessionAffinity" "None" "type" "LoadBalancer" )) )) -}}
-{{- $services = (mustAppend $services $svc) -}}
+{{- $services = (concat (default (list ) $services) (list $svc)) -}}
 {{- end -}}
 {{- (dict "r" $services) | toJson -}}
 {{- break -}}

--- a/charts/redpanda/templates/service.nodeport.go.tpl
+++ b/charts/redpanda/templates/service.nodeport.go.tpl
@@ -12,7 +12,7 @@
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $ports := (list ) -}}
+{{- $ports := (coalesce nil) -}}
 {{- range $name, $listener := $values.listeners.admin.external -}}
 {{- if (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
 {{- continue -}}
@@ -21,7 +21,7 @@
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (0 | int)) -}}
 {{- $nodePort = (index $listener.advertisedPorts (0 | int)) -}}
 {{- end -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "admin-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "admin-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort )))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.kafka.external -}}
 {{- if (not (get (fromJson (include "redpanda.KafkaExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
@@ -31,7 +31,7 @@
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (0 | int)) -}}
 {{- $nodePort = (index $listener.advertisedPorts (0 | int)) -}}
 {{- end -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "kafka-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "kafka-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort )))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.http.external -}}
 {{- if (not (get (fromJson (include "redpanda.HTTPExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
@@ -41,7 +41,7 @@
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (0 | int)) -}}
 {{- $nodePort = (index $listener.advertisedPorts (0 | int)) -}}
 {{- end -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "http-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "http-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort )))) -}}
 {{- end -}}
 {{- range $name, $listener := $values.listeners.schemaRegistry.external -}}
 {{- if (not (get (fromJson (include "redpanda.SchemaRegistryExternal.IsEnabled" (dict "a" (list $listener) ))) "r")) -}}
@@ -51,7 +51,7 @@
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (0 | int)) -}}
 {{- $nodePort = (index $listener.advertisedPorts (0 | int)) -}}
 {{- end -}}
-{{- $ports = (mustAppend $ports (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "schema-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort ))) -}}
+{{- $ports = (concat (default (list ) $ports) (list (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" (printf "schema-%s" $name) "protocol" "TCP" "port" ($listener.port | int) "nodePort" $nodePort )))) -}}
 {{- end -}}
 {{- $annotations := $values.external.annotations -}}
 {{- if (eq $annotations (coalesce nil)) -}}

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -71,7 +71,7 @@
 {{- end -}}
 {{- $users := (list ) -}}
 {{- range $_, $u := $a.sasl.users -}}
-{{- $users = (mustAppend $users $u.name) -}}
+{{- $users = (concat (default (list ) $users) (list $u.name)) -}}
 {{- end -}}
 {{- (dict "r" (dict "superusers" $users )) | toJson -}}
 {{- break -}}
@@ -268,9 +268,9 @@
 {{- $fullname := (index .a 2) -}}
 {{- $internalDomain := (index .a 3) -}}
 {{- range $_ := (list 1) -}}
-{{- $result := (list ) -}}
+{{- $result := (coalesce nil) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) ($replicas|int) (1|int) -}}
-{{- $result = (mustAppend $result (dict "host" (dict "address" (printf "%s-%d.%s" $fullname $i $internalDomain) "port" ($l.rpc.port | int) ) )) -}}
+{{- $result = (concat (default (list ) $result) (list (dict "host" (dict "address" (printf "%s-%d.%s" $fullname $i $internalDomain) "port" ($l.rpc.port | int) ) ))) -}}
 {{- end -}}
 {{- (dict "r" $result) | toJson -}}
 {{- break -}}
@@ -283,9 +283,9 @@
 {{- $fullname := (index .a 2) -}}
 {{- $internalDomain := (index .a 3) -}}
 {{- range $_ := (list 1) -}}
-{{- $result := (list ) -}}
+{{- $result := (coalesce nil) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) ($replicas|int) (1|int) -}}
-{{- $result = (mustAppend $result (printf "%s-%d.%s:%d" $fullname $i $internalDomain (($l.admin.port | int) | int))) -}}
+{{- $result = (concat (default (list ) $result) (list (printf "%s-%d.%s:%d" $fullname $i $internalDomain (($l.admin.port | int) | int)))) -}}
 {{- end -}}
 {{- (dict "r" $result) | toJson -}}
 {{- break -}}
@@ -395,7 +395,7 @@
 {{- if (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) -}}
 {{- continue -}}
 {{- end -}}
-{{- $admin = (mustAppend $admin (dict "name" $k "port" ($lis.port | int) "address" "0.0.0.0" )) -}}
+{{- $admin = (concat (default (list ) $admin) (list (dict "name" $k "port" ($lis.port | int) "address" "0.0.0.0" ))) -}}
 {{- end -}}
 {{- (dict "r" $admin) | toJson -}}
 {{- break -}}
@@ -409,14 +409,14 @@
 {{- $admin := (list ) -}}
 {{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
-{{- $admin = (mustAppend $admin $internal) -}}
+{{- $admin = (concat (default (list ) $admin) (list $internal)) -}}
 {{- end -}}
 {{- range $k, $lis := $l.external -}}
 {{- if (or (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $admin = (mustAppend $admin (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") )) -}}
+{{- $admin = (concat (default (list ) $admin) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $admin) | toJson -}}
 {{- break -}}
@@ -456,7 +456,7 @@
 {{- if (ne $am_21 "") -}}
 {{- $_ := (set $listener "authentication_method" $am_21) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $listener) -}}
+{{- $result = (concat (default (list ) $result) (list $listener)) -}}
 {{- end -}}
 {{- (dict "r" $result) | toJson -}}
 {{- break -}}
@@ -470,14 +470,14 @@
 {{- $pp := (list ) -}}
 {{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
-{{- $pp = (mustAppend $pp $internal) -}}
+{{- $pp = (concat (default (list ) $pp) (list $internal)) -}}
 {{- end -}}
 {{- range $k, $lis := $l.external -}}
 {{- if (or (not (get (fromJson (include "redpanda.HTTPExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $pp = (mustAppend $pp (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") )) -}}
+{{- $pp = (concat (default (list ) $pp) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $pp) | toJson -}}
 {{- break -}}
@@ -517,7 +517,7 @@
 {{- if (ne $am_23 "") -}}
 {{- $_ := (set $listener "authentication_method" $am_23) -}}
 {{- end -}}
-{{- $kafka = (mustAppend $kafka $listener) -}}
+{{- $kafka = (concat (default (list ) $kafka) (list $listener)) -}}
 {{- end -}}
 {{- (dict "r" $kafka) | toJson -}}
 {{- break -}}
@@ -531,14 +531,14 @@
 {{- $kafka := (list ) -}}
 {{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
-{{- $kafka = (mustAppend $kafka $internal) -}}
+{{- $kafka = (concat (default (list ) $kafka) (list $internal)) -}}
 {{- end -}}
 {{- range $k, $lis := $l.external -}}
 {{- if (or (not (get (fromJson (include "redpanda.KafkaExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $kafka = (mustAppend $kafka (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") )) -}}
+{{- $kafka = (concat (default (list ) $kafka) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $kafka) | toJson -}}
 {{- break -}}
@@ -578,7 +578,7 @@
 {{- if (ne $am_25 "") -}}
 {{- $_ := (set $listener "authentication_method" $am_25) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $listener) -}}
+{{- $result = (concat (default (list ) $result) (list $listener)) -}}
 {{- end -}}
 {{- (dict "r" $result) | toJson -}}
 {{- break -}}
@@ -592,14 +592,14 @@
 {{- $listeners := (list ) -}}
 {{- $internal := (get (fromJson (include "redpanda.createInternalListenerTLSCfg" (dict "a" (list $tls $l.tls) ))) "r") -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $internal) ))) "r") | int) (0 | int)) -}}
-{{- $listeners = (mustAppend $listeners $internal) -}}
+{{- $listeners = (concat (default (list ) $listeners) (list $internal)) -}}
 {{- end -}}
 {{- range $k, $lis := $l.external -}}
 {{- if (or (not (get (fromJson (include "redpanda.SchemaRegistryExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) -}}
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $listeners = (mustAppend $listeners (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") )) -}}
+{{- $listeners = (concat (default (list ) $listeners) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $listeners) | toJson -}}
 {{- break -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -693,8 +693,7 @@ type Listeners struct {
 }
 
 func (l *Listeners) CreateSeedServers(replicas int, fullname, internalDomain string) []map[string]any {
-	result := []map[string]any{}
-
+	var result []map[string]any
 	for i := 0; i < replicas; i++ {
 		result = append(result, map[string]any{
 			"host": map[string]any{
@@ -703,17 +702,14 @@ func (l *Listeners) CreateSeedServers(replicas int, fullname, internalDomain str
 			},
 		})
 	}
-
 	return result
 }
 
 func (l *Listeners) AdminList(replicas int, fullname, internalDomain string) []string {
-	result := []string{}
-
+	var result []string
 	for i := 0; i < replicas; i++ {
 		result = append(result, fmt.Sprintf("%s-%d.%s:%d", fullname, i, internalDomain, int(l.Admin.Port)))
 	}
-
 	return result
 }
 

--- a/pkg/gotohelm/testdata/src/example/inputs/inputs.yaml
+++ b/pkg/gotohelm/testdata/src/example/inputs/inputs.yaml
@@ -37,7 +37,7 @@
 {{- range $_ := (list 1) -}}
 {{- $keys := (list ) -}}
 {{- range $key, $_ := $globals.Values -}}
-{{- $keys = (mustAppend $keys $key) -}}
+{{- $keys = (concat (default (list ) $keys) (list $key)) -}}
 {{- end -}}
 {{- $keys = (keys $globals.Values) -}}
 {{- $_ := (sortAlpha $keys) -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/shims.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/shims.yaml
@@ -12,13 +12,13 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $inputs := (get (fromJson (include "sprig.numericTestInputs" (dict "a" (list $dot) ))) "r") -}}
-{{- $inputs = (concat $inputs (list ((10 | int) | int) 1.5 (index $dot.Values "numeric"))) -}}
+{{- $inputs = (concat (default (list ) $inputs) (list ((10 | int) | int) 1.5 (index $dot.Values "numeric"))) -}}
 {{- $outputs := (list ) -}}
 {{- range $_, $in := $inputs -}}
 {{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $in) ))) "r")) ))) "r") -}}
 {{- $isNumeric := $tmp_tuple_1.T2 -}}
 {{- $value := ($tmp_tuple_1.T1 | float64) -}}
-{{- $outputs = (mustAppend $outputs (list $in $value $isNumeric)) -}}
+{{- $outputs = (concat (default (list ) $outputs) (list (list $in $value $isNumeric))) -}}
 {{- end -}}
 {{- (dict "r" $outputs) | toJson -}}
 {{- break -}}
@@ -29,13 +29,13 @@
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $inputs := (get (fromJson (include "sprig.numericTestInputs" (dict "a" (list $dot) ))) "r") -}}
-{{- $inputs = (concat $inputs (list ((10 | int) | int) 1.5 (index $dot.Values "numeric"))) -}}
+{{- $inputs = (concat (default (list ) $inputs) (list ((10 | int) | int) 1.5 (index $dot.Values "numeric"))) -}}
 {{- $outputs := (list ) -}}
 {{- range $_, $in := $inputs -}}
 {{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $in) ))) "r")) ))) "r") -}}
 {{- $isIntegral := $tmp_tuple_2.T2 -}}
 {{- $value := ($tmp_tuple_2.T1 | int) -}}
-{{- $outputs = (mustAppend $outputs (list $in $value $isIntegral)) -}}
+{{- $outputs = (concat (default (list ) $outputs) (list (list $in $value $isIntegral))) -}}
 {{- end -}}
 {{- (dict "r" $outputs) | toJson -}}
 {{- break -}}

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -125,7 +125,7 @@
 
 {{- define "sprig.concat" -}}
 {{- range $_ := (list 1) -}}
-{{- (dict "r" (list (concat (list (1 | int) (2 | int)) (list (3 | int) (4 | int))) (concat (list (1 | int) (2 | int)) (list (3 | int) (4 | int)) (list (5 | int) (6 | int))) (concat (list (1 | int) (2 | int)) (list (3 | int) (4 | int))) (concat (list (1 | int) (2 | int)) (list (3 | int) (4 | int))))) | toJson -}}
+{{- (dict "r" (list (concat (list (1 | int) (2 | int)) (list (3 | int) (4 | int))) (concat (list (1 | int) (2 | int)) (list (3 | int) (4 | int)) (list (5 | int) (6 | int))) (concat (default (list ) (list (1 | int) (2 | int))) (default (list ) (list (3 | int) (4 | int)))) (concat (default (list ) (list (1 | int) (2 | int))) (list (3 | int) (4 | int))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.go
@@ -59,6 +59,7 @@ func Syntax() map[string]any {
 		"forExpr":         forExpr(10, Complex{Iterations: 5}),
 		"binaryExprs":     binaryExprs(),
 		"instance-method": instanceMethod(),
+		"append":          appends(),
 	}
 }
 
@@ -278,4 +279,17 @@ func forExpr(iteration int, in Complex) [][]string {
 	result = append(result, test)
 
 	return result
+}
+
+func appends() [][]int {
+	var x []int
+	y := []int{1, 2, 3}
+
+	return [][]int{
+		append(x),
+		append(x, 4),
+		append(x, y...),
+		append(y, x...),
+		append(y, 1, 2, 3, 4),
+	}
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.rewritten.go
@@ -62,6 +62,7 @@ func Syntax() map[string]any {
 		"forExpr":         forExpr(10, Complex{Iterations: 5}),
 		"binaryExprs":     binaryExprs(),
 		"instance-method": instanceMethod(),
+		"append":          appends(),
 	}
 }
 
@@ -281,4 +282,17 @@ func forExpr(iteration int, in Complex) [][]string {
 	result = append(result, test)
 
 	return result
+}
+
+func appends() [][]int {
+	var x []int
+	y := []int{1, 2, 3}
+
+	return [][]int{
+		append(x),
+		append(x, 4),
+		append(x, y...),
+		append(y, x...),
+		append(y, 1, 2, 3, 4),
+	}
 }

--- a/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
+++ b/pkg/gotohelm/testdata/src/example/syntax/syntax.yaml
@@ -23,7 +23,7 @@
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "[]%s" "string") $x (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $_ = (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list (printf "map[%s]%s" "string" "interface {}") $x (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list (10 | int) (mustMergeOverwrite (dict "Iterations" 0 ) (dict "Iterations" (5 | int) ))) ))) "r") "binaryExprs" (get (fromJson (include "syntax.binaryExprs" (dict "a" (list ) ))) "r") "instance-method" (get (fromJson (include "syntax.instanceMethod" (dict "a" (list ) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "sliceExpr" $slice "negativeNumbers" (list -2 -4) "forExpr" (get (fromJson (include "syntax.forExpr" (dict "a" (list (10 | int) (mustMergeOverwrite (dict "Iterations" 0 ) (dict "Iterations" (5 | int) ))) ))) "r") "binaryExprs" (get (fromJson (include "syntax.binaryExprs" (dict "a" (list ) ))) "r") "instance-method" (get (fromJson (include "syntax.instanceMethod" (dict "a" (list ) ))) "r") "append" (get (fromJson (include "syntax.appends" (dict "a" (list ) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -169,50 +169,59 @@
 {{- $result := (list ) -}}
 {{- $test := (list ) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) (($in.Iterations | int)|int) (1|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((0 | int)|int) ($iteration|int) (1|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((2 | int)|int) ($iteration|int) (1|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((2 | int)|int) (($in.Iterations | int)|int) (1|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((2 | int)|int) ($iteration|int) ((2 | int)|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((2 | int)|int) (($in.Iterations | int)|int) ((2 | int)|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((17 | int)|int) ($iteration|int) ((-2 | int)|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ((17 | int)|int) (($in.Iterations | int)|int) ((-2 | int)|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- $test = (list ) -}}
 {{- range $_, $i := untilStep ($iteration|int) ((17 | int)|int) ((-2 | int)|int) -}}
-{{- $test = (mustAppend $test (printf "%d" $i)) -}}
+{{- $test = (concat (default (list ) $test) (list (printf "%d" $i))) -}}
 {{- end -}}
-{{- $result = (mustAppend $result $test) -}}
+{{- $result = (concat (default (list ) $result) (list $test)) -}}
 {{- (dict "r" $result) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "syntax.appends" -}}
+{{- range $_ := (list 1) -}}
+{{- $x := (coalesce nil) -}}
+{{- $y := (list (1 | int) (2 | int) (3 | int)) -}}
+{{- (dict "r" (list (concat (default (list ) $x) (list )) (concat (default (list ) $x) (list (4 | int))) (concat (default (list ) $x) (default (list ) $y)) (concat (default (list ) $y) (default (list ) $x)) (concat (default (list ) $y) (list (1 | int) (2 | int) (3 | int) (4 | int))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
Prior to this commit our gotohelmified go code was littered with slice declarations in the form `_ := T[]{}` due to sprig's `mustAppend` function not supporting appends to `nil` slices as go's does.

This commit corrects the semantics of transpiling `append` to now match go's semantics by use of `default` and `concat` instead of `mustAppend`. It also updates a few occurences of `_ := T[]{}` to the more idiomatic `var _ T[]`