### PR TITLE
redpanda: allow specifying `truststore_file`

### DIFF
--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -323,11 +323,11 @@ func brokersTLSConfiguration(dot *helmette.Dot) map[string]any {
 	}
 
 	result := map[string]any{}
-	certName := values.Listeners.Kafka.TLS.Cert
 
-	if cert, ok := values.TLS.Certs[certName]; ok && cert.CAEnabled {
-		result["truststore_file"] = fmt.Sprintf("/etc/tls/certs/%s/ca.crt", values.Listeners.Kafka.TLS.Cert)
+	if truststore := values.Listeners.Kafka.TLS.TrustStoreFilePath(&values.TLS); truststore != defaultTruststorePath {
+		result["truststore_file"] = truststore
 	}
+
 	if values.Listeners.Kafka.TLS.RequireClientAuth {
 		result["cert_file"] = fmt.Sprintf("/etc/tls/certs/%s-client/tls.crt", Fullname(dot))
 		result["key_file"] = fmt.Sprintf("/etc/tls/certs/%s-client/tls.key", Fullname(dot))
@@ -345,10 +345,8 @@ func adminTLSConfiguration(dot *helmette.Dot) map[string]any {
 		return result
 	}
 
-	certName := values.Listeners.Admin.TLS.Cert
-
-	if cert, ok := values.TLS.Certs[certName]; ok && cert.CAEnabled {
-		result["truststore_file"] = fmt.Sprintf("/etc/tls/certs/%s/ca.crt", values.Listeners.Admin.TLS.Cert)
+	if truststore := values.Listeners.Admin.TLS.TrustStoreFilePath(&values.TLS); truststore != defaultTruststorePath {
+		result["truststore_file"] = truststore
 	}
 
 	if values.Listeners.Admin.TLS.RequireClientAuth {
@@ -380,7 +378,7 @@ func kafkaClient(dot *helmette.Dot) map[string]any {
 			"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", kafkaTLS.Cert),
 			"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", kafkaTLS.Cert),
 			"require_client_auth": kafkaTLS.RequireClientAuth,
-			"truststore_file":     values.TLS.Certs.getTrustStoreFilePath(kafkaTLS.Cert),
+			"truststore_file":     kafkaTLS.TrustStoreFilePath(&values.TLS),
 		}
 	}
 
@@ -468,7 +466,7 @@ func rpcListenersTLS(dot *helmette.Dot) map[string]any {
 		"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", certName),
 		"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", certName),
 		"require_client_auth": r.TLS.RequireClientAuth,
-		"truststore_file":     values.TLS.Certs.getTrustStoreFilePath(certName),
+		"truststore_file":     r.TLS.TrustStoreFilePath(&values.TLS),
 	}
 }
 
@@ -493,7 +491,7 @@ func createInternalListenerTLSCfg(tls *TLS, internal InternalTLS) map[string]any
 		"cert_file":           fmt.Sprintf("/etc/tls/certs/%s/tls.crt", internal.Cert),
 		"key_file":            fmt.Sprintf("/etc/tls/certs/%s/tls.key", internal.Cert),
 		"require_client_auth": internal.RequireClientAuth,
-		"truststore_file":     tls.Certs.getTrustStoreFilePath(internal.Cert),
+		"truststore_file":     internal.TrustStoreFilePath(tls),
 	}
 }
 

--- a/charts/redpanda/templates/_configmap.go.tpl
+++ b/charts/redpanda/templates/_configmap.go.tpl
@@ -242,12 +242,9 @@
 {{- break -}}
 {{- end -}}
 {{- $result := (dict ) -}}
