### PR TITLE
fix up secrets.go

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.9
+version: 5.8.10
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.9](https://img.shields.io/badge/Version-5.8.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.8](https://img.shields.io/badge/AppVersion-v24.1.8-informational?style=flat-square)
+![Version: 5.8.10](https://img.shields.io/badge/Version-5.8.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.8](https://img.shields.io/badge/AppVersion-v24.1.8-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/secrets.go
+++ b/charts/redpanda/secrets.go
@@ -521,8 +521,10 @@ func secretConfiguratorKafkaConfig(dot *helmette.Dot) []string {
 				}
 
 				host := advertisedHostJSON(dot, externalName, port, replicaIndex)
-				// Use the advertised-host as a template
-				address := helmette.Tpl(helmette.ToJSON(host), dot)
+				// XXX: the original code used the stringified `host` value as a template
+				// for re-expansion; however it was impossible to make this work usefully,
+				/// even with the original yaml template.
+				address := helmette.ToJSON(host)
 				prefixTemplate := ptr.Deref(externalVals.PrefixTemplate, "")
 				if prefixTemplate == "" {
 					// Required because the values might not specify this, it'll ensur we see "" if it's missing.
@@ -596,8 +598,10 @@ func secretConfiguratorHTTPConfig(dot *helmette.Dot) []string {
 				}
 
 				host := advertisedHostJSON(dot, externalName, port, replicaIndex)
-				// Use the advertised-host as a template
-				address := helmette.Tpl(helmette.ToJSON(host), dot)
+				// XXX: the original code used the stringified `host` value as a template
+				// for re-expansion; however it was impossible to make this work usefully,
+				/// even with the original yaml template.
+				address := helmette.ToJSON(host)
 
 				prefixTemplate := ptr.Deref(externalVals.PrefixTemplate, "")
 				if prefixTemplate == "" {

--- a/charts/redpanda/templates/secrets.go.tpl
+++ b/charts/redpanda/templates/secrets.go.tpl
@@ -199,7 +199,7 @@ echo "passed"`) -}}
 {{- end -}}
 {{- end -}}
 {{- $host := (get (fromJson (include "redpanda.advertisedHostJSON" (dict "a" (list $dot $externalName $port $replicaIndex) ))) "r") -}}
-{{- $address := (tpl (toJson $host) $dot) -}}
+{{- $address := (toJson $host) -}}
 {{- $prefixTemplate := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $externalVals.prefixTemplate "") ))) "r") -}}
 {{- if (eq $prefixTemplate "") -}}
 {{- $prefixTemplate = (default "" $values.external.prefixTemplate) -}}
@@ -239,7 +239,7 @@ echo "passed"`) -}}
 {{- end -}}
 {{- end -}}
 {{- $host := (get (fromJson (include "redpanda.advertisedHostJSON" (dict "a" (list $dot $externalName $port $replicaIndex) ))) "r") -}}
-{{- $address := (tpl (toJson $host) $dot) -}}
+{{- $address := (toJson $host) -}}
 {{- $prefixTemplate := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $externalVals.prefixTemplate "") ))) "r") -}}
 {{- if (eq $prefixTemplate "") -}}
 {{- $prefixTemplate = (default "" $values.external.prefixTemplate) -}}

--- a/charts/redpanda/testdata/ci/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/01-default-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -145,7 +145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -184,7 +184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -337,7 +337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -363,7 +363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -433,7 +433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -481,7 +481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -608,7 +608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
 spec:
   selector:
@@ -628,11 +628,11 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
       annotations:
-        config.redpanda.com/checksum: aa90aeb75dadca72fc9e5a117d97d2c91ce87d1742337d7d92c800afd7315ab7
+        config.redpanda.com/checksum: 2db215ee97c159ef80ce432d93d5e5ea02397e5bf42ac61dd0e7623dc102525f
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -928,7 +928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -1006,7 +1006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     testlabel: exercise_common_labels_template
   annotations:
     "helm.sh/hook": post-upgrade

