### PR TITLE
redpanda: values.statefulSet.initContainers.tuning.extraVolumeMounts …

### DIFF
--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -777,7 +777,7 @@ To create `Guaranteed` Pods for Redpanda brokers, provide both requests and limi
 
 ### [statefulset.initContainers.tuning.extraVolumeMounts](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainers.tuning.extraVolumeMounts)
 
-**Default:** `""`
+**Default:** `[]`
 
 ### [statefulset.initContainers.tuning.resources](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=statefulset.initContainers.tuning.resources)
 

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -3,7 +3,6 @@ package redpanda_test
 import (
 	"maps"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/redpanda-data/helm-charts/charts/redpanda"
@@ -17,8 +16,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/yaml"
 )
 
 func TieredStorageStatic(t *testing.T) redpanda.PartialValues {
@@ -141,90 +138,6 @@ func TestChart(t *testing.T) {
 		require.Equal(t, true, config["cloud_storage_enabled"])
 		require.Equal(t, "from-secret-access-key", config["cloud_storage_access_key"])
 	})
-}
-
-// preTranspilerChartVersion is the latest release of the Redpanda helm chart prior to the introduction of
-// ConfigMap go base implementation. It's used to verify that translated code is functionally equivalent.
-const preTranspilerChartVersion = "redpanda-5.8.8.tgz"
-
-func TestConfigMap(t *testing.T) {
-	ctx := testutil.Context(t)
-	client, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
-	require.NoError(t, err)
-
-	// Downloading Redpanda helm chart release is required as client.Template
-	// function does not pass HELM_CONFIG_HOME, that prevents from downloading specific
-	// Redpanda helm chart version from public helm repository.
-	require.NoError(t, client.DownloadFile(ctx, "https://github.com/redpanda-data/helm-charts/releases/download/redpanda-5.8.8/redpanda-5.8.8.tgz", preTranspilerChartVersion))
-
-	values, err := os.ReadDir("./ci")
-	require.NoError(t, err)
-
-	for _, v := range values {
-		t.Run(v.Name(), func(t *testing.T) {
-			t.Parallel()
-
-			// First generate latest released Redpanda charts manifests. From ConfigMap bootstrap,
-			// redpanda node configuration and RPK profile.
-			manifests, err := client.Template(ctx, filepath.Join(client.GetConfigHome(), preTranspilerChartVersion), helm.TemplateOptions{
-				Name:       "redpanda",
-				ValuesFile: "./ci/" + v.Name(),
-				Set: []string{
-					// Tests utilize some non-deterministic helpers (rng). We don't
-					// really care about the stability of their output, so globally
-					// disable them.
-					"tests.enabled=false",
-					// jwtSecret defaults to a random string. Can't have that
-					// in snapshot testing so set it to a static value.
-					"console.secret.login.jwtSecret=SECRETKEY",
-				},
-			})
-			require.NoError(t, err)
-
-			oldRedpanda, oldRPKProfile, err := getConfigMaps(manifests)
-			require.NoError(t, err)
-
-			// Now helm template will generate Redpanda configuration from local definition
-			manifests, err = client.Template(ctx, ".", helm.TemplateOptions{
-				Name:       "redpanda",
-				ValuesFile: "./ci/" + v.Name(),
-				Set: []string{
-					// Tests utilize some non-deterministic helpers (rng). We don't
-					// really care about the stability of their output, so globally
-					// disable them.
-					"tests.enabled=false",
-					// jwtSecret defaults to a random string. Can't have that
-					// in snapshot testing so set it to a static value.
-					"console.secret.login.jwtSecret=SECRETKEY",
-				},
-			})
-			require.NoError(t, err)
-
-			newRedpanda, newRPKProfile, err := getConfigMaps(manifests)
-			require.NoError(t, err)
-
-			// Overprovisioned field till Redpanda chart version 5.8.8 was wrongly set to `false`
-			// when CPU request value was bellow 1000 mili cores. Function `redpanda-smp`, that
-			// should overwrite `overprovisioned` flag in old implementation, was not called
-			// before setting `overprovisioned` flag (`{{ dig "cpu" "overprovisioned" false .Values.resources }}`).
-			// redpanda-smp template - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_helpers.tpl#L187
-			// redpanda-smp template invocation - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_configmap.tpl#L610
-			// overprovisioned flag - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_configmap.tpl#L607
-			var newUnstructuredRedpandaConf map[string]any
-			require.NoError(t, yaml.Unmarshal([]byte(newRedpanda.Data["redpanda.yaml"]), &newUnstructuredRedpandaConf))
-			require.NoError(t, unstructured.SetNestedField(newUnstructuredRedpandaConf, false, "rpk", "overprovisioned"))
-
-			require.Equal(t, getJSONObject(t, oldRedpanda.Data["redpanda.yaml"]), newUnstructuredRedpandaConf)
-			require.Equal(t, getJSONObject(t, oldRedpanda.Data["bootstrap.yaml"]), getJSONObject(t, newRedpanda.Data["bootstrap.yaml"]))
-			require.Equal(t, getJSONObject(t, oldRPKProfile.Data["profile"]), getJSONObject(t, newRPKProfile.Data["profile"]))
-		})
-	}
-}
-
-func getJSONObject(t *testing.T, input string) any {
-	var output any
-	require.NoError(t, yaml.Unmarshal([]byte(input), &output))
-	return output
 }
 
 // getConfigMaps is parsing all manifests (resources) created by helm template