-{{- $certName := $values.listeners.kafka.tls.cert -}}
-{{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.tls.certs $certName (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- $ok_6 := $tmp_tuple_3.T2 -}}
-{{- $cert_5 := $tmp_tuple_3.T1 -}}
-{{- if (and $ok_6 $cert_5.caEnabled) -}}
-{{- $_ := (set $result "truststore_file" (printf "/etc/tls/certs/%s/ca.crt" $values.listeners.kafka.tls.cert)) -}}
+{{- $truststore_5 := (get (fromJson (include "redpanda.InternalTLS.TrustStoreFilePath" (dict "a" (list $values.listeners.kafka.tls $values.tls) ))) "r") -}}
+{{- if (ne $truststore_5 "/etc/ssl/certs/ca-certificates.crt") -}}
+{{- $_ := (set $result "truststore_file" $truststore_5) -}}
 {{- end -}}
 {{- if $values.listeners.kafka.tls.requireClientAuth -}}
 {{- $_ := (set $result "cert_file" (printf "/etc/tls/certs/%s-client/tls.crt" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) -}}
@@ -267,12 +264,9 @@
 {{- (dict "r" $result) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- $certName := $values.listeners.admin.tls.cert -}}
-{{- $tmp_tuple_4 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.tls.certs $certName (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- $ok_8 := $tmp_tuple_4.T2 -}}
-{{- $cert_7 := $tmp_tuple_4.T1 -}}
-{{- if (and $ok_8 $cert_7.caEnabled) -}}
-{{- $_ := (set $result "truststore_file" (printf "/etc/tls/certs/%s/ca.crt" $values.listeners.admin.tls.cert)) -}}
+{{- $truststore_6 := (get (fromJson (include "redpanda.InternalTLS.TrustStoreFilePath" (dict "a" (list $values.listeners.admin.tls $values.tls) ))) "r") -}}
+{{- if (ne $truststore_6 "/etc/ssl/certs/ca-certificates.crt") -}}
+{{- $_ := (set $result "truststore_file" $truststore_6) -}}
 {{- end -}}
 {{- if $values.listeners.admin.tls.requireClientAuth -}}
 {{- $_ := (set $result "cert_file" (printf "/etc/tls/certs/%s-client/tls.crt" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) -}}
@@ -294,7 +288,7 @@
 {{- $kafkaTLS := $values.listeners.kafka.tls -}}
 {{- $brokerTLS := (coalesce nil) -}}
 {{- if (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $values.listeners.kafka.tls $values.tls) ))) "r") -}}
-{{- $brokerTLS = (dict "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $kafkaTLS.cert) "key_file" (printf "/etc/tls/certs/%s/tls.key" $kafkaTLS.cert) "require_client_auth" $kafkaTLS.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $values.tls.certs) $kafkaTLS.cert) ))) "r") ) -}}
+{{- $brokerTLS = (dict "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $kafkaTLS.cert) "key_file" (printf "/etc/tls/certs/%s/tls.key" $kafkaTLS.cert) "require_client_auth" $kafkaTLS.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.InternalTLS.TrustStoreFilePath" (dict "a" (list $kafkaTLS $values.tls) ))) "r") ) -}}
 {{- end -}}
 {{- $cfg := (dict "brokers" $brokerList ) -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $brokerTLS) ))) "r") | int) (0 | int)) -}}
@@ -314,18 +308,18 @@
 {{- $_ := (set $redpanda "kafka_api" (get (fromJson (include "redpanda.KafkaListeners.Listeners" (dict "a" (list $values.listeners.kafka $values.auth) ))) "r")) -}}
 {{- $_ := (set $redpanda "rpc_server" (get (fromJson (include "redpanda.rpcListeners" (dict "a" (list $dot) ))) "r")) -}}
 {{- $_ := (set $redpanda "admin_api_tls" (coalesce nil)) -}}