--- a/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -181,7 +181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -399,7 +399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -426,7 +426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -495,7 +495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -542,7 +542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -706,7 +706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -725,10 +725,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 2ac6b37aae256eed7076cdd3446b477c13413318b98df401ec6255a0306cac51
+        config.redpanda.com/checksum: e6584271adfcd6cec0ad21de17d6397388b24794659132be35e975c4c1e421de
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1019,7 +1019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1108,7 +1108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1165,7 +1165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1198,7 +1198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1328,7 +1328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -290,7 +290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -450,7 +450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -544,7 +544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -591,7 +591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -724,7 +724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -743,10 +743,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 01c07c970007ed1534365d5178eba7dbe91ebe3181551960c1b0a48fe03de672
+        config.redpanda.com/checksum: 35dc59e4744313a4c764dc5f08ff949d6307d380914491ea1cffaa4e12939114
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1053,7 +1053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1135,7 +1135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -147,7 +147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -164,7 +164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -290,7 +290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -528,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -555,7 +555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -624,7 +624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -671,7 +671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -842,7 +842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -861,10 +861,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 1feea55fcc443a84de420c2433f9113ce45937f0204ac0a639cb34e49b97e3e0
+        config.redpanda.com/checksum: 038ee417c8b4e38f521174b81de070b79021898b0caa0bddfd7046096ea82ec0
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1170,7 +1170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1259,7 +1259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1316,7 +1316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1349,7 +1349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1391,7 +1391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -51,7 +51,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -65,7 +65,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -158,7 +158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -196,7 +196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -450,7 +450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -481,7 +481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
     - ""
@@ -550,7 +550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
     - ""
@@ -580,7 +580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -600,7 +600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -644,7 +644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -691,7 +691,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -855,7 +855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -874,10 +874,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 0bcd37e31b7d33b72c7f5403011c658f300d436157a23a865649e84589ad298d
+        config.redpanda.com/checksum: 15c6b92f0edb8ae1624300d1f8efc1bf59b8512fec695b4aecb4b90f5c3f185d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1168,7 +1168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1194,7 +1194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1314,7 +1314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1331,7 +1331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1347,7 +1347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1389,7 +1389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -485,7 +485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -805,7 +805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -824,10 +824,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 0f6097dcb1c5481fe10a973166070a9ee223cbb4fec6fd1aa3d289c8233f8c95
+        config.redpanda.com/checksum: 0d31d4531c17cee23fa0e8adc81425683647020f7cb3edcb018f0349c103a4a1
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1168,7 +1168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1194,7 +1194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1337,7 +1337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1353,7 +1353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-cert2-root-certificate
@@ -1370,7 +1370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1386,7 +1386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1403,7 +1403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1419,7 +1419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1461,7 +1461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1555,7 +1555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1055,7 +1055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1081,7 +1081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1105,7 +1105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1185,7 +1185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1201,7 +1201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1234,7 +1234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1276,7 +1276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1364,7 +1364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -240,7 +240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -514,7 +514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -587,7 +587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -634,7 +634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -798,7 +798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -817,10 +817,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1210,7 +1210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1234,7 +1234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1273,7 +1273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1314,7 +1314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1330,7 +1330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1347,7 +1347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1363,7 +1363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1405,7 +1405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1493,7 +1493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 0a8be833bf68e01c2db07358c461fbba29e6e17f31d7b6c490d1be558fb660ef
+        config.redpanda.com/checksum: 1658c839e4ac05193669bc1e1bb8e3f51332a454f61ecddaac27c76b082ecf0b
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -146,7 +146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: some-users
   namespace: default
 stringData:
@@ -167,7 +167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -293,7 +293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -557,7 +557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -661,7 +661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -708,7 +708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -879,7 +879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -898,10 +898,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 4a14b5c323987661123027898d7abf3950091b7285f45ca86f82f142a6f4034a
+        config.redpanda.com/checksum: 069d4f585ef63eef7dfb421a12faade8eb478c74c78fed79a67ce17b72c6de93
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1257,7 +1257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1337,7 +1337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1353,7 +1353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1370,7 +1370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1386,7 +1386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1428,7 +1428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1522,7 +1522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d81014c1d7f4f8c580ec92bc570288445f8dbceab55c37a99ca0312cd339c6ac
+        config.redpanda.com/checksum: c144bd0d1802008cf2faf5ea5b8268b6136080b8257eb2bae04525c4a174491f
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1123,7 +1123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1139,7 +1139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1269,7 +1269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -625,7 +625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -671,7 +671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -834,7 +834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -853,10 +853,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 3bc18d07106a7191a54f3727a345b6a97f7ec46ab5e4f46d56c6d73cf32ffcb9
+        config.redpanda.com/checksum: d6ec3bc5a4a4b349d2f3e3dc2a1c1ef4dc02eb64a1092a07731f588a43553e11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1171,7 +1171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1214,7 +1214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1230,7 +1230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1272,7 +1272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1360,7 +1360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -360,7 +360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -389,7 +389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -509,7 +509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -654,10 +654,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 9cd66388a127cd8a6177c37b731f758c2c3cbde2089d614ffaffec60a5636e0b
+        config.redpanda.com/checksum: 3070001107f218f6758aa92ec045c406aadb68de78e85c3ef21108bc55ffce10
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -925,7 +925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -978,7 +978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1250,7 +1250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1396,7 +1396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
     - ""
