### PR TITLE
*: run tests on Kubernetes 1.30.0

### DIFF
--- a/.github/kind.yaml
+++ b/.github/kind.yaml
@@ -1,9 +1,15 @@
 ---
+# See https://github.com/kubernetes-sigs/kind/releases for images.
 apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 nodes:
   - role: control-plane
+    image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
   - role: worker
+    image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
   - role: worker
+    image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
   - role: worker
+    image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e
   - role: worker
+    image: kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e


### PR DESCRIPTION
This commit updates our kind config to explicitly specify the Kubernetes node version for each node in the cluster and additionally bumps that version to the latest Kubernetes release (1.30.0).