--- a/charts/redpanda/ci/09-initcontainers-resources-values.yaml
+++ b/charts/redpanda/ci/09-initcontainers-resources-values.yaml
@@ -42,7 +42,7 @@ statefulset:
         - name: test-extra-volume
           mountPath: /fake/lifecycle
     tuning:
-      extraVolumeMounts: |-
+      extraVolumeMounts:
         - name: test-extra-volume
           mountPath: /fake/lifecycle
     setDataDirOwnership:

--- a/charts/redpanda/templates/statefulset.yaml
+++ b/charts/redpanda/templates/statefulset.yaml
@@ -31,6 +31,8 @@ limitations under the License.
     -}}
   {{- end -}}
 {{- end -}}
+
+{{- $initContainers := (get ((include "redpanda.StatefulSetInitContainers" (dict "a" (list .))) | fromJson) "r") -}}
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -61,28 +63,8 @@ spec:
       imagePullSecrets: {{- toYaml . | nindent 8 }}
     {{- end }}
       initContainers:
-{{- if and (hasKey $values.tuning "tune_aio_events") $values.tuning.tune_aio_events }}
-        - name: tuning
-          image: {{ .Values.image.repository }}:{{ template "redpanda.tag" . }}
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
-          securityContext:
-            capabilities:
-              add: ["SYS_RESOURCE"]
-            privileged: true
-            runAsUser: 0
-            runAsGroup: 0
-          volumeMounts: {{ include "common-mounts" . | nindent 12 }}
-  {{- if dig "initContainers" "tuning" "extraVolumeMounts" false .Values.statefulset -}}
-    {{ tpl .Values.statefulset.initContainers.tuning.extraVolumeMounts . | nindent 12 }}
-  {{- end }}
-            - name: {{ template "redpanda.fullname" . }}
-              mountPath: /etc/redpanda
-  {{- if get .Values.statefulset.initContainers.tuning "resources" }}
-          resources: {{- toYaml .Values.statefulset.initContainers.tuning.resources | nindent 12 }}
-  {{- end }}
+{{- if not (empty $initContainers) }}
+{{- toYaml $initContainers | nindent 8 }}
 {{- end }}
 {{- if .Values.statefulset.initContainers.setDataDirOwnership.enabled }}
         - name: set-datadir-ownership

--- a/charts/redpanda/testdata/ci/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/01-default-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -640,22 +640,23 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -736,25 +736,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -754,24 +754,26 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/secrets/users
-              name: users
-              readOnly: true
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/secrets/users
+            name: users
+            readOnly: true
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -872,28 +872,30 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/secrets/users
-              name: users
-              readOnly: true
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/secrets/users
+            name: users
+            readOnly: true
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
@@ -893,25 +893,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: redpanda
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
@@ -835,27 +835,29 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/cert2
-              name: redpanda-cert2-cert
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/cert2
+            name: redpanda-cert2-cert
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
@@ -828,27 +828,29 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: test-extra-volume
-              mountPath: /fake/lifecycle
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /fake/lifecycle
+            name: test-extra-volume
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-datadir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", "chown 101:101 -R /var/lib/redpanda/data"]