@@ -528,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
     - ""
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
       - ""
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -630,7 +630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -651,7 +651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
       - apps
@@ -702,7 +702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -794,7 +794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -958,7 +958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -977,10 +977,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1310,7 +1310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1373,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1414,7 +1414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1447,7 +1447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1463,7 +1463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1505,7 +1505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1593,7 +1593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c4ae63b16a07ce73a50c05117d81d45f231fc801f837b33a3216123ca59931bd
+        config.redpanda.com/checksum: 484d24e5a2590e2901cb5c06c54195db35255e12acef5c7dbb8d29bae1f97f88
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1059,7 +1059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1085,7 +1085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1109,7 +1109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1189,7 +1189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1368,7 +1368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 865f5ccf111fe3bca87600c424f04e991be582ab447c6b1ba4f9012330b454ed
+        config.redpanda.com/checksum: c2978f05e0b11cf5f4ad8814b48da36ea90aaa8275795a5ff992f0aff2b9327a
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -485,7 +485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -589,7 +589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -816,7 +816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -835,10 +835,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c7d455702c3875f26a436f9884879af4570b9c174f4620ae264ff5da8c3ccf69
+        config.redpanda.com/checksum: 9ce0788bc11e4f307b510be888dc9e6a80a930442b9ea35baa7a16a2f91c376e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1172,7 +1172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1276,7 +1276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1309,7 +1309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1325,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1367,7 +1367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -486,7 +486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -817,7 +817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -836,10 +836,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 8343bafad1f4e396825f9486a9d6dec1f977b0204f9208809fbefffc5878b9a3
+        config.redpanda.com/checksum: 4298ae9699b0bf2fb775aa1b6d72910876f7f829466644e9f2263ab23ad64346
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1173,7 +1173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1197,7 +1197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1236,7 +1236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1293,7 +1293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1310,7 +1310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1368,7 +1368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1480,7 +1480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -815,7 +815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -834,10 +834,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 440d5b2a55f97686f63cfd2620928f62c06cc0fe6bf23092ef064fb2f7462e05
+        config.redpanda.com/checksum: 09f4d04f6fa684eea8a496d720be6aab7b029a625f7152a21db92bf8d4af4d6e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1172,7 +1172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1196,7 +1196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1276,7 +1276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1309,7 +1309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1325,7 +1325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1367,7 +1367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1475,7 +1475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -437,7 +437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -468,7 +468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -541,7 +541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -752,7 +752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -771,10 +771,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 759c1361b69b3ddb4458b107d64665979747b890eb13d20a2802136894d8997a
+        config.redpanda.com/checksum: 2d37febbd887893e7f1cfd7a4a2bcd12b1b44c3278da0e7dda6b24c8a292a443
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1083,7 +1083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1109,7 +1109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1133,7 +1133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1172,7 +1172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1213,7 +1213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1229,7 +1229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1246,7 +1246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1410,7 +1410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -485,7 +485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -589,7 +589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -816,7 +816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -835,10 +835,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c7d455702c3875f26a436f9884879af4570b9c174f4620ae264ff5da8c3ccf69
+        config.redpanda.com/checksum: 9ce0788bc11e4f307b510be888dc9e6a80a930442b9ea35baa7a16a2f91c376e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1204,7 +1204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1243,7 +1243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -486,7 +486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -817,7 +817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -836,10 +836,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 8343bafad1f4e396825f9486a9d6dec1f977b0204f9208809fbefffc5878b9a3
+        config.redpanda.com/checksum: 4298ae9699b0bf2fb775aa1b6d72910876f7f829466644e9f2263ab23ad64346
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1376,7 +1376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1488,7 +1488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -815,7 +815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -834,10 +834,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 440d5b2a55f97686f63cfd2620928f62c06cc0fe6bf23092ef064fb2f7462e05
+        config.redpanda.com/checksum: 09f4d04f6fa684eea8a496d720be6aab7b029a625f7152a21db92bf8d4af4d6e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1376,7 +1376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1484,7 +1484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -437,7 +437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -468,7 +468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -541,7 +541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -752,7 +752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -771,10 +771,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 440d5b2a55f97686f63cfd2620928f62c06cc0fe6bf23092ef064fb2f7462e05
+        config.redpanda.com/checksum: 09f4d04f6fa684eea8a496d720be6aab7b029a625f7152a21db92bf8d4af4d6e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1118,7 +1118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1313,7 +1313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1419,7 +1419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -485,7 +485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -516,7 +516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -589,7 +589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -816,7 +816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -835,10 +835,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c7d455702c3875f26a436f9884879af4570b9c174f4620ae264ff5da8c3ccf69
+        config.redpanda.com/checksum: 9ce0788bc11e4f307b510be888dc9e6a80a930442b9ea35baa7a16a2f91c376e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1154,7 +1154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1180,7 +1180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1204,7 +1204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1243,7 +1243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1284,7 +1284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1300,7 +1300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1317,7 +1317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1333,7 +1333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1485,7 +1485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -486,7 +486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -517,7 +517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -637,7 +637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -817,7 +817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -836,10 +836,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 8343bafad1f4e396825f9486a9d6dec1f977b0204f9208809fbefffc5878b9a3
+        config.redpanda.com/checksum: 4298ae9699b0bf2fb775aa1b6d72910876f7f829466644e9f2263ab23ad64346
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1376,7 +1376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1488,7 +1488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -484,7 +484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -515,7 +515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -635,7 +635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -815,7 +815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -834,10 +834,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 440d5b2a55f97686f63cfd2620928f62c06cc0fe6bf23092ef064fb2f7462e05
+        config.redpanda.com/checksum: 09f4d04f6fa684eea8a496d720be6aab7b029a625f7152a21db92bf8d4af4d6e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1205,7 +1205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1285,7 +1285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1301,7 +1301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1376,7 +1376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1484,7 +1484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -437,7 +437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -468,7 +468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -541,7 +541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -588,7 +588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -752,7 +752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -771,10 +771,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 440d5b2a55f97686f63cfd2620928f62c06cc0fe6bf23092ef064fb2f7462e05
+        config.redpanda.com/checksum: 09f4d04f6fa684eea8a496d720be6aab7b029a625f7152a21db92bf8d4af4d6e
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1092,7 +1092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1118,7 +1118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1142,7 +1142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1181,7 +1181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1238,7 +1238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1255,7 +1255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1313,7 +1313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1419,7 +1419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: ab6fdb8b292dea8ba0caef96cbf8f0e37467a004644063ec4272ee7576ef3093
+        config.redpanda.com/checksum: a288c3a921f9b033d921851c238b778377e53ab421c057700c73e267de4dd17c
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -763,10 +763,10 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1057,7 +1057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1083,7 +1083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1107,7 +1107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1146,7 +1146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1203,7 +1203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1220,7 +1220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1236,7 +1236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1366,7 +1366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -482,7 +482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -514,7 +514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -589,7 +589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -636,7 +636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -808,7 +808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -827,10 +827,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: ef9ae08cf7e7f437c398cdcdf1be66598e244057c5e023923ea696690729a110
+        config.redpanda.com/checksum: dbbf9364fda4450f6b9fa66ff7e4b5310766280b97abdb5000a5c6b107f5e940
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1129,7 +1129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1155,7 +1155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1179,7 +1179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1218,7 +1218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1259,7 +1259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1292,7 +1292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1308,7 +1308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1350,7 +1350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1438,7 +1438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -52,7 +52,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -145,7 +145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -183,7 +183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -431,7 +431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -462,7 +462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -535,7 +535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -752,7 +752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -774,13 +774,13 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
         redpanda.com/testing-samples-two: two
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1077,7 +1077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1127,7 +1127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1166,7 +1166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1256,7 +1256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1386,7 +1386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -508,7 +508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
     - ""
