### PR TITLE
redpanda: release 5.8.9

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.8
+version: 5.8.9
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v24.1.1
+appVersion: v24.1.8
 
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.8](https://img.shields.io/badge/Version-5.8.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.1](https://img.shields.io/badge/AppVersion-v24.1.1-informational?style=flat-square)
+![Version: 5.8.9](https://img.shields.io/badge/Version-5.8.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.8](https://img.shields.io/badge/AppVersion-v24.1.8-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 


### PR DESCRIPTION
This commit releases the most recent changes of the redpanda chart and bumps the appVersion to the latest redpanda release at the time of release (v24.1.8).