### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,85 @@
+# Change Log
+
+## Redpanda Chart
+
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-FILLMEIN) - YYYY-MM-DD
+
+#### Added
+
+#### Changed
+* `image.repository` longer needs to be the default value of
+  `"docker.redpanda.com/redpandadata/redpanda"` to respect version checks of
+  `image.tag`
+  ([#1334](https://github.com/redpanda-data/helm-charts/issues/1334)).
+* `post_upgrade_job.extraEnv` and `post_upgrade_job.extraEnvFrom` no longer accept string inputs.
+
+    Previously, they accepted either strings or structured fields. As the types
+    of this chart are reflected in the operator's CRD, we are bound by the
+    constraints of Kubernetes' CRDs, which do not support fields with multiple
+    types. We also noticed that the [CRD requires these fields to be structured
+    types](https://github.com/redpanda-data/redpanda-operator/blob/9fa7a7848a22ece215be36dd17f0e4c2ba0002f7/src/go/k8s/api/redpanda/v1alpha2/redpanda_clusterspec_types.go#L597-L600)
+    rather than strings. Too minimize the divergences between the two, we've
+    opted to drop support for string inputs here but preserve them elsewhere.
+
+    Updating these fields, if they are strings, is typically a case of needing
+    to remove `|-`'s from one's values file.
+
+    Before:
+    ```yaml
+    post_upgrade_job:
+      extraEnv: |-
+      - name: SPECIAL_LEVEL_KEY
+          valueFrom:
+            configMapKeyRef:
+              name: special-config
+              key: special.how
+    ```
+
+    After:
+    ```yaml
+    post_upgrade_job:
+      extraEnv:
+      - name: SPECIAL_LEVEL_KEY
+        valueFrom:
+          configMapKeyRef:
+            name: special-config
+            key: special.how
+    ```
+
+    If you were using a templated value and would like to see it added back,
+    please [file us an
+    issue](https://github.com/redpanda-data/helm-charts/issues/new/choose) and
+    tell us about your use case!
+
+#### Fixed
+* Numeric node/broker configurations are now properly transcoded as numerics.
+
+#### Removed
+
+## Redpanda Operator Chart
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/operator-FILLMEIN) - YYYY-MM-DD
+#### Added
+#### Changed
+#### Fixed
+#### Removed
+
+## Connectors Chart
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/connectors-FILLMEIN) - YYYY-MM-DD
+#### Added
+#### Changed
+#### Fixed
+#### Removed
+
+## Console Chart
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/console-FILLMEIN) - YYYY-MM-DD
+#### Added
+#### Changed
+#### Fixed
+#### Removed
+
+## Kminion Chart
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/console-FILLMEIN) - YYYY-MM-DD
+#### Added
+#### Changed
+#### Fixed
+#### Removed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,98 +27,13 @@ nix develop -c fish  # Enter a development shell using fish/zsh
 nix develop -c zsh  # Enter a development shell using fish/zsh
 ```
 
-## Contributing
+## Making Changes
 
-One way to debug during helm development is to diff the kubernetes configuration files that helm generates:
+User facing changes should be documented in [the CHANGELOG][./CHANGELOG.md]
+under the chart appropriate subheading. Changes are grouped into "Added,
+Changed, Fixed, and Removed". Breaking changes[^1] and deprecations should be
+prefixed with the "BREAKING" and "DEPRECATED", respectively.
 
-### Setup
-
-Create and initialize git in a new directory (make sure to be outside an existing source-controlled directory):
-
-```sh
-mkdir helm-output
-cd helm-output
-git init
-```
-
-#### Create scripts
-
-Create a new file `split-output.sh` in the `helm-output` directory:
-
-```
-#!/bin/bash
-# split-output.sh - split helm output into individual files
-if (($# != 2)); then
-  echo "Requires the helm directory and namespace as arguments"
-  echo "./split-output.sh <helm directory> <namespace>"
-  echo "ex: ./split-output.sh helm-charts/redpanda helm-test"
-  exit 1
-fi
-helm -n $2 install redpanda $1 --dry-run > input.yaml
-csplit -s --suppress-matched -z input.yaml /---/ '{*}'
-# remove the first file (it is helm metadata rather than a k8s object)
-rm xx00
-# loop through each file and rename according to to k8s name and source
-# ex. <name>-<source-file>, or redpanda-statefulset.yaml
-for file in xx*; do
-  NEWNAME=`grep -Po "(?<=^\ \ name:\ ).*" $file | sed 's/"//g' | xargs`-`head -1 "$file" | cut -d '/' -f 3 | sed 's/\.yaml//'`.yaml
-  mv "$file" $NEWNAME
-done
-```
-
-Create another new file `get-redpanda-config.sh` in the same directory:
-
-```
-#!/bin/bash
-# get-redpanda-config.sh - retrieves Redpanda config from a running node
-# This node's configuration is printed out at startup, and a file responsible for this is application.cc
-# We need to find the relevant message in the log to then filter all subsequent messages by
-if (($# != 1)); then
-  echo "Requires namespace as the first argument"
-  echo "./get-redpanda-config.sh <namespace>"
-  echo "ex: ./get-redpanda-config.sh helm-test"
-  exit 1
-fi
-COUNT=$(kubectl -n $1 get sts | sed '2q;d' | awk '{print $2}' | cut -c1-1)
-for (( i=0; i<$COUNT; i++)); do
-  RELEVANTLINE=$(kubectl logs -n $1 redpanda-$i | grep application.cc | sed '7q;d' | awk '{print $8}')
-  kubectl logs -n $1 redpanda-$i | grep $RELEVANTLINE | awk -F' - ' '{ $1=""; $2=""; print}' > ~/projects/redpanda/helm-output/redpanda-$i-config.txt
-done
-```
-
-Make both of these files executable:
-
-```sh
-chmod +x split-output.sh && chmod +x get-redpanda-config.sh
-```
-
-#### Run scripts
-
-Collect the initial logs and yaml files from a running Redpanda cluster. The namespace `helm-test` is used below... replace with whatever namespace you used for your redpanda install. This will be the baseline of your output files, so you will be able to compare any differences based on future changes to the helm chart:
-
-```sh
-./get-redpanda-config.sh helm-test
-./split-output.sh ../helm-charts/redpanda helm-test
-```
-
-You will have many yaml files along with a `redpanda-0-config.txt` file and your two scripts. Commit all these files to the repo:
-
-```sh
-git add . && git commit -m 'init commit'
-```
-
-### Iterate
-
-Now you are ready to make changes to the helm chart and eventually restart your cluster. Once this is done, re-run the `get-redpanda-config.sh` and `split-output.sh` scripts to extract the same files again, and use git to diff the results.
-
-#### Restoring output directory
-
-One you are done comparing the differences, you will likely want to get back to the initial state for these log files so you can compare against subsequent runs. Do this with the following command:
-
-
-```sh
-git restore -- . && git clean -df
-```
-
-But be careful! The above command will throw away all changes in whatever git repo you run it against, and you will be back to the most recent commit.
-
+[^1]: A change is considered breaking if the `values.yaml`, sans deprecated fields,
+from the previous release cannot be used in a `helm upgrade` command without
+modifications.


### PR DESCRIPTION
This commit adds a CHANGELOG.md file. Rather than automatically constructing release notes from the git commit log using semantic commits, we've opted to have dev's add notes about user facing changes to this log as they commit them.

This commit also slightly expands CONTRIBUTING.md and removes the, now very, outdated notes.

Closes #1406