--- a/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
@@ -909,28 +909,30 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/secrets/users
-              name: users
-              readOnly: true
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/secrets/users
+            name: users
+            readOnly: true
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
@@ -864,25 +864,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
@@ -665,22 +665,23 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
@@ -1003,25 +1003,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -846,25 +846,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -847,25 +847,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -845,25 +845,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -782,25 +782,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -846,25 +846,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -847,25 +847,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -845,25 +845,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -782,25 +782,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -846,25 +846,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -847,25 +847,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -845,25 +845,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -782,25 +782,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -774,25 +774,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
@@ -838,25 +838,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
@@ -788,25 +788,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
@@ -1003,25 +1003,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
@@ -960,25 +960,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-datadir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", "chown 101:101 -R /var/lib/redpanda/data"]

--- a/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
@@ -962,25 +962,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/36-single-external-address-with-template-domain-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/36-single-external-address-with-template-domain-novalues.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/37-internal-service-changed-name-and-annotations-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/37-internal-service-changed-name-and-annotations-novalues.yaml.golden
@@ -779,25 +779,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/38-post-install-upgrade-merges-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/38-post-install-upgrade-merges-novalues.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/38-post-install-upgrade-no-overrides-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/38-post-install-upgrade-no-overrides-novalues.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/39-default-image-pull-secrets-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/39-default-image-pull-secrets-novalues.yaml.golden
@@ -776,25 +776,27 @@ spec:
         - name: secret-1
         - name: secret-2
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
@@ -978,28 +978,30 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/secrets/users
-              name: users
-              readOnly: true
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/secrets/users
+            name: users
+            readOnly: true
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
@@ -836,25 +836,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
@@ -778,25 +778,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
           command:

--- a/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -798,25 +798,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: set-tiered-storage-cache-dir-ownership
           image: busybox:latest
           command: ["/bin/sh", "-c", 'mkdir -p /var/lib/redpanda/data/cloud_storage_cache; chown 101:101 -R /var/lib/redpanda/data/cloud_storage_cache']

--- a/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
@@ -771,25 +771,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v22.3.14
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v22.3.14
           command:

--- a/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
@@ -834,25 +834,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v22.3.14
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v22.3.14
           command:

--- a/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
@@ -777,25 +777,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v22.3.14
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v22.3.14
           command:

--- a/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
@@ -771,25 +771,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.2
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.2
           command:

--- a/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
@@ -834,25 +834,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.2
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.2
           command:

--- a/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
@@ -777,25 +777,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.2
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.2
           command:

--- a/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
@@ -771,25 +771,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.3
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.3
           command:

--- a/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
@@ -834,25 +834,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.3
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.3
           command:

--- a/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
@@ -777,25 +777,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.3
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.1.3
           command:

--- a/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
@@ -771,25 +771,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
           command:

--- a/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
@@ -834,25 +834,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
           command:

--- a/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
@@ -777,25 +777,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.2.1
           command:

--- a/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.0
           command:

--- a/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
@@ -836,25 +836,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.0
           command:

--- a/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
@@ -779,25 +779,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v23.3.0
           command:

--- a/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.0
           command:

--- a/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
@@ -836,25 +836,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.0
           command:

--- a/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
@@ -779,25 +779,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: docker.redpanda.com/redpandadata/redpanda:v24.1.0
           command:

--- a/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-0.yaml.golden
@@ -771,25 +771,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: somecustomrepo:v23.2.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: somecustomrepo:v23.2.8
           command:

--- a/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-1.yaml.golden
@@ -834,25 +834,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: somecustomrepo:v23.2.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: somecustomrepo:v23.2.8
           command:

--- a/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-2.yaml.golden
@@ -777,25 +777,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: somecustomrepo:v23.2.8
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: somecustomrepo:v23.2.8
           command:

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
@@ -773,25 +773,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: somecustomrepo:v24.1.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: somecustomrepo:v24.1.0
           command:

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
@@ -836,25 +836,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: somecustomrepo:v24.1.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: somecustomrepo:v24.1.0
           command:

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
@@ -779,25 +779,27 @@ spec:
         fsGroupChangePolicy: OnRootMismatch
       serviceAccountName: default
       initContainers:
-        - name: tuning
+        - command:
+          - /bin/bash
+          - -c
+          - rpk redpanda tune all
           image: somecustomrepo:v24.1.0
-          command:
-            - /bin/bash
-            - -c
-            - rpk redpanda tune all
+          name: tuning
+          resources: {}
           securityContext:
             capabilities:
-              add: ["SYS_RESOURCE"]
+              add:
+              - SYS_RESOURCE
             privileged: true
