### PR TITLE
fix: Terraform Helm error "invalid Yaml document separator: apiVersion: v1"

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.11
+version: 5.8.12
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.11](https://img.shields.io/badge/Version-5.8.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.8](https://img.shields.io/badge/AppVersion-v24.1.8-informational?style=flat-square)
+![Version: 5.8.12](https://img.shields.io/badge/Version-5.8.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.1.8](https://img.shields.io/badge/AppVersion-v24.1.8-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/templates/service.internal.yaml
+++ b/charts/redpanda/templates/service.internal.yaml
@@ -14,8 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
----
 {{- $svc := (get ((include "redpanda.ServiceInternal" (dict "a" (list .))) | fromJson) "r") }}
 {{- if ne $svc nil -}}
+---
 {{toYaml $svc}}
 {{- end -}}


### PR DESCRIPTION
Apparently Terraform Helm doesn't like the notation used in the `charts/redpanda/templates/service.internal.yaml` (delimiter without condition).

Replicating the notation from `charts/redpanda/templates/poddisruptionbudget.yaml` fixed the issue.

Fixes the #1410 