### PR TITLE
Fix any Node configuration that is of numerical type

### DIFF
--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -3,7 +3,6 @@ package redpanda_test
 import (
 	"maps"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/redpanda-data/helm-charts/charts/redpanda"
@@ -17,8 +16,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"sigs.k8s.io/yaml"
 )
 
 func TieredStorageStatic(t *testing.T) redpanda.PartialValues {
@@ -141,90 +138,6 @@ func TestChart(t *testing.T) {
 		require.Equal(t, true, config["cloud_storage_enabled"])
 		require.Equal(t, "from-secret-access-key", config["cloud_storage_access_key"])
 	})
-}
-
-// preTranspilerChartVersion is the latest release of the Redpanda helm chart prior to the introduction of
-// ConfigMap go base implementation. It's used to verify that translated code is functionally equivalent.
-const preTranspilerChartVersion = "redpanda-5.8.8.tgz"
-
-func TestConfigMap(t *testing.T) {
-	ctx := testutil.Context(t)
-	client, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
-	require.NoError(t, err)
-
-	// Downloading Redpanda helm chart release is required as client.Template
-	// function does not pass HELM_CONFIG_HOME, that prevents from downloading specific
-	// Redpanda helm chart version from public helm repository.
-	require.NoError(t, client.DownloadFile(ctx, "https://github.com/redpanda-data/helm-charts/releases/download/redpanda-5.8.8/redpanda-5.8.8.tgz", preTranspilerChartVersion))
-
-	values, err := os.ReadDir("./ci")
-	require.NoError(t, err)
-
-	for _, v := range values {
-		t.Run(v.Name(), func(t *testing.T) {
-			t.Parallel()
-
-			// First generate latest released Redpanda charts manifests. From ConfigMap bootstrap,
-			// redpanda node configuration and RPK profile.
-			manifests, err := client.Template(ctx, filepath.Join(client.GetConfigHome(), preTranspilerChartVersion), helm.TemplateOptions{
-				Name:       "redpanda",
-				ValuesFile: "./ci/" + v.Name(),
-				Set: []string{
-					// Tests utilize some non-deterministic helpers (rng). We don't
-					// really care about the stability of their output, so globally
-					// disable them.
-					"tests.enabled=false",
-					// jwtSecret defaults to a random string. Can't have that
-					// in snapshot testing so set it to a static value.
-					"console.secret.login.jwtSecret=SECRETKEY",
-				},
-			})
-			require.NoError(t, err)
-
-			oldRedpanda, oldRPKProfile, err := getConfigMaps(manifests)
-			require.NoError(t, err)
-
-			// Now helm template will generate Redpanda configuration from local definition
-			manifests, err = client.Template(ctx, ".", helm.TemplateOptions{
-				Name:       "redpanda",
-				ValuesFile: "./ci/" + v.Name(),
-				Set: []string{
-					// Tests utilize some non-deterministic helpers (rng). We don't
-					// really care about the stability of their output, so globally
-					// disable them.
-					"tests.enabled=false",
-					// jwtSecret defaults to a random string. Can't have that
-					// in snapshot testing so set it to a static value.
-					"console.secret.login.jwtSecret=SECRETKEY",
-				},
-			})
-			require.NoError(t, err)
-
-			newRedpanda, newRPKProfile, err := getConfigMaps(manifests)
-			require.NoError(t, err)
-
-			// Overprovisioned field till Redpanda chart version 5.8.8 was wrongly set to `false`
-			// when CPU request value was bellow 1000 mili cores. Function `redpanda-smp`, that
-			// should overwrite `overprovisioned` flag in old implementation, was not called
-			// before setting `overprovisioned` flag (`{{ dig "cpu" "overprovisioned" false .Values.resources }}`).
-			// redpanda-smp template - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_helpers.tpl#L187
-			// redpanda-smp template invocation - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_configmap.tpl#L610
-			// overprovisioned flag - https://github.com/redpanda-data/helm-charts/blob/5f287d45a3bda2763896840e505fb3de82b968b6/charts/redpanda/templates/_configmap.tpl#L607
-			var newUnstructuredRedpandaConf map[string]any
-			require.NoError(t, yaml.Unmarshal([]byte(newRedpanda.Data["redpanda.yaml"]), &newUnstructuredRedpandaConf))
-			require.NoError(t, unstructured.SetNestedField(newUnstructuredRedpandaConf, false, "rpk", "overprovisioned"))
-
-			require.Equal(t, getJSONObject(t, oldRedpanda.Data["redpanda.yaml"]), newUnstructuredRedpandaConf)
-			require.Equal(t, getJSONObject(t, oldRedpanda.Data["bootstrap.yaml"]), getJSONObject(t, newRedpanda.Data["bootstrap.yaml"]))
-			require.Equal(t, getJSONObject(t, oldRPKProfile.Data["profile"]), getJSONObject(t, newRPKProfile.Data["profile"]))
-		})
-	}
-}
-
-func getJSONObject(t *testing.T, input string) any {
-	var output any
-	require.NoError(t, yaml.Unmarshal([]byte(input), &output))
-	return output
 }
 
 // getConfigMaps is parsing all manifests (resources) created by helm template

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -727,7 +727,13 @@
 {{- $result := (dict ) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
+{{- $tmp_tuple_14 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_14 := $tmp_tuple_14.T2 -}}
+{{- if $ok_14 -}}
+{{- $_ := (set $result $k $v) -}}
+{{- else -}}
 {{- $_ := (set $result $k (toYaml $v)) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- (dict "r" $result) | toJson -}}
@@ -745,26 +751,26 @@
 {{- if (and (eq $k "default_topic_replications") (not $skipDefaultTopic)) -}}
 {{- $r := ($replicas | int) -}}
 {{- $input := ($r | int) -}}
-{{- $tmp_tuple_14 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_15 := $tmp_tuple_14.T2 -}}
-{{- $num_14 := ($tmp_tuple_14.T1 | int) -}}
-{{- if $ok_15 -}}
-{{- $input = $num_14 -}}
+{{- $tmp_tuple_15 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_16 := $tmp_tuple_15.T2 -}}
+{{- $num_15 := ($tmp_tuple_15.T1 | int) -}}
+{{- if $ok_16 -}}
+{{- $input = $num_15 -}}
 {{- end -}}
-{{- $tmp_tuple_15 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_17 := $tmp_tuple_15.T2 -}}
-{{- $f_16 := ($tmp_tuple_15.T1 | float64) -}}
-{{- if $ok_17 -}}
-{{- $input = ($f_16 | int) -}}
+{{- $tmp_tuple_16 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_18 := $tmp_tuple_16.T2 -}}
+{{- $f_17 := ($tmp_tuple_16.T1 | float64) -}}
+{{- if $ok_18 -}}
+{{- $input = ($f_17 | int) -}}
 {{- end -}}
 {{- $_ := (set $result $k (min ($input | int64) (((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int) | int64))) -}}
 {{- continue -}}
 {{- end -}}
-{{- $tmp_tuple_16 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
-{{- $ok_19 := $tmp_tuple_16.T2 -}}
-{{- $b_18 := $tmp_tuple_16.T1 -}}
-{{- if $ok_19 -}}
-{{- $_ := (set $result $k $b_18) -}}
+{{- $tmp_tuple_17 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
+{{- $ok_20 := $tmp_tuple_17.T2 -}}
+{{- $b_19 := $tmp_tuple_17.T1 -}}
+{{- if $ok_20 -}}
+{{- $_ := (set $result $k $b_19) -}}
 {{- continue -}}
 {{- end -}}
 {{- if (not (empty $v)) -}}

--- a/charts/redpanda/testdata/ci/01-default-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/01-default-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/02-one-node-cluster-no-tls-no-sasl-values.yaml.golden
@@ -269,7 +269,7 @@ data:
       admin_api_tls: null
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -632,7 +632,7 @@ spec:
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
       annotations:
-        config.redpanda.com/checksum: 2c1f05e58ff4b6d758334c8000ff07808c52ae0863ef7298b076172b4a56ce50
+        config.redpanda.com/checksum: 7598204e5801e40e8d771ff696609bd3779b4770539a245d37f6580532f5b219
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/03-one-node-cluster-tls-no-sasl-values.yaml.golden
@@ -294,7 +294,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -728,7 +728,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: decd10abe74246ff0e9944a5a4cc93f7b771cdc23917f600ef4c7f06f59af51b
+        config.redpanda.com/checksum: 32d148735eb546d1d96441a3da93351c6f551ecfd0054936a0bada03747eefe3
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -377,7 +377,7 @@ data:
       admin_api_tls: null
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
@@ -746,7 +746,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 554c82d83fcf89c7980111e4b8ed75a39cdde6b0ff3d724b038c5f564953dc1c
+        config.redpanda.com/checksum: cbdea1a5f6d2579415fa8d61135f18362458c5196a5181ebd6f8714a3c9561a8
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/05-one-node-cluster-tls-sasl-values.yaml.golden
@@ -412,7 +412,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
@@ -864,7 +864,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 74cb854b82e90b33f77cad207c0a6e899c628cac74b0ef2d83919808fbdd4952
+        config.redpanda.com/checksum: 55335b55accce0db3f2c72a2a8d06aad408df771be0eded36d0ca15687515931
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/06-rack-awareness-values.yaml.golden
@@ -331,7 +331,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -885,7 +885,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: e2cf8f893603cc15f25a48281063b9657cfa6f2e8874e547cfe597f9438fd2a4
+        config.redpanda.com/checksum: 1a08afe5e2cb947c1ca3591fee128d89ad7da6d1ae205dea1ebab80137df0d61
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/07-multiple-listeners-values.yaml.golden
@@ -361,7 +361,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -827,7 +827,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 3fd388b4b3d76c2c52ed8bb08ac4dfe88390f5044dcdf2897c1a3a77ee860316
+        config.redpanda.com/checksum: 35ce65371730e2862570935d6685bd83846022838c158e0fee8dbbd616f4ff09
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/08-custom-podantiaffinity-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/09-initcontainers-resources-values.yaml.golden
@@ -364,7 +364,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -820,7 +820,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/10-external-addresses-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 2024c44d472faf980c18a269e174894143009bf723de6bfdb06f37c9852e50d1
+        config.redpanda.com/checksum: 7a4fb818987748edfce63aba4a3fb78140a97f77b90da014e45b63a3eacbbf39
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/11-update-sasl-users-values.yaml.golden
@@ -429,7 +429,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
@@ -901,7 +901,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: e04df4047cd5864fcdd6071ef969e884455591fd0693d59108caa25d5feba59b
+        config.redpanda.com/checksum: e87ab20c4843ab8236f44fd43e45ba24483e693648b83728ccee39a2a1682f24
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/12-external-cert-secrets-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 657ea146e99a6f215c0ecd4803285968ee1bb8cee79b3c1de3a591a4390bcf97
+        config.redpanda.com/checksum: 2b580c7243d089e468229fb3b0a49085eb072deaf18d47ac07bc2a86bde37da0
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/13-loadbalancer-tls-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -856,7 +856,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d53a5dc0e0cc139bffe6f5ca4dde72bed9dd9b017a4db702af7eb125b0d21317
+        config.redpanda.com/checksum: b64d818bce95ab7da72c7f6b053ebb4f7a0b2090e3a1dc0eddfa664b048449c0
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
@@ -279,7 +279,7 @@ data:
       admin_api_tls: null
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -657,7 +657,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 8e2136dd635cfdc366c5fd1b57a06a039a5aeb51feadd984662199d36fa27305
+        config.redpanda.com/checksum: ae7fe6040bcd3d7b265b0d981e1dbcffc0ad0866da71e5f9953bb68372c227b2
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/15-prometheus-tls-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/16-controller-sidecar-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -995,7 +995,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/17-resources-without-unit-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: fdfb745d48fff40b5a2a1610bdd64b448e72e52a376caedc11ab57adf639c7ec
+        config.redpanda.com/checksum: aa83b0d0194a5193d77d3fe60682e52a241dea4e683d8a20a3d20f56aae0f6bf
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/18-single-external-address-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 991d2b7b48671e3bd45f1328d8376ad9da8b72f8be7ca6819742905c15f2d2ba
+        config.redpanda.com/checksum: 0e5fe016c4a09a2db6ac5d6b80f6a5026d37ae356a035c33004c536b88ce2b33
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/21-eks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -366,7 +366,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -838,7 +838,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d34e596b34806855084c10b006f06e8516566b11da7f1a7149e13cba4171eb43
+        config.redpanda.com/checksum: 1ecece944f0b068b297e2f2410334ce9025d9e5d76c35ce042738b088288c8ff
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/22-gke-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -367,7 +367,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -839,7 +839,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: f6d84134a2a8cff171b2546abc7e7d7d56f692bc181bc45fa51f0ffaf8ad1410
+        config.redpanda.com/checksum: 807fa0cccbbff590a9cb810114104ac8384fff95b7845f5d81bdaf40821ad8e6
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-with-creds-values.yaml.tpl.golden
@@ -365,7 +365,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -837,7 +837,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c1b219d754c1a40f7fd6a49d21f433f78531baeec4b7c5a11c36f27f018bd9cc
+        config.redpanda.com/checksum: a3a1ca180d74ac5d7337cc27a732778831aedd949f456e89be96777ed3c10096
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/23-aks-tiered-storage-without-creds-novalues.yaml.tpl.golden
@@ -318,7 +318,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -774,7 +774,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 374166623b7ace85c9a21badd8826a42b5e5414d03e0ddc288a6639b367b6942
+        config.redpanda.com/checksum: 2395f34698a66674d1ebf487d4eda069ff3c2f70095fde32220ecb9cb42da062
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/24-eks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -366,7 +366,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -838,7 +838,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d34e596b34806855084c10b006f06e8516566b11da7f1a7149e13cba4171eb43
+        config.redpanda.com/checksum: 1ecece944f0b068b297e2f2410334ce9025d9e5d76c35ce042738b088288c8ff
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/25-gke-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -367,7 +367,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -839,7 +839,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: f6d84134a2a8cff171b2546abc7e7d7d56f692bc181bc45fa51f0ffaf8ad1410
+        config.redpanda.com/checksum: 807fa0cccbbff590a9cb810114104ac8384fff95b7845f5d81bdaf40821ad8e6
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-with-creds-values.yaml.tpl.golden
@@ -365,7 +365,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -837,7 +837,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c1b219d754c1a40f7fd6a49d21f433f78531baeec4b7c5a11c36f27f018bd9cc
+        config.redpanda.com/checksum: a3a1ca180d74ac5d7337cc27a732778831aedd949f456e89be96777ed3c10096
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/26-aks-tiered-storage-persistent-without-creds-novalues.yaml.tpl.golden
@@ -318,7 +318,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -774,7 +774,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c1b219d754c1a40f7fd6a49d21f433f78531baeec4b7c5a11c36f27f018bd9cc
+        config.redpanda.com/checksum: a3a1ca180d74ac5d7337cc27a732778831aedd949f456e89be96777ed3c10096
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/27-eks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -366,7 +366,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -838,7 +838,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: d34e596b34806855084c10b006f06e8516566b11da7f1a7149e13cba4171eb43
+        config.redpanda.com/checksum: 1ecece944f0b068b297e2f2410334ce9025d9e5d76c35ce042738b088288c8ff
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/28-gke-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -367,7 +367,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -839,7 +839,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: f6d84134a2a8cff171b2546abc7e7d7d56f692bc181bc45fa51f0ffaf8ad1410
+        config.redpanda.com/checksum: 807fa0cccbbff590a9cb810114104ac8384fff95b7845f5d81bdaf40821ad8e6
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-with-creds-values.yaml.tpl.golden
@@ -365,7 +365,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -837,7 +837,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c1b219d754c1a40f7fd6a49d21f433f78531baeec4b7c5a11c36f27f018bd9cc
+        config.redpanda.com/checksum: a3a1ca180d74ac5d7337cc27a732778831aedd949f456e89be96777ed3c10096
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/29-aks-tiered-storage-persistent-nameoverwrite-without-creds-novalues.yaml.tpl.golden
@@ -318,7 +318,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -774,7 +774,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c1b219d754c1a40f7fd6a49d21f433f78531baeec4b7c5a11c36f27f018bd9cc
+        config.redpanda.com/checksum: a3a1ca180d74ac5d7337cc27a732778831aedd949f456e89be96777ed3c10096
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/30-additional-flags-override-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 62bd678749437bf1f545eb0040415cc6d9587e81fecc1dd9d7b63fbba57c5cfd
+        config.redpanda.com/checksum: dd62085ecb8b1246e4b086f89896fb878f53c4b827e94ae8b911514ab9a32385
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/31-overwrite-statefulset-pod-labels-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -766,7 +766,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/32-statefulset-podspec-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-advertised-ports-values.yaml.golden
@@ -369,7 +369,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -830,7 +830,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 552eafcf5f042178f1fa81d69fadcbcee927c67aedeb4af42a100abc2c697a9c
+        config.redpanda.com/checksum: 0e31e26313ffb77fa8c9c6255e70a4bf80fd1f66af4f8289468282e8a6f1cf23
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/33-pod-selector-lables-novalues.yaml.golden
@@ -312,7 +312,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -780,7 +780,7 @@ spec:
         redpanda.com/testing-samples: sample
         redpanda.com/testing-samples-two: two
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-security-contexts-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -995,7 +995,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/34-statefulset-sidecars-novalues.yaml.golden
@@ -364,7 +364,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -952,7 +952,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/35-connectors-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -954,7 +954,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/36-single-external-address-with-template-domain-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/36-single-external-address-with-template-domain-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c3f036ed9f2108ee474f0e67b248ae99bd3408321dc276f7c509338a8cc744d3
+        config.redpanda.com/checksum: 9d127f98f3a655911ac67dab76c8c97ee59d5db0f1dfe9a1ede850ac14436a93
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/37-internal-service-changed-name-and-annotations-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/37-internal-service-changed-name-and-annotations-novalues.yaml.golden
@@ -310,7 +310,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -771,7 +771,7 @@ spec:
         redpanda.com/poddisruptionbudget: redpanda
         test: test
       annotations:
-        config.redpanda.com/checksum: bfe43b6a634164f858149ed33cc03d63badb649ca1701301719f424e01184913
+        config.redpanda.com/checksum: f9fdf89647e3376343181f0522cd2a4d25a9f4aa3e23c4322a292c76e31d0715
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/38-post-install-upgrade-merges-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/38-post-install-upgrade-merges-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/38-post-install-upgrade-no-overrides-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/38-post-install-upgrade-no-overrides-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/39-default-image-pull-secrets-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/39-default-image-pull-secrets-novalues.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/96-audit-logging-values.yaml.tpl.golden
@@ -485,7 +485,7 @@ data:
       audit_enabled: true
       cluster_id: cluster-id-test
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
@@ -970,7 +970,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: e3c65c5da8461f2a4cfd209a64fd8c4295ce60e7271509595816623b8b181082
+        config.redpanda.com/checksum: df95fa3e0329459ed2c89496c112bbe9525cc985f32ec555d38dbd990ac371e6
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
+++ b/charts/redpanda/testdata/ci/97-license-key-values.yaml.tpl.golden
@@ -356,7 +356,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -828,7 +828,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/98-license-secret-values.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -770,7 +770,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/99-none-existent-config-options-with-empty-values.yaml.golden
@@ -319,7 +319,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_idempotence: false
@@ -790,7 +790,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 497cbd38af19eb04dfc6aa373ef0757d54858fca567c0e72b051956c8d439dfb
+        config.redpanda.com/checksum: 01143b8f7653bc789fa81228fdfcf2555739d5c1e92d4fe6154c603af4c0a16b
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-0.yaml.golden
@@ -307,7 +307,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -763,7 +763,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 205e2fc63f57cb26f4b8d3cceb20a9991bb32c6a2f377d12079239a3ecddfcbd
+        config.redpanda.com/checksum: 11bd4963b82066d70a6bdd7f26bcbf0b131a7a8e8e345823564ffaa9d4a4872d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-1.yaml.golden
@@ -354,7 +354,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -826,7 +826,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 530ddada8af04d4ad6753516a59e73e0dc376dc107d8e357db122ea727d328f3
+        config.redpanda.com/checksum: f7f751323754b8378871d955c328d27a03b18c35284d62e6e0c69d5f0b51ee47
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v22.3.14-2.yaml.golden
@@ -313,7 +313,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -769,7 +769,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 425f0e6481653dcc8794f38435bb85b78406017729bbc7a5e1bb4b6eedc2c321
+        config.redpanda.com/checksum: 42751ebc8cad79a5f3ff3e6277b900c1d0fd06fae265df5627681a0a3ddcd85d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-0.yaml.golden
@@ -307,7 +307,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -763,7 +763,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 205e2fc63f57cb26f4b8d3cceb20a9991bb32c6a2f377d12079239a3ecddfcbd
+        config.redpanda.com/checksum: 11bd4963b82066d70a6bdd7f26bcbf0b131a7a8e8e345823564ffaa9d4a4872d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-1.yaml.golden
@@ -354,7 +354,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -826,7 +826,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 530ddada8af04d4ad6753516a59e73e0dc376dc107d8e357db122ea727d328f3
+        config.redpanda.com/checksum: f7f751323754b8378871d955c328d27a03b18c35284d62e6e0c69d5f0b51ee47
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.2-2.yaml.golden
@@ -313,7 +313,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -769,7 +769,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 425f0e6481653dcc8794f38435bb85b78406017729bbc7a5e1bb4b6eedc2c321
+        config.redpanda.com/checksum: 42751ebc8cad79a5f3ff3e6277b900c1d0fd06fae265df5627681a0a3ddcd85d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-0.yaml.golden
@@ -307,7 +307,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -763,7 +763,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 205e2fc63f57cb26f4b8d3cceb20a9991bb32c6a2f377d12079239a3ecddfcbd
+        config.redpanda.com/checksum: 11bd4963b82066d70a6bdd7f26bcbf0b131a7a8e8e345823564ffaa9d4a4872d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-1.yaml.golden
@@ -354,7 +354,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -826,7 +826,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 530ddada8af04d4ad6753516a59e73e0dc376dc107d8e357db122ea727d328f3
+        config.redpanda.com/checksum: f7f751323754b8378871d955c328d27a03b18c35284d62e6e0c69d5f0b51ee47
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.1.3-2.yaml.golden
@@ -313,7 +313,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -769,7 +769,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 425f0e6481653dcc8794f38435bb85b78406017729bbc7a5e1bb4b6eedc2c321
+        config.redpanda.com/checksum: 42751ebc8cad79a5f3ff3e6277b900c1d0fd06fae265df5627681a0a3ddcd85d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-0.yaml.golden
@@ -307,7 +307,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -763,7 +763,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 205e2fc63f57cb26f4b8d3cceb20a9991bb32c6a2f377d12079239a3ecddfcbd
+        config.redpanda.com/checksum: 11bd4963b82066d70a6bdd7f26bcbf0b131a7a8e8e345823564ffaa9d4a4872d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-1.yaml.golden
@@ -354,7 +354,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -826,7 +826,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 530ddada8af04d4ad6753516a59e73e0dc376dc107d8e357db122ea727d328f3
+        config.redpanda.com/checksum: f7f751323754b8378871d955c328d27a03b18c35284d62e6e0c69d5f0b51ee47
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.2.1-2.yaml.golden
@@ -313,7 +313,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -769,7 +769,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 425f0e6481653dcc8794f38435bb85b78406017729bbc7a5e1bb4b6eedc2c321
+        config.redpanda.com/checksum: 42751ebc8cad79a5f3ff3e6277b900c1d0fd06fae265df5627681a0a3ddcd85d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-0.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: ac5553b3b2f121b37b54ffa72ce4e429d90d3adb0d5e15411c313c4e26e4ec89
+        config.redpanda.com/checksum: 23982b44b38baf6a3fbe40ee0df7aada2aa4cb09625c7e176f3b1ce74bce24db
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-1.yaml.golden
@@ -356,7 +356,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -828,7 +828,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v23.3.0-2.yaml.golden
@@ -315,7 +315,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -771,7 +771,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: e2cf8f893603cc15f25a48281063b9657cfa6f2e8874e547cfe597f9438fd2a4
+        config.redpanda.com/checksum: 1a08afe5e2cb947c1ca3591fee128d89ad7da6d1ae205dea1ebab80137df0d61
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-0.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: ac5553b3b2f121b37b54ffa72ce4e429d90d3adb0d5e15411c313c4e26e4ec89
+        config.redpanda.com/checksum: 23982b44b38baf6a3fbe40ee0df7aada2aa4cb09625c7e176f3b1ce74bce24db
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-1.yaml.golden
@@ -356,7 +356,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -828,7 +828,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/default-v24.1.0-2.yaml.golden
@@ -315,7 +315,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -771,7 +771,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: e2cf8f893603cc15f25a48281063b9657cfa6f2e8874e547cfe597f9438fd2a4
+        config.redpanda.com/checksum: 1a08afe5e2cb947c1ca3591fee128d89ad7da6d1ae205dea1ebab80137df0d61
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-0.yaml.golden
@@ -307,7 +307,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -763,7 +763,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 205e2fc63f57cb26f4b8d3cceb20a9991bb32c6a2f377d12079239a3ecddfcbd
+        config.redpanda.com/checksum: 11bd4963b82066d70a6bdd7f26bcbf0b131a7a8e8e345823564ffaa9d4a4872d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-1.yaml.golden
@@ -354,7 +354,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -826,7 +826,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 530ddada8af04d4ad6753516a59e73e0dc376dc107d8e357db122ea727d328f3
+        config.redpanda.com/checksum: f7f751323754b8378871d955c328d27a03b18c35284d62e6e0c69d5f0b51ee47
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v23.2.8-2.yaml.golden
@@ -313,7 +313,7 @@ data:
         require_client_auth: false
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -769,7 +769,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: 425f0e6481653dcc8794f38435bb85b78406017729bbc7a5e1bb4b6eedc2c321
+        config.redpanda.com/checksum: 42751ebc8cad79a5f3ff3e6277b900c1d0fd06fae265df5627681a0a3ddcd85d
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-0.yaml.golden
@@ -309,7 +309,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -765,7 +765,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: ac5553b3b2f121b37b54ffa72ce4e429d90d3adb0d5e15411c313c4e26e4ec89
+        config.redpanda.com/checksum: 23982b44b38baf6a3fbe40ee0df7aada2aa4cb09625c7e176f3b1ce74bce24db
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-1.yaml.golden
@@ -356,7 +356,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -828,7 +828,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: c44cce63405ee771589aabf243f7b6f3cb7629709ecdb7219963809efb85b907
+        config.redpanda.com/checksum: c8db5b6405d72c312154fbf729e24fba7d7fc4483e00f0134fee8f2880c44938
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
+++ b/charts/redpanda/testdata/versions/somecustomrepo-v24.1.0-2.yaml.golden
@@ -315,7 +315,7 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       audit_enabled: false
       compacted_log_segment_size: 67108864
-      crash_loop_limit: "5"
+      crash_loop_limit: 5
       default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -771,7 +771,7 @@ spec:
         helm.sh/chart: redpanda-5.8.11
         redpanda.com/poddisruptionbudget: redpanda
       annotations:
-        config.redpanda.com/checksum: e2cf8f893603cc15f25a48281063b9657cfa6f2e8874e547cfe597f9438fd2a4
+        config.redpanda.com/checksum: 1a08afe5e2cb947c1ca3591fee128d89ad7da6d1ae205dea1ebab80137df0d61
     spec:
       terminationGracePeriodSeconds: 90
       securityContext: 

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -1404,7 +1404,11 @@ func (c *NodeConfig) Translate() map[string]any {
 
 	for k, v := range *c {
 		if !helmette.Empty(v) {
-			result[k] = helmette.ToYaml(v)
+			if _, ok := helmette.AsNumeric(v); ok {
+				result[k] = v
+			} else {
+				result[k] = helmette.ToYaml(v)
+			}
 		}
 	}
 


### PR DESCRIPTION
For example crash_loop_limit can change value type from integer to string while template engine converts it due to `toYaml` function usage.

### Reference

https://docs.redpanda.com/current/reference/properties/broker-properties/#crash_loop_limit