@@ -528,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
     - ""
@@ -558,7 +558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
       - ""
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -630,7 +630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -651,7 +651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
       - apps
@@ -702,7 +702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -794,7 +794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -958,7 +958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -977,10 +977,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1324,7 +1324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1348,7 +1348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1387,7 +1387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1428,7 +1428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1444,7 +1444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1461,7 +1461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1477,7 +1477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1519,7 +1519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1607,7 +1607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -240,7 +240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -483,7 +483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -514,7 +514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -564,7 +564,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
       - ""
@@ -596,7 +596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -617,7 +617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 rules:
   - apiGroups:
       - apps
@@ -668,7 +668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -713,7 +713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -760,7 +760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -924,7 +924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -943,10 +943,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1268,7 +1268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1294,7 +1294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1357,7 +1357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1398,7 +1398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1414,7 +1414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1431,7 +1431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1447,7 +1447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1489,7 +1489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1577,7 +1577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -576,7 +576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -623,7 +623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -932,7 +932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -951,10 +951,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1245,7 +1245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1271,7 +1271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1295,7 +1295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1334,7 +1334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1391,7 +1391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1408,7 +1408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1424,7 +1424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1466,7 +1466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1554,7 +1554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/36-single-external-address-with-template-domain-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/36-single-external-address-with-template-domain-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 06981221863da080de943266681c36314e7f4380fea044aed8cf7f38e4070371
+        config.redpanda.com/checksum: 102a51ff0ab3ec1668389ff1462acbe7d976c290bfa4b516c5cc1a7f116e5a4f
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1147,7 +1147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/37-internal-service-changed-name-and-annotations-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/37-internal-service-changed-name-and-annotations-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -50,7 +50,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -143,7 +143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -181,7 +181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -429,7 +429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -460,7 +460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -534,7 +534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -582,7 +582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: change-name-external
   namespace: default
 spec:
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -767,11 +767,11 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
         test: test
       annotations:
