### PR TITLE
redpanda: convert NOTES.txt to go

### DIFF
--- a/charts/redpanda/notes.go
+++ b/charts/redpanda/notes.go
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +gotohelm:filename=notes.go.tpl
+package redpanda
+
+import (
+	"fmt"
+
+	"golang.org/x/exp/maps"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+)
+
+func Warnings(dot *helmette.Dot) []string {
+	var warnings []string
+	if w := cpuWarning(dot); w != "" {
+		warnings = append(warnings, fmt.Sprintf(`**Warning**: %s`, w))
+	}
+	return warnings
+}
+
+func cpuWarning(dot *helmette.Dot) string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	coresInMillis := values.Resources.CPU.Cores.MilliValue()
+	if coresInMillis < 1000 {
+		return fmt.Sprintf("%dm is below the minimum recommended CPU value for Redpanda", coresInMillis)
+	}
+	return ""
+}
+
+func Notes(dot *helmette.Dot) []string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	anySASL := values.Auth.IsSASLEnabled()
+	var notes []string
+	notes = append(notes,
+		``, ``, ``, ``,
+		fmt.Sprintf(`Congratulations on installing %s!`, dot.Chart.Name),
+		``,
+		`The pods will rollout in a few seconds. To check the status:`,
+		``,
+		fmt.Sprintf(`  kubectl -n %s rollout status statefulset %s --watch`,
+			dot.Release.Namespace,
+			Fullname(dot),
+		),
+	)
+	if values.External.Enabled && values.External.Type == corev1.ServiceTypeLoadBalancer {
+		notes = append(notes,
+			``,
+			`If you are using the load balancer service with a cloud provider, the services will likely have automatically-generated addresses. In this scenario the advertised listeners must be updated in order for external access to work. Run the following command once Redpanda is deployed:`,
+			``,
+			// Yes, this really is a jsonpath string to be exposed to the user
+			fmt.Sprintf(`  helm upgrade %s redpanda/redpanda --reuse-values -n %s --set $(kubectl get svc -n %s -o jsonpath='{"external.addresses={"}{ range .items[*]}{.status.loadBalancer.ingress[0].ip }{.status.loadBalancer.ingress[0].hostname}{","}{ end }{"}\n"}')`,
+				Name(dot),
+				dot.Release.Namespace,
+				dot.Release.Namespace,
+			),
+		)
+	}
+	profiles := maps.Keys(values.Listeners.Kafka.External)
+	helmette.SortAlpha(profiles)
+	profileName := profiles[0]
+	notes = append(notes,
+		``,
+		`Set up rpk for access to your external listeners:`,
+	)
+	profile := values.Listeners.Kafka.External[profileName]
+	if TLSEnabled(dot) {
+		var external string
+		if profile.TLS != nil && profile.TLS.Cert != nil {
+			external = *profile.TLS.Cert
+		} else {
+			external = values.Listeners.Kafka.TLS.Cert
+		}
+		notes = append(notes,
+			fmt.Sprintf(`  kubectl get secret -n %s %s-%s-cert -o go-template='{{ index .data "ca.crt" | base64decode }}' > ca.crt`,
+				dot.Release.Namespace,
+				Fullname(dot),
+				external,
+			),
+		)
+		if values.Listeners.Kafka.TLS.RequireClientAuth || values.Listeners.Admin.TLS.RequireClientAuth {
+			notes = append(notes,
+				fmt.Sprintf(`  kubectl get secret -n %s %s-client -o go-template='{{ index .data "tls.crt" | base64decode }}' > tls.crt`,
+					dot.Release.Namespace,
+					Fullname(dot),
+				),
+				fmt.Sprintf(`  kubectl get secret -n %s %s-client -o go-template='{{ index .data "tls.key" | base64decode }}' > tls.key`,
+					dot.Release.Namespace,
+					Fullname(dot),
+				),
+			)
+		}
+	}
+	notes = append(notes,
+		fmt.Sprintf(`  rpk profile create --from-profile <(kubectl get configmap -n %s %s-rpk -o go-template='{{ .data.profile }}') %s`,
+			dot.Release.Namespace,
+			Fullname(dot),
+			profileName,
+		),
+		``,
+		`Set up dns to look up the pods on their Kubernetes Nodes. You can use this query to get the list of short-names to IP addresses. Add your external domain to the hostnames and you could test by adding these to your /etc/hosts:`,
+		``,
+		fmt.Sprintf(`  kubectl get pod -n %s -o custom-columns=node:.status.hostIP,name:.metadata.name --no-headers -l app.kubernetes.io/name=redpanda,app.kubernetes.io/component=redpanda-statefulset`,
+			dot.Release.Namespace,
+		),
+	)
+	if anySASL {
+		notes = append(notes,
+			``,
+			`Set the credentials in the environment:`,
+			``,
+			fmt.Sprintf(`  kubectl -n %s get secret %s -o go-template="{{ range .data }}{{ . | base64decode }}{{ end }}" | IFS=: read -r %s`,
+				dot.Release.Namespace,
+				values.Auth.SASL.SecretRef,
+				RpkSASLEnvironmentVariables(dot),
+			),
+			fmt.Sprintf(`  export %s`,
+				RpkSASLEnvironmentVariables(dot),
+			),
+		)
+	}
+	notes = append(notes,
+		``,
+		`Try some sample commands:`,
+	)
+	if anySASL {
+		notes = append(notes,
+			`Create a user:`,
+			``,
+			fmt.Sprintf(`  %s`, RpkACLUserCreate(dot)),
+			``,
+			`Give the user permissions:`,
+			``,
+			fmt.Sprintf(`  %s`, RpkACLCreate(dot)),
+		)
+	}
+	notes = append(notes,
+		``,
+		`Get the api status:`,
+		``,
+		fmt.Sprintf(`  %s`, RpkClusterInfo(dot)),
+		``,
+		`Create a topic`,
+		``,
+		fmt.Sprintf(`  %s`, RpkTopicCreate(dot)),
+		``,
+		`Describe the topic:`,
+		``,
+		fmt.Sprintf(`  %s`, RpkTopicDescribe(dot)),
+		``,
+		`Delete the topic:`,
+		``,
+		fmt.Sprintf(`  %s`, RpkTopicDelete(dot)),
+	)
+
+	return notes
+}
+
+// Any rpk command that's given to the user in in this file must be defined in _example-commands.tpl and tested in a test.
+// These are all tested in `tests/test-kafka-sasl-status.yaml`
+
+func RpkACLUserCreate(dot *helmette.Dot) string {
+	return fmt.Sprintf(`rpk acl user create myuser --new-password changeme --mechanism %s`, SASLMechanism(dot))
+}
+
+func SASLMechanism(dot *helmette.Dot) string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	if values.Auth.SASL != nil {
+		return values.Auth.SASL.Mechanism
+	}
+	return "SCRAM-SHA-512"
+}
+
+func RpkACLCreate(*helmette.Dot) string {
+	return `rpk acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic'`
+}
+
+func RpkClusterInfo(*helmette.Dot) string {
+	return `rpk cluster info`
+}
+
+func RpkTopicCreate(dot *helmette.Dot) string {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	return fmt.Sprintf(`rpk topic create test-topic -p 3 -r %d`, helmette.Min(3, int64(values.Statefulset.Replicas)))
+}
+
+func RpkTopicDescribe(*helmette.Dot) string {
+	return `rpk topic describe test-topic`
+}
+
+func RpkTopicDelete(dot *helmette.Dot) string {
+	return `rpk topic delete test-topic`
+}
+
+// was:   rpk sasl environment variables
+//
+// This will return a string with the correct environment variables to use for SASL based on the
+// version of the redpanda container being used
+func RpkSASLEnvironmentVariables(dot *helmette.Dot) string {
+	if RedpandaAtLeast_23_2_1(dot) {
+		return `RPK_USER RPK_PASS RPK_SASL_MECHANISM`
+	} else {
+		return `REDPANDA_SASL_USERNAME REDPANDA_SASL_PASSWORD REDPANDA_SASL_MECHANISM`
+	}
+}