-            runAsUser: 0
             runAsGroup: 0
-          volumeMounts: 
-            - mountPath: /etc/tls/certs/default
-              name: redpanda-default-cert
-            - mountPath: /etc/tls/certs/external
-              name: redpanda-external-cert
-            - name: redpanda
-              mountPath: /etc/redpanda
+            runAsUser: 0
+          volumeMounts:
+          - mountPath: /etc/tls/certs/default
+            name: redpanda-default-cert
+          - mountPath: /etc/tls/certs/external
+            name: redpanda-external-cert
+          - mountPath: /etc/redpanda
+            name: redpanda
         - name: redpanda-configurator
           image: somecustomrepo:v24.1.0
           command:

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -573,8 +573,8 @@ type Statefulset struct {
 		} `json:"setTieredStorageCacheDirOwnership"`
 		Tuning struct {
 			// Enabled           bool           `json:"enabled"`
-			Resources         map[string]any `json:"resources"`
-			ExtraVolumeMounts string         `json:"extraVolumeMounts"`
+			Resources         map[string]any       `json:"resources"`
+			ExtraVolumeMounts []corev1.VolumeMount `json:"extraVolumeMounts"`
 		} `json:"tuning"`
 		ExtraInitContainers string `json:"extraInitContainers"`
 	} `json:"initContainers"`

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -3485,7 +3485,30 @@
             "tuning": {
               "properties": {
                 "extraVolumeMounts": {
-                  "type": "string"
+                  "items": {
+                    "properties": {
+                      "mountPath": {
+                        "type": "string"
+                      },
+                      "mountPropagation": {
+                        "type": "string"
+                      },
+                      "name": {
+                        "type": "string"
+                      },
+                      "readOnly": {
+                        "type": "boolean"
+                      },
+                      "subPath": {
+                        "type": "string"
+                      },
+                      "subPathExpr": {
+                        "type": "string"
+                      }
+                    },
+                    "type": "object"
+                  },
+                  "type": "array"
                 },
                 "resources": {
                   "type": "object"

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -797,7 +797,7 @@ statefulset:
       # * Every container in the Pod must have a CPU limit and a CPU request.
       # * For every container in the Pod, the CPU limit must equal the CPU request.
       resources: {}
-      extraVolumeMounts: |-
+      extraVolumeMounts: []
     setDataDirOwnership:
       # -- In environments where root is not allowed, you cannot change the ownership of files and directories.
       # Enable `setDataDirOwnership` when using default minikube cluster configuration.

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -6,7 +6,7 @@
 package redpanda
 
 import (
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
+	cmmetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -263,8 +263,8 @@ type PartialStatefulset struct {
 			ExtraVolumeMounts *string        "json:\"extraVolumeMounts,omitempty\""
 		} "json:\"setTieredStorageCacheDirOwnership,omitempty\""
 		Tuning *struct {
-			Resources         map[string]any "json:\"resources,omitempty\""
-			ExtraVolumeMounts *string        "json:\"extraVolumeMounts,omitempty\""
+			Resources         map[string]any       "json:\"resources,omitempty\""
+			ExtraVolumeMounts []corev1.VolumeMount "json:\"extraVolumeMounts,omitempty\""
 		} "json:\"tuning,omitempty\""
 		ExtraInitContainers *string "json:\"extraInitContainers,omitempty\""
 	} "json:\"initContainers,omitempty\""
@@ -442,7 +442,7 @@ type PartialTLSCert struct {
 	CAEnabled             *bool                        "json:\"caEnabled,omitempty\" jsonschema:\"required\""
 	ApplyInternalDNSNames *bool                        "json:\"applyInternalDNSNames,omitempty\""
 	Duration              *string                      "json:\"duration,omitempty\" jsonschema:\"pattern=.*[smh]$\""
-	IssuerRef             *cmmeta.ObjectReference      "json:\"issuerRef,omitempty\""
+	IssuerRef             *cmmetav1.ObjectReference    "json:\"issuerRef,omitempty\""
 	SecretRef             *corev1.LocalObjectReference "json:\"secretRef,omitempty\""
 }
 


### PR DESCRIPTION
…is now an array, not a string template

This begins a conversion of statefulset.yaml init-containers to go.

As a part of this, the `values.yaml` type for `extraVolumeMounts` is refined to take an explicit `corev1.VolumeMount` structure rather than a bare string that was interpreted as templated yaml.