-{{- $tls_9 := (get (fromJson (include "redpanda.AdminListeners.ListenersTLS" (dict "a" (list $values.listeners.admin $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_9) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $redpanda "admin_api_tls" $tls_9) -}}
+{{- $tls_7 := (get (fromJson (include "redpanda.AdminListeners.ListenersTLS" (dict "a" (list $values.listeners.admin $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_7) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "admin_api_tls" $tls_7) -}}
 {{- end -}}
 {{- $_ := (set $redpanda "kafka_api_tls" (coalesce nil)) -}}
-{{- $tls_10 := (get (fromJson (include "redpanda.KafkaListeners.ListenersTLS" (dict "a" (list $values.listeners.kafka $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_10) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $redpanda "kafka_api_tls" $tls_10) -}}
+{{- $tls_8 := (get (fromJson (include "redpanda.KafkaListeners.ListenersTLS" (dict "a" (list $values.listeners.kafka $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_8) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "kafka_api_tls" $tls_8) -}}
 {{- end -}}
-{{- $tls_11 := (get (fromJson (include "redpanda.rpcListenersTLS" (dict "a" (list $dot) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_11) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $redpanda "rpc_server_tls" $tls_11) -}}
+{{- $tls_9 := (get (fromJson (include "redpanda.rpcListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_9) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "rpc_server_tls" $tls_9) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -337,9 +331,9 @@
 {{- $pandaProxy := (dict ) -}}
 {{- $_ := (set $pandaProxy "pandaproxy_api" (get (fromJson (include "redpanda.HTTPListeners.Listeners" (dict "a" (list $values.listeners.http (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $_ := (set $pandaProxy "pandaproxy_api_tls" (coalesce nil)) -}}
-{{- $tls_12 := (get (fromJson (include "redpanda.HTTPListeners.ListenersTLS" (dict "a" (list $values.listeners.http $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_12) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $pandaProxy "pandaproxy_api_tls" $tls_12) -}}
+{{- $tls_10 := (get (fromJson (include "redpanda.HTTPListeners.ListenersTLS" (dict "a" (list $values.listeners.http $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_10) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $pandaProxy "pandaproxy_api_tls" $tls_10) -}}
 {{- end -}}
 {{- (dict "r" $pandaProxy) | toJson -}}
 {{- break -}}
@@ -353,9 +347,9 @@
 {{- $schemaReg := (dict ) -}}
 {{- $_ := (set $schemaReg "schema_registry_api" (get (fromJson (include "redpanda.SchemaRegistryListeners.Listeners" (dict "a" (list $values.listeners.schemaRegistry (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $_ := (set $schemaReg "schema_registry_api_tls" (coalesce nil)) -}}
-{{- $tls_13 := (get (fromJson (include "redpanda.SchemaRegistryListeners.ListenersTLS" (dict "a" (list $values.listeners.schemaRegistry $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_13) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $schemaReg "schema_registry_api_tls" $tls_13) -}}
+{{- $tls_11 := (get (fromJson (include "redpanda.SchemaRegistryListeners.ListenersTLS" (dict "a" (list $values.listeners.schemaRegistry $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_11) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $schemaReg "schema_registry_api_tls" $tls_11) -}}
 {{- end -}}
 {{- (dict "r" $schemaReg) | toJson -}}
 {{- break -}}
@@ -375,7 +369,7 @@
 {{- break -}}
 {{- end -}}
 {{- $certName := $r.tls.cert -}}
-{{- (dict "r" (dict "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" $r.tls.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $values.tls.certs) $certName) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" $r.tls.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.InternalTLS.TrustStoreFilePath" (dict "a" (list $r.tls $values.tls) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -397,7 +391,7 @@
 {{- (dict "r" (dict )) | toJson -}}
 {{- break -}}
 {{- end -}}
-{{- (dict "r" (dict "name" "internal" "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $internal.cert) "key_file" (printf "/etc/tls/certs/%s/tls.key" $internal.cert) "require_client_auth" $internal.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $internal.cert) ))) "r") )) | toJson -}}
+{{- (dict "r" (dict "name" "internal" "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $internal.cert) "key_file" (printf "/etc/tls/certs/%s/tls.key" $internal.cert) "require_client_auth" $internal.requireClientAuth "truststore_file" (get (fromJson (include "redpanda.InternalTLS.TrustStoreFilePath" (dict "a" (list $internal $tls) ))) "r") )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -296,6 +296,36 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "redpanda.Listeners.TrustStoreVolume" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $sources := (coalesce nil) -}}
+{{- range $_, $ts := (get (fromJson (include "redpanda.Listeners.TrustStores" (dict "a" (list $l $tls) ))) "r") -}}
+{{- $sources = (concat (default (list ) $sources) (list (get (fromJson (include "redpanda.TrustStore.VolumeProjection" (dict "a" (list $ts) ))) "r"))) -}}
+{{- end -}}
+{{- if (lt ((get (fromJson (include "_shims.len" (dict "a" (list $sources) ))) "r") | int) (1 | int)) -}}
+{{- (dict "r" (coalesce nil)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "projected" (mustMergeOverwrite (dict "sources" (coalesce nil) ) (dict "sources" $sources )) )) (dict "name" "truststores" ))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Listeners.TrustStores" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $tss := (get (fromJson (include "redpanda.KafkaListeners.TrustStores" (dict "a" (list $l.kafka $tls) ))) "r") -}}
+{{- $tss = (concat (default (list ) $tss) (default (list ) (get (fromJson (include "redpanda.AdminListeners.TrustStores" (dict "a" (list $l.admin $tls) ))) "r"))) -}}
+{{- $tss = (concat (default (list ) $tss) (default (list ) (get (fromJson (include "redpanda.HTTPListeners.TrustStores" (dict "a" (list $l.http $tls) ))) "r"))) -}}
+{{- $tss = (concat (default (list ) $tss) (default (list ) (get (fromJson (include "redpanda.SchemaRegistryListeners.TrustStores" (dict "a" (list $l.schemaRegistry $tls) ))) "r"))) -}}
+{{- (dict "r" $tss) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "redpanda.Config.CreateRPKConfiguration" -}}
 {{- $c := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
@@ -308,43 +338,49 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "redpanda.TLSCertMap.getTrustStoreFilePath" -}}
-{{- $m := (index .a 0) -}}
-{{- $certName := (index .a 1) -}}
-{{- range $_ := (list 1) -}}
-{{- if (eq $m (coalesce nil)) -}}
-{{- $_ := (fail "TLS map is not defined") -}}
-{{- end -}}
-{{- if (eq $certName "") -}}
-{{- (dict "r" "/etc/ssl/certs/ca-certificates.crt") | toJson -}}
-{{- break -}}
-{{- end -}}
-{{- $tmp_tuple_18 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $certName (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- $ok_19 := $tmp_tuple_18.T2 -}}
-{{- $crt_18 := $tmp_tuple_18.T1 -}}
-{{- if (and $ok_19 $crt_18.caEnabled) -}}
-{{- (dict "r" (printf "/etc/tls/certs/%s/ca.crt" $certName)) | toJson -}}
-{{- break -}}
-{{- else -}}{{- if (not $ok_19) -}}
-{{- $_ := (fail (printf "Certificate name reference (%s) defined in listener, but not found in the tls.certs map" $certName)) -}}
-{{- end -}}
-{{- end -}}
-{{- (dict "r" "/etc/ssl/certs/ca-certificates.crt") | toJson -}}
-{{- break -}}
-{{- end -}}
-{{- end -}}
-
 {{- define "redpanda.TLSCertMap.MustGet" -}}
 {{- $m := (index .a 0) -}}
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
-{{- $tmp_tuple_19 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- $ok := $tmp_tuple_19.T2 -}}
-{{- $cert := $tmp_tuple_19.T1 -}}
+{{- $tmp_tuple_18 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_18.T2 -}}
+{{- $cert := $tmp_tuple_18.T1 -}}
 {{- if (not $ok) -}}
-{{- $_ := (fail "TODO") -}}
+{{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
 {{- (dict "r" $cert) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.TrustStore.TrustStoreFilePath" -}}
+{{- $t := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (printf "%s/%s" "/etc/truststores" (get (fromJson (include "redpanda.TrustStore.RelativePath" (dict "a" (list $t) ))) "r"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.TrustStore.RelativePath" -}}
+{{- $t := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $t.configMapKeyRef (coalesce nil)) -}}
+{{- (dict "r" (printf "configmaps/%s-%s" $t.configMapKeyRef.name $t.configMapKeyRef.key)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (printf "secrets/%s-%s" $t.secretKeyRef.name $t.secretKeyRef.key)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.TrustStore.VolumeProjection" -}}
+{{- $t := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $t.configMapKeyRef (coalesce nil)) -}}
+{{- (dict "r" (mustMergeOverwrite (dict ) (dict "configMap" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" $t.configMapKeyRef.name )) (dict "items" (list (mustMergeOverwrite (dict "key" "" "path" "" ) (dict "key" $t.configMapKeyRef.key "path" (get (fromJson (include "redpanda.TrustStore.RelativePath" (dict "a" (list $t) ))) "r") ))) )) ))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (mustMergeOverwrite (dict ) (dict "name" $t.secretKeyRef.name )) (dict "items" (list (mustMergeOverwrite (dict "key" "" "path" "" ) (dict "key" $t.secretKeyRef.key "path" (get (fromJson (include "redpanda.TrustStore.RelativePath" (dict "a" (list $t) ))) "r") ))) )) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -354,6 +390,23 @@
 {{- $tls := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (and (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $t.enabled $tls.enabled) ))) "r") (ne $t.cert ""))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.InternalTLS.TrustStoreFilePath" -}}
+{{- $t := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $t.trustStore (coalesce nil)) -}}
+{{- (dict "r" (get (fromJson (include "redpanda.TrustStore.TrustStoreFilePath" (dict "a" (list $t.trustStore) ))) "r")) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (get (fromJson (include "redpanda.TLSCertMap.MustGet" (dict "a" (list (deepCopy $tls.certs) $t.cert) ))) "r").caEnabled -}}
+{{- (dict "r" (printf "/etc/tls/certs/%s/ca.crt" $t.cert)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" "/etc/ssl/certs/ca-certificates.crt") | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -373,6 +426,24 @@
 {{- $i := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- (dict "r" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $t.cert $i.cert) ))) "r")) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.ExternalTLS.TrustStoreFilePath" -}}
+{{- $t := (index .a 0) -}}
+{{- $i := (index .a 1) -}}
+{{- $tls := (index .a 2) -}}
+{{- range $_ := (list 1) -}}
+{{- if (ne $t.trustStore (coalesce nil)) -}}
+{{- (dict "r" (get (fromJson (include "redpanda.TrustStore.TrustStoreFilePath" (dict "a" (list $t.trustStore) ))) "r")) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- if (get (fromJson (include "redpanda.ExternalTLS.GetCert" (dict "a" (list $t $i $tls) ))) "r").caEnabled -}}
+{{- (dict "r" (printf "/etc/tls/certs/%s/ca.crt" (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $t $i) ))) "r"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" "/etc/ssl/certs/ca-certificates.crt") | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -420,9 +491,28 @@
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $admin = (concat (default (list ) $admin) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
+{{- $admin = (concat (default (list ) $admin) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.ExternalTLS.TrustStoreFilePath" (dict "a" (list $lis.tls $l.tls $tls) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $admin) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.AdminListeners.TrustStores" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $tss := (list ) -}}
+{{- if (and (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $l.tls $tls) ))) "r") (ne $l.tls.trustStore (coalesce nil))) -}}
+{{- $tss = (concat (default (list ) $tss) (list $l.tls.trustStore)) -}}
+{{- end -}}
+{{- range $_, $lis := $l.external -}}
+{{- if (or (or (not (get (fromJson (include "redpanda.AdminExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) (eq $lis.tls.trustStore (coalesce nil))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $tss = (concat (default (list ) $tss) (list $lis.tls.trustStore)) -}}
+{{- end -}}
+{{- (dict "r" $tss) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -443,9 +533,9 @@
 {{- if $saslEnabled -}}
 {{- $_ := (set $internal "authentication_method" "http_basic") -}}
 {{- end -}}
-{{- $am_20 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_20 "") -}}
-{{- $_ := (set $internal "authentication_method" $am_20) -}}
+{{- $am_18 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_18 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_18) -}}
 {{- end -}}
 {{- $result := (list $internal) -}}
 {{- range $k, $l := $l.external -}}
@@ -456,9 +546,9 @@
 {{- if $saslEnabled -}}
 {{- $_ := (set $listener "authentication_method" "http_basic") -}}
 {{- end -}}
-{{- $am_21 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_21 "") -}}
-{{- $_ := (set $listener "authentication_method" $am_21) -}}
+{{- $am_19 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_19 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_19) -}}
 {{- end -}}
 {{- $result = (concat (default (list ) $result) (list $listener)) -}}
 {{- end -}}
@@ -481,9 +571,28 @@
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $pp = (concat (default (list ) $pp) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
+{{- $pp = (concat (default (list ) $pp) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.ExternalTLS.TrustStoreFilePath" (dict "a" (list $lis.tls $l.tls $tls) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $pp) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.HTTPListeners.TrustStores" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $tss := (coalesce nil) -}}
+{{- if (and (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $l.tls $tls) ))) "r") (ne $l.tls.trustStore (coalesce nil))) -}}
+{{- $tss = (concat (default (list ) $tss) (list $l.tls.trustStore)) -}}
+{{- end -}}
+{{- range $_, $lis := $l.external -}}
+{{- if (or (or (not (get (fromJson (include "redpanda.HTTPExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) (eq $lis.tls.trustStore (coalesce nil))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $tss = (concat (default (list ) $tss) (list $lis.tls.trustStore)) -}}
+{{- end -}}
+{{- (dict "r" $tss) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -504,9 +613,9 @@
 {{- if (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $auth) ))) "r") -}}
 {{- $_ := (set $internal "authentication_method" "sasl") -}}
 {{- end -}}
-{{- $am_22 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_22 "") -}}
-{{- $_ := (set $internal "authentication_method" $am_22) -}}
+{{- $am_20 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_20 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_20) -}}
 {{- end -}}
 {{- $kafka := (list $internal) -}}
 {{- range $k, $l := $l.external -}}
@@ -517,9 +626,9 @@
 {{- if (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $auth) ))) "r") -}}
 {{- $_ := (set $listener "authentication_method" "sasl") -}}
 {{- end -}}
-{{- $am_23 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_23 "") -}}
-{{- $_ := (set $listener "authentication_method" $am_23) -}}
+{{- $am_21 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_21 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_21) -}}
 {{- end -}}
 {{- $kafka = (concat (default (list ) $kafka) (list $listener)) -}}
 {{- end -}}
@@ -542,9 +651,28 @@
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $kafka = (concat (default (list ) $kafka) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
+{{- $kafka = (concat (default (list ) $kafka) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.ExternalTLS.TrustStoreFilePath" (dict "a" (list $lis.tls $l.tls $tls) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $kafka) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.KafkaListeners.TrustStores" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $tss := (coalesce nil) -}}
+{{- if (and (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $l.tls $tls) ))) "r") (ne $l.tls.trustStore (coalesce nil))) -}}
+{{- $tss = (concat (default (list ) $tss) (list $l.tls.trustStore)) -}}
+{{- end -}}
+{{- range $_, $lis := $l.external -}}
+{{- if (or (or (not (get (fromJson (include "redpanda.KafkaExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) (eq $lis.tls.trustStore (coalesce nil))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $tss = (concat (default (list ) $tss) (list $lis.tls.trustStore)) -}}
+{{- end -}}
+{{- (dict "r" $tss) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -565,9 +693,9 @@
 {{- if $saslEnabled -}}
 {{- $_ := (set $internal "authentication_method" "http_basic") -}}
 {{- end -}}
-{{- $am_24 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $sr.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_24 "") -}}
-{{- $_ := (set $internal "authentication_method" $am_24) -}}
+{{- $am_22 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $sr.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_22 "") -}}
+{{- $_ := (set $internal "authentication_method" $am_22) -}}
 {{- end -}}
 {{- $result := (list $internal) -}}
 {{- range $k, $l := $sr.external -}}
@@ -578,9 +706,9 @@
 {{- if $saslEnabled -}}
 {{- $_ := (set $listener "authentication_method" "http_basic") -}}
 {{- end -}}
-{{- $am_25 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
-{{- if (ne $am_25 "") -}}
-{{- $_ := (set $listener "authentication_method" $am_25) -}}
+{{- $am_23 := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $l.authenticationMethod "") ))) "r") -}}
+{{- if (ne $am_23 "") -}}
+{{- $_ := (set $listener "authentication_method" $am_23) -}}
 {{- end -}}
 {{- $result = (concat (default (list ) $result) (list $listener)) -}}
 {{- end -}}
@@ -603,9 +731,28 @@
 {{- continue -}}
 {{- end -}}
 {{- $certName := (get (fromJson (include "redpanda.ExternalTLS.GetCertName" (dict "a" (list $lis.tls $l.tls) ))) "r") -}}
-{{- $listeners = (concat (default (list ) $listeners) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.TLSCertMap.getTrustStoreFilePath" (dict "a" (list (deepCopy $tls.certs) $certName) ))) "r") ))) -}}
+{{- $listeners = (concat (default (list ) $listeners) (list (dict "name" $k "enabled" true "cert_file" (printf "/etc/tls/certs/%s/tls.crt" $certName) "key_file" (printf "/etc/tls/certs/%s/tls.key" $certName) "require_client_auth" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $lis.tls.requireClientAuth false) ))) "r") "truststore_file" (get (fromJson (include "redpanda.ExternalTLS.TrustStoreFilePath" (dict "a" (list $lis.tls $l.tls $tls) ))) "r") ))) -}}
 {{- end -}}
 {{- (dict "r" $listeners) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.SchemaRegistryListeners.TrustStores" -}}
+{{- $l := (index .a 0) -}}
+{{- $tls := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $tss := (coalesce nil) -}}
+{{- if (and (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $l.tls $tls) ))) "r") (ne $l.tls.trustStore (coalesce nil))) -}}
+{{- $tss = (concat (default (list ) $tss) (list $l.tls.trustStore)) -}}
+{{- end -}}
+{{- range $_, $lis := $l.external -}}
+{{- if (or (or (not (get (fromJson (include "redpanda.SchemaRegistryExternal.IsEnabled" (dict "a" (list $lis) ))) "r")) (not (get (fromJson (include "redpanda.ExternalTLS.IsEnabled" (dict "a" (list $lis.tls $l.tls $tls) ))) "r"))) (eq $lis.tls.trustStore (coalesce nil))) -}}
+{{- continue -}}
+{{- end -}}
+{{- $tss = (concat (default (list ) $tss) (list $lis.tls.trustStore)) -}}
+{{- end -}}
+{{- (dict "r" $tss) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -660,26 +807,26 @@
 {{- if (and (eq $k "default_topic_replications") (not $skipDefaultTopic)) -}}
 {{- $r := ($replicas | int) -}}
 {{- $input := ($r | int) -}}
-{{- $tmp_tuple_22 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_27 := $tmp_tuple_22.T2 -}}
-{{- $num_26 := ($tmp_tuple_22.T1 | int) -}}
-{{- if $ok_27 -}}
-{{- $input = $num_26 -}}
+{{- $tmp_tuple_21 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_25 := $tmp_tuple_21.T2 -}}
+{{- $num_24 := ($tmp_tuple_21.T1 | int) -}}
+{{- if $ok_25 -}}
+{{- $input = $num_24 -}}
 {{- end -}}
-{{- $tmp_tuple_23 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_29 := $tmp_tuple_23.T2 -}}
-{{- $f_28 := ($tmp_tuple_23.T1 | float64) -}}
-{{- if $ok_29 -}}
-{{- $input = ($f_28 | int) -}}
+{{- $tmp_tuple_22 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_27 := $tmp_tuple_22.T2 -}}
+{{- $f_26 := ($tmp_tuple_22.T1 | float64) -}}
+{{- if $ok_27 -}}
+{{- $input = ($f_26 | int) -}}
 {{- end -}}
 {{- $_ := (set $result $k (min $input ((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int))) -}}
 {{- continue -}}
 {{- end -}}
-{{- $tmp_tuple_24 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
-{{- $ok_31 := $tmp_tuple_24.T2 -}}
-{{- $b_30 := $tmp_tuple_24.T1 -}}
-{{- if $ok_31 -}}
-{{- $_ := (set $result $k $b_30) -}}
+{{- $tmp_tuple_23 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
+{{- $ok_29 := $tmp_tuple_23.T2 -}}
+{{- $b_28 := $tmp_tuple_23.T1 -}}
+{{- if $ok_29 -}}
+{{- $_ := (set $result $k $b_28) -}}
 {{- continue -}}
 {{- end -}}
 {{- if (not (empty $v)) -}}

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -403,6 +403,39 @@
                         },
                         "requireClientAuth": {
                           "type": "boolean"
+                        },
+                        "trustStore": {
+                          "properties": {
+                            "configMapKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object"
@@ -429,6 +462,39 @@
                 },
                 "requireClientAuth": {
                   "type": "boolean"
+                },
+                "trustStore": {
+                  "properties": {
+                    "configMapKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "secretKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "required": [
@@ -511,6 +577,39 @@
                         },
                         "requireClientAuth": {
                           "type": "boolean"
+                        },
+                        "trustStore": {
+                          "properties": {
+                            "configMapKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object"
@@ -541,6 +640,39 @@
                 },
                 "requireClientAuth": {
                   "type": "boolean"
+                },
+                "trustStore": {
+                  "properties": {
+                    "configMapKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "secretKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "required": [
@@ -624,6 +756,39 @@
                         },
                         "requireClientAuth": {
                           "type": "boolean"
+                        },
+                        "trustStore": {
+                          "properties": {
+                            "configMapKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object"
@@ -650,6 +815,39 @@
                 },
                 "requireClientAuth": {
                   "type": "boolean"
+                },
+                "trustStore": {
+                  "properties": {
+                    "configMapKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "secretKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "required": [
@@ -680,6 +878,39 @@
                 },
                 "requireClientAuth": {
                   "type": "boolean"
+                },
+                "trustStore": {
+                  "properties": {
+                    "configMapKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "secretKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "required": [
@@ -759,6 +990,39 @@
                         },
                         "requireClientAuth": {
                           "type": "boolean"
+                        },
+                        "trustStore": {
+                          "properties": {
+                            "configMapKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            },
+                            "secretKeyRef": {
+                              "properties": {
+                                "key": {
+                                  "type": "string"
+                                },
+                                "name": {
+                                  "type": "string"
+                                },
+                                "optional": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "type": "object"
+                            }
+                          },
+                          "type": "object"
                         }
                       },
                       "type": "object"
@@ -786,6 +1050,39 @@
                 },
                 "requireClientAuth": {
                   "type": "boolean"
+                },
+                "trustStore": {
+                  "properties": {
+                    "configMapKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    },
+                    "secretKeyRef": {
+                      "properties": {
+                        "key": {
+                          "type": "string"
+                        },
+                        "name": {
+                          "type": "string"
+                        },
+                        "optional": {
+                          "type": "boolean"
+                        }
+                      },
+                      "type": "object"
+                    }
+                  },
+                  "type": "object"
                 }
               },
               "required": [

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -414,16 +414,23 @@ type PartialSASLAuth struct {
 	Users     []PartialSASLUser `json:"users,omitempty"`
 }
 
+type PartialTrustStore struct {
+	ConfigMapKeyRef *corev1.ConfigMapKeySelector `json:"configMapKeyRef,omitempty"`
+	SecretKeyRef    *corev1.SecretKeySelector    `json:"secretKeyRef,omitempty"`
+}
+
 type PartialInternalTLS struct {
-	Enabled           *bool   `json:"enabled,omitempty"`
-	Cert              *string `json:"cert,omitempty" jsonschema:"required"`
-	RequireClientAuth *bool   `json:"requireClientAuth,omitempty" jsonschema:"required"`
+	Enabled           *bool              `json:"enabled,omitempty"`
+	Cert              *string            `json:"cert,omitempty" jsonschema:"required"`
+	RequireClientAuth *bool              `json:"requireClientAuth,omitempty" jsonschema:"required"`
+	TrustStore        *PartialTrustStore `json:"trustStore,omitempty"`
 }
 
 type PartialExternalTLS struct {
-	Enabled           *bool   `json:"enabled,omitempty"`
-	Cert              *string `json:"cert,omitempty"`
-	RequireClientAuth *bool   `json:"requireClientAuth,omitempty"`
+	Enabled           *bool              `json:"enabled,omitempty"`
+	Cert              *string            `json:"cert,omitempty"`
+	RequireClientAuth *bool              `json:"requireClientAuth,omitempty"`
+	TrustStore        *PartialTrustStore `json:"trustStore,omitempty"`
 }
 
 type PartialAdminListeners struct {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/homeport/dyff v1.7.1
 	github.com/imdario/mergo v0.3.16
 	github.com/invopop/jsonschema v0.12.0
+	github.com/json-iterator/go v1.1.12
 	github.com/lucasjones/reggen v0.0.0-20200904144131-37ba4fa293bb
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.74.0
@@ -95,7 +96,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
-	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.16.0 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect


### PR DESCRIPTION
Prior to this commit the `truststore_file` of a given listener could only be set by using the confusingly named `caEnabled` field on certificates. Furthermore `caEnabled` was limited to a the `ca.crt` key of the certificate's secret and was set on a per certificate basis.

This commit allows explicit control of `truststore_file` on a per listener basis by adding a `truststore` field to listeners' `tls` field. Similar to Kubernetes' `corev1.EnvVarSource`, `truststore` accepts either a `configMapKeyRef` or a `secretKeyRef`.

Fixes #1339