-        config.redpanda.com/checksum: 30cbf5dcfdd74db8d7c8e97245f7458cadfce62f7edcc682a2063c9f1a909b08
+        config.redpanda.com/checksum: 19da1c6f83d185311b356d2eee641589384cadc57c81e069e10da81c7b72defd
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1064,7 +1064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1090,7 +1090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1114,7 +1114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1153,7 +1153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1194,7 +1194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1210,7 +1210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1227,7 +1227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1243,7 +1243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1258,7 +1258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -1316,7 +1316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1404,7 +1404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/38-post-install-upgrade-merges-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/38-post-install-upgrade-merges-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1095,7 +1095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1199,7 +1199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1290,7 +1290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1394,7 +1394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/38-post-install-upgrade-no-overrides-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/38-post-install-upgrade-no-overrides-novalues.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1069,7 +1069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1095,7 +1095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1158,7 +1158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1199,7 +1199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1232,7 +1232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1290,7 +1290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1398,7 +1398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -193,7 +193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -210,7 +210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -336,7 +336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -610,7 +610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -641,7 +641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -714,7 +714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -761,7 +761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -948,7 +948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -967,10 +967,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 4ef60fc612e1ede678e38d685914b84864ab7732300accd25676f267f1a546d3
+        config.redpanda.com/checksum: 9c4d4cc9edc36c8c935c3c21b21f37a8355260507cf2d1facee44f75c2cbfc0d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1276,7 +1276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1302,7 +1302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1326,7 +1326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1406,7 +1406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1422,7 +1422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1439,7 +1439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1455,7 +1455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1497,7 +1497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1593,7 +1593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -825,10 +825,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1169,7 +1169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1265,7 +1265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1340,7 +1340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -767,10 +767,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1061,7 +1061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1087,7 +1087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1111,7 +1111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1150,7 +1150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1191,7 +1191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1207,7 +1207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1224,7 +1224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1375,7 +1375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -439,7 +439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -470,7 +470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -543,7 +543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -590,7 +590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -768,7 +768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -787,10 +787,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 3b7ed2ea217beb012b7ff44be96b1a99d775c6c343100a1245b8e04c166fcb12
+        config.redpanda.com/checksum: 00319af9b3be72192a1871ea5a3e8a97b2817e4fdb87598d32fcbbe9c8f22d97
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1098,7 +1098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1124,7 +1124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1148,7 +1148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1187,7 +1187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1228,7 +1228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1244,7 +1244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1261,7 +1261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1319,7 +1319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -426,7 +426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -760,10 +760,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d636d86a3eac5aedf92b98f5afbb5256934ff7ebbfb3f53767efa4da5dd3c89f
+        config.redpanda.com/checksum: 30af543c6914bcc9c5dee1eee32742e34761af1428196c50ed74cbec86272d75
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1104,7 +1104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1363,7 +1363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -624,7 +624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -823,10 +823,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 131ad79872815ae16b7f02d208ba9e421c18ab88b98715706f5b848e60505a1d
+        config.redpanda.com/checksum: eef20c28823c903af541386035ed3e26eb6576fc91e2e1dbeb978b9661d1c886
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1167,7 +1167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1338,7 +1338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1428,7 +1428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -463,7 +463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -583,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -766,10 +766,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: bade2ce899435d25f75cf35c18048cf26f360af41667e5d02a5b351ce1fa79da
+        config.redpanda.com/checksum: f35b96eb8241f792ee30105ab01bb946d99237a1161ee98c78562449d2ffed08
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -426,7 +426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -760,10 +760,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d636d86a3eac5aedf92b98f5afbb5256934ff7ebbfb3f53767efa4da5dd3c89f
+        config.redpanda.com/checksum: 30af543c6914bcc9c5dee1eee32742e34761af1428196c50ed74cbec86272d75
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1104,7 +1104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1363,7 +1363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -624,7 +624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -823,10 +823,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 131ad79872815ae16b7f02d208ba9e421c18ab88b98715706f5b848e60505a1d
+        config.redpanda.com/checksum: eef20c28823c903af541386035ed3e26eb6576fc91e2e1dbeb978b9661d1c886
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1167,7 +1167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1338,7 +1338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1428,7 +1428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -463,7 +463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -583,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -766,10 +766,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: bade2ce899435d25f75cf35c18048cf26f360af41667e5d02a5b351ce1fa79da
+        config.redpanda.com/checksum: f35b96eb8241f792ee30105ab01bb946d99237a1161ee98c78562449d2ffed08
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -426,7 +426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -760,10 +760,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d636d86a3eac5aedf92b98f5afbb5256934ff7ebbfb3f53767efa4da5dd3c89f
+        config.redpanda.com/checksum: 30af543c6914bcc9c5dee1eee32742e34761af1428196c50ed74cbec86272d75
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1104,7 +1104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1363,7 +1363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -624,7 +624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -823,10 +823,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 131ad79872815ae16b7f02d208ba9e421c18ab88b98715706f5b848e60505a1d
+        config.redpanda.com/checksum: eef20c28823c903af541386035ed3e26eb6576fc91e2e1dbeb978b9661d1c886
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1167,7 +1167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1338,7 +1338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1428,7 +1428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -463,7 +463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -583,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -766,10 +766,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: bade2ce899435d25f75cf35c18048cf26f360af41667e5d02a5b351ce1fa79da
+        config.redpanda.com/checksum: f35b96eb8241f792ee30105ab01bb946d99237a1161ee98c78562449d2ffed08
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -426,7 +426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -457,7 +457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -530,7 +530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -741,7 +741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -760,10 +760,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d636d86a3eac5aedf92b98f5afbb5256934ff7ebbfb3f53767efa4da5dd3c89f
+        config.redpanda.com/checksum: 30af543c6914bcc9c5dee1eee32742e34761af1428196c50ed74cbec86272d75
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1104,7 +1104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1184,7 +1184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1200,7 +1200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1217,7 +1217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1233,7 +1233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1363,7 +1363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -473,7 +473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -577,7 +577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -624,7 +624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -804,7 +804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -823,10 +823,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 131ad79872815ae16b7f02d208ba9e421c18ab88b98715706f5b848e60505a1d
+        config.redpanda.com/checksum: eef20c28823c903af541386035ed3e26eb6576fc91e2e1dbeb978b9661d1c886
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1117,7 +1117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1143,7 +1143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1167,7 +1167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1247,7 +1247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1263,7 +1263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1280,7 +1280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1296,7 +1296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1338,7 +1338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1428,7 +1428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -463,7 +463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -536,7 +536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -583,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -747,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -766,10 +766,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: bade2ce899435d25f75cf35c18048cf26f360af41667e5d02a5b351ce1fa79da
+        config.redpanda.com/checksum: f35b96eb8241f792ee30105ab01bb946d99237a1161ee98c78562449d2ffed08
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1060,7 +1060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1086,7 +1086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1110,7 +1110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1149,7 +1149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1190,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1239,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1281,7 +1281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1369,7 +1369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 5062d7a7c8764d94287dd25824d0a7310d473cfb31762cd8173d95917b823a07
+        config.redpanda.com/checksum: 5f5611683411e2ab7af11b31e15e4c0ab20c5b0bddf8a8c392ab8c0ce4892b39
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -825,10 +825,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1169,7 +1169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1265,7 +1265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1340,7 +1340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -434,7 +434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -465,7 +465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -768,10 +768,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 0bcd37e31b7d33b72c7f5403011c658f300d436157a23a865649e84589ad298d
+        config.redpanda.com/checksum: 15c6b92f0edb8ae1624300d1f8efc1bf59b8512fec695b4aecb4b90f5c3f185d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1062,7 +1062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1088,7 +1088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1112,7 +1112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 5062d7a7c8764d94287dd25824d0a7310d473cfb31762cd8173d95917b823a07
+        config.redpanda.com/checksum: 5f5611683411e2ab7af11b31e15e4c0ab20c5b0bddf8a8c392ab8c0ce4892b39
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -825,10 +825,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1169,7 +1169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1265,7 +1265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1340,7 +1340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -434,7 +434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -465,7 +465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -768,10 +768,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 0bcd37e31b7d33b72c7f5403011c658f300d436157a23a865649e84589ad298d
+        config.redpanda.com/checksum: 15c6b92f0edb8ae1624300d1f8efc1bf59b8512fec695b4aecb4b90f5c3f185d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1062,7 +1062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1088,7 +1088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1112,7 +1112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -428,7 +428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -459,7 +459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -532,7 +532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -743,7 +743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -762,10 +762,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 5062d7a7c8764d94287dd25824d0a7310d473cfb31762cd8173d95917b823a07
+        config.redpanda.com/checksum: 5f5611683411e2ab7af11b31e15e4c0ab20c5b0bddf8a8c392ab8c0ce4892b39
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1056,7 +1056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1082,7 +1082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1186,7 +1186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1202,7 +1202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1219,7 +1219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1235,7 +1235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1277,7 +1277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1365,7 +1365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -96,7 +96,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -189,7 +189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -475,7 +475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -506,7 +506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -579,7 +579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -626,7 +626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -825,10 +825,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 549626b4ff30ae712bb482375a53c8f3708f8a3d18b45b33b6e48b522585e9f3
+        config.redpanda.com/checksum: 0e448033777a1fc6bcc970eff47a691cae9bb16e0aff074cfb00fd06c7da6d11
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1119,7 +1119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1145,7 +1145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1169,7 +1169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1249,7 +1249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1265,7 +1265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1282,7 +1282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1298,7 +1298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1340,7 +1340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1430,7 +1430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 spec:
@@ -49,7 +49,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -142,7 +142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -180,7 +180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -434,7 +434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda
   namespace: default
 ---