--- a/charts/redpanda/templates/NOTES.txt
+++ b/charts/redpanda/templates/NOTES.txt
@@ -15,90 +15,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */}}
 
-{{/*
-  Add warnings to the warnings template
-*/}}
-{{ $warnings := (fromJson (include "warnings" .)).result }}
-{{- if $warnings }}
----
-{{ range $warning := $warnings }}
+{{- $warnings := (get ((include "redpanda.Warnings" (dict "a" (list .))) | fromJson) "r") }}
+{{- range $_, $warning := $warnings }}
 {{ $warning }}
 {{- end }}
 
----
+{{- $notes := (get ((include "redpanda.Notes" (dict "a" (list .))) | fromJson) "r") }}
+{{- range $_, $note := $notes }}
+{{ $note }}
 {{- end }}
-
-{{-
-/*
-Any rpk command that's given to the user in in this file must be defined in _example-commands.tpl and tested in a test.
-*/
--}}
-
-{{- $anySASL := (include "sasl-enabled" . | fromJson).bool }}
-
-Congratulations on installing {{ .Chart.Name }}!
-
-The pods will rollout in a few seconds. To check the status:
-
-  kubectl -n {{ .Release.Namespace }} rollout status statefulset {{ template "redpanda.fullname" . }} --watch
-
-{{- if and (toJson (dict "bool" .Values.external.enabled)) (eq .Values.external.type "LoadBalancer") }}
-
-If you are using the load balancer service with a cloud provider, the services will likely have automatically-generated addresses. In this scenario the advertised listeners must be updated in order for external access to work. Run the following command once Redpanda is deployed:
-
-  {{ printf "helm upgrade %s redpanda/redpanda --reuse-values -n %s --set $(kubectl get svc -n %s -o jsonpath='{\"external.addresses={\"}{ range .items[*]}{.status.loadBalancer.ingress[0].ip }{.status.loadBalancer.ingress[0].hostname}{\",\"}{ end }{\"}\\n\"}')" (include "redpanda.name" .) .Release.Namespace .Release.Namespace }}
-{{- end }}
-
-Set up rpk for access to your external listeners:
-{{- $profile := keys .Values.listeners.kafka.external | first -}}
-{{ if (include "tls-enabled" . | fromJson).bool }}
-  {{- $external := dig "tls" "cert" .Values.listeners.kafka.tls.cert (get .Values.listeners.kafka.external $profile )}}
-  kubectl get secret -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-{{ $external }}-cert -o go-template='{{ "{{" }} index .data "ca.crt" | base64decode }}' > ca.crt
-  {{- if or .Values.listeners.kafka.tls.requireClientAuth .Values.listeners.admin.tls.requireClientAuth }}
-  kubectl get secret -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-client -o go-template='{{ "{{" }} index .data "tls.crt" | base64decode }}' > tls.crt
-  kubectl get secret -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-client -o go-template='{{ "{{" }} index .data "tls.key" | base64decode }}' > tls.key
-  {{- end }}
-{{- end }}
-  rpk profile create --from-profile <(kubectl get configmap -n {{ .Release.Namespace }} {{ include "redpanda.fullname" . }}-rpk -o go-template='{{ "{{" }} .data.profile }}') {{ $profile }}
-
-Set up dns to look up the pods on their Kubernetes Nodes. You can use this query to get the list of short-names to IP addresses. Add your external domain to the hostnames and you could test by adding these to your /etc/hosts:
-
-  kubectl get pod -n {{ .Release.Namespace }} -o custom-columns=node:.status.hostIP,name:.metadata.name --no-headers -l app.kubernetes.io/name=redpanda,app.kubernetes.io/component=redpanda-statefulset
-
-{{- if and $anySASL }}
-
-Set the credentials in the environment:
-
-  kubectl -n {{ .Release.Namespace }} get secret {{ .Values.auth.sasl.secretRef }} -o go-template="{{ "{{" }} range .data }}{{ "{{" }} . | base64decode }}{{ "{{" }} end }}" | IFS=: read -r {{ include "rpk-sasl-environment-variables" . }}
-  export {{ include "rpk-sasl-environment-variables" . }}
-
-{{- end }}
-
-Try some sample commands:
-
-{{- if and $anySASL }}
-Create a user:
-
-  {{ include "rpk-acl-user-create" . }}
-
-Give the user permissions:
-
-  {{ include "rpk-acl-create" . }}
-
-{{- end }}
-
-Get the api status:
-
-  {{ include "rpk-cluster-info" . }}
-
-Create a topic
-
-  {{ include "rpk-topic-create" . }}
-
-Describe the topic:
-
-  {{ include "rpk-topic-describe" . }}
-
-Delete the topic:
-
-  {{ include "rpk-topic-delete" . }}

--- a/charts/redpanda/templates/_example-commands.tpl
+++ b/charts/redpanda/templates/_example-commands.tpl
@@ -23,30 +23,36 @@ and tested in a test.
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-user-create" -}}
-rpk acl user create myuser --new-password changeme --mechanism {{ include "sasl-mechanism" . }}
+{{- $cmd := (get ((include "redpanda.RpkACLUserCreate" (dict "a" (list .))) | fromJson) "r") }}
+{{- $cmd }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-acl-create" -}}
-rpk acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic'
+{{- $cmd := (get ((include "redpanda.RpkACLCreate" (dict "a" (list .))) | fromJson) "r") }}
+{{- $cmd }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-cluster-info" -}}
-rpk cluster info
+{{- $cmd := (get ((include "redpanda.RpkClusterInfo" (dict "a" (list .))) | fromJson) "r") }}
+{{- $cmd }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-create" -}}
-rpk topic create test-topic -p 3 -r {{ min (int64 .Values.statefulset.replicas) 3 }}
+{{- $cmd := (get ((include "redpanda.RpkTopicCreate" (dict "a" (list .))) | fromJson) "r") }}
+{{- $cmd }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-describe" -}}
-rpk topic describe test-topic
+{{- $cmd := (get ((include "redpanda.RpkTopicDescribe" (dict "a" (list .))) | fromJson) "r") }}
+{{- $cmd }}
 {{- end -}}
 
 {{/* tested in tests/test-kafka-sasl-status.yaml */}}
 {{- define "rpk-topic-delete" -}}
-rpk topic delete test-topic
+{{- $cmd := (get ((include "redpanda.RpkTopicDelete" (dict "a" (list .))) | fromJson) "r") }}
+{{- $cmd }}
 {{- end -}}

--- a/charts/redpanda/templates/notes.go.tpl
+++ b/charts/redpanda/templates/notes.go.tpl
@@ -1,0 +1,142 @@
+{{- /* Generated from "notes.go" */ -}}
+
+{{- define "redpanda.Warnings" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $warnings := (coalesce nil) -}}
+{{- $w_1 := (get (fromJson (include "redpanda.cpuWarning" (dict "a" (list $dot) ))) "r") -}}
+{{- if (ne $w_1 "") -}}
+{{- $warnings = (concat (default (list ) $warnings) (list (printf `**Warning**: %s` $w_1))) -}}
+{{- end -}}
+{{- (dict "r" $warnings) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.cpuWarning" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $coresInMillis := ((get (fromJson (include "_shims.resource_MilliValue" (dict "a" (list $values.resources.cpu.cores) ))) "r") | int64) -}}
+{{- if (lt $coresInMillis (1000 | int64)) -}}
+{{- (dict "r" (printf "%dm is below the minimum recommended CPU value for Redpanda" $coresInMillis)) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" "") | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.Notes" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $anySASL := (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r") -}}
+{{- $notes := (coalesce nil) -}}
+{{- $notes = (concat (default (list ) $notes) (list `` `` `` `` (printf `Congratulations on installing %s!` $dot.Chart.Name) `` `The pods will rollout in a few seconds. To check the status:` `` (printf `  kubectl -n %s rollout status statefulset %s --watch` $dot.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")))) -}}
+{{- if (and $values.external.enabled (eq $values.external.type "LoadBalancer")) -}}
+{{- $notes = (concat (default (list ) $notes) (list `` `If you are using the load balancer service with a cloud provider, the services will likely have automatically-generated addresses. In this scenario the advertised listeners must be updated in order for external access to work. Run the following command once Redpanda is deployed:` `` (printf `  helm upgrade %s redpanda/redpanda --reuse-values -n %s --set $(kubectl get svc -n %s -o jsonpath='{"external.addresses={"}{ range .items[*]}{.status.loadBalancer.ingress[0].ip }{.status.loadBalancer.ingress[0].hostname}{","}{ end }{"}\n"}')` (get (fromJson (include "redpanda.Name" (dict "a" (list $dot) ))) "r") $dot.Release.Namespace $dot.Release.Namespace))) -}}
+{{- end -}}
+{{- $profiles := (keys $values.listeners.kafka.external) -}}
+{{- $_ := (sortAlpha $profiles) -}}
+{{- $profileName := (index $profiles (0 | int)) -}}
+{{- $notes = (concat (default (list ) $notes) (list `` `Set up rpk for access to your external listeners:`)) -}}
+{{- $profile := (index $values.listeners.kafka.external $profileName) -}}
+{{- if (get (fromJson (include "redpanda.TLSEnabled" (dict "a" (list $dot) ))) "r") -}}
+{{- $external := "" -}}
+{{- if (and (ne $profile.tls (coalesce nil)) (ne $profile.tls.cert (coalesce nil))) -}}
+{{- $external = $profile.tls.cert -}}
+{{- else -}}
+{{- $external = $values.listeners.kafka.tls.cert -}}
+{{- end -}}
+{{- $notes = (concat (default (list ) $notes) (list (printf `  kubectl get secret -n %s %s-%s-cert -o go-template='{{ index .data "ca.crt" | base64decode }}' > ca.crt` $dot.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $external))) -}}
+{{- if (or $values.listeners.kafka.tls.requireClientAuth $values.listeners.admin.tls.requireClientAuth) -}}
+{{- $notes = (concat (default (list ) $notes) (list (printf `  kubectl get secret -n %s %s-client -o go-template='{{ index .data "tls.crt" | base64decode }}' > tls.crt` $dot.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) (printf `  kubectl get secret -n %s %s-client -o go-template='{{ index .data "tls.key" | base64decode }}' > tls.key` $dot.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")))) -}}
+{{- end -}}
+{{- end -}}
+{{- $notes = (concat (default (list ) $notes) (list (printf `  rpk profile create --from-profile <(kubectl get configmap -n %s %s-rpk -o go-template='{{ .data.profile }}') %s` $dot.Release.Namespace (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") $profileName) `` `Set up dns to look up the pods on their Kubernetes Nodes. You can use this query to get the list of short-names to IP addresses. Add your external domain to the hostnames and you could test by adding these to your /etc/hosts:` `` (printf `  kubectl get pod -n %s -o custom-columns=node:.status.hostIP,name:.metadata.name --no-headers -l app.kubernetes.io/name=redpanda,app.kubernetes.io/component=redpanda-statefulset` $dot.Release.Namespace))) -}}
+{{- if $anySASL -}}
+{{- $notes = (concat (default (list ) $notes) (list `` `Set the credentials in the environment:` `` (printf `  kubectl -n %s get secret %s -o go-template="{{ range .data }}{{ . | base64decode }}{{ end }}" | IFS=: read -r %s` $dot.Release.Namespace $values.auth.sasl.secretRef (get (fromJson (include "redpanda.RpkSASLEnvironmentVariables" (dict "a" (list $dot) ))) "r")) (printf `  export %s` (get (fromJson (include "redpanda.RpkSASLEnvironmentVariables" (dict "a" (list $dot) ))) "r")))) -}}
+{{- end -}}
+{{- $notes = (concat (default (list ) $notes) (list `` `Try some sample commands:`)) -}}
+{{- if $anySASL -}}
+{{- $notes = (concat (default (list ) $notes) (list `Create a user:` `` (printf `  %s` (get (fromJson (include "redpanda.RpkACLUserCreate" (dict "a" (list $dot) ))) "r")) `` `Give the user permissions:` `` (printf `  %s` (get (fromJson (include "redpanda.RpkACLCreate" (dict "a" (list $dot) ))) "r")))) -}}
+{{- end -}}
+{{- $notes = (concat (default (list ) $notes) (list `` `Get the api status:` `` (printf `  %s` (get (fromJson (include "redpanda.RpkClusterInfo" (dict "a" (list $dot) ))) "r")) `` `Create a topic` `` (printf `  %s` (get (fromJson (include "redpanda.RpkTopicCreate" (dict "a" (list $dot) ))) "r")) `` `Describe the topic:` `` (printf `  %s` (get (fromJson (include "redpanda.RpkTopicDescribe" (dict "a" (list $dot) ))) "r")) `` `Delete the topic:` `` (printf `  %s` (get (fromJson (include "redpanda.RpkTopicDelete" (dict "a" (list $dot) ))) "r")))) -}}
+{{- (dict "r" $notes) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkACLUserCreate" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" (printf `rpk acl user create myuser --new-password changeme --mechanism %s` (get (fromJson (include "redpanda.SASLMechanism" (dict "a" (list $dot) ))) "r"))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.SASLMechanism" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- if (ne $values.auth.sasl (coalesce nil)) -}}
+{{- (dict "r" $values.auth.sasl.mechanism) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- (dict "r" "SCRAM-SHA-512") | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkACLCreate" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" `rpk acl create --allow-principal 'myuser' --allow-host '*' --operation all --topic 'test-topic'`) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkClusterInfo" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" `rpk cluster info`) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkTopicCreate" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- (dict "r" (printf `rpk topic create test-topic -p 3 -r %d` (min (3 | int64) (($values.statefulset.replicas | int) | int64)))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkTopicDescribe" -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" `rpk topic describe test-topic`) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkTopicDelete" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- (dict "r" `rpk topic delete test-topic`) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.RpkSASLEnvironmentVariables" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- if (get (fromJson (include "redpanda.RedpandaAtLeast_23_2_1" (dict "a" (list $dot) ))) "r") -}}
+{{- (dict "r" `RPK_USER RPK_PASS RPK_SASL_MECHANISM`) | toJson -}}
+{{- break -}}
+{{- else -}}
+{{- (dict "r" `REDPANDA_SASL_USERNAME REDPANDA_SASL_PASSWORD REDPANDA_SASL_MECHANISM`) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -6,7 +6,7 @@
 package redpanda
 
 import (
-	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -442,7 +442,7 @@ type PartialTLSCert struct {
 	CAEnabled             *bool                        "json:\"caEnabled,omitempty\" jsonschema:\"required\""
 	ApplyInternalDNSNames *bool                        "json:\"applyInternalDNSNames,omitempty\""
 	Duration              *string                      "json:\"duration,omitempty\" jsonschema:\"pattern=.*[smh]$\""
-	IssuerRef             *cmmetav1.ObjectReference    "json:\"issuerRef,omitempty\""
+	IssuerRef             *cmmeta.ObjectReference      "json:\"issuerRef,omitempty\""
 	SecretRef             *corev1.LocalObjectReference "json:\"secretRef,omitempty\""
 }
 


### PR DESCRIPTION
I didn't add the Ci machinery to compare a whole raft of (pretty much identical) NOTES.txt output, just ran it locally.

The `_example-commands.tpl` script calls into the gotohelm functions now.