@@ -465,7 +465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -585,7 +585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external
   namespace: default
 spec:
@@ -749,7 +749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selector:
     matchLabels: 
@@ -768,10 +768,10 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.9
+        helm.sh/chart: redpanda-5.8.10
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 0bcd37e31b7d33b72c7f5403011c658f300d436157a23a865649e84589ad298d
+        config.redpanda.com/checksum: 15c6b92f0edb8ae1624300d1f8efc1bf59b8512fec695b4aecb4b90f5c3f185d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 
@@ -1062,7 +1062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1088,7 +1088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   duration: 43800h
   isCA: true
@@ -1112,7 +1112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1151,7 +1151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1192,7 +1192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1208,7 +1208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-default-root-certificate
@@ -1225,7 +1225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   selfSigned: {}
 ---
@@ -1241,7 +1241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
 spec:
   ca:
     secretName: redpanda-external-root-certificate
@@ -1283,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1371,7 +1371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.9
+    helm.sh/chart: redpanda-5.8.10
   annotations:
     "helm.sh/hook": post-upgrade
     "helm.sh/hook-delete-policy": before-hook-creation


### PR DESCRIPTION
The `tmplVals` code appears to be entirely dead code - the only previous call to `tpl` is computing `externalAdvertiseAddress`, which is performed using `.` = `$`. The template expansion of external hostnames is done using the root context (which is preserved in `.` in this case).

### References

https://github.com/redpanda-data/helm-charts/pull/425
https://github.com/helm/helm/issues/4166#issuecomment-497430905
https://github.com/redpanda-data/helm-charts/pull/410