### PR TITLE
operator: bump app version to v2.1.26-24.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@
 #### Added
 #### Changed
 #### Fixed
+#### Removed
+
+### [0.4.25](https://github.com/redpanda-data/helm-charts/releases/tag/operator-0.4.25) - 2024-07-17
+#### Added
+#### Changed
+* Updated `appVersion` to `v2.1.26-24.1.9`
+#### Fixed
 * Added missing permissions for the NodeWatcher controller (`rbac.createAdditionalControllerCRs`)
 #### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 #### Added
 #### Changed
 #### Fixed
+* Added missing permissions for the NodeWatcher controller (`rbac.createAdditionalControllerCRs`)
 #### Removed
 
 ## Connectors Chart

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.24
+version: 0.4.25
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
-appVersion: v2.1.20-24.1.2
+appVersion: v2.1.26-24.1.9
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -34,11 +34,11 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.20-24.1.2
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.26-24.1.9
     - name: configurator
-      image: docker.redpanda.com/redpandadata/configurator:v2.1.20-24.1.2
+      image: docker.redpanda.com/redpandadata/configurator:v2.1.26-24.1.9
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v24.1.2
+      image: docker.redpanda.com/redpandadata/redpanda:v24.1.9
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   artifacthub.io/crds: |

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.24](https://img.shields.io/badge/Version-0.4.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.20-24.1.2](https://img.shields.io/badge/AppVersion-v2.1.20--24.1.2-informational?style=flat-square)
+![Version: 0.4.25](https://img.shields.io/badge/Version-0.4.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.26-24.1.9](https://img.shields.io/badge/AppVersion-v2.1.26--24.1.9-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/operator/files/three_node_redpanda.yaml
+++ b/charts/operator/files/three_node_redpanda.yaml
@@ -16,7 +16,8 @@ spec:
         external: {}
         port: 9644
         tls:
-          cert: ""
+          # TODO(chrisseto): Uncomment this once the redpanda chart is fixed.
+          # cert: ""
           enabled: false
           requireClientAuth: false
       http:
@@ -26,7 +27,8 @@ spec:
         kafkaEndpoint: kafka-default
         port: 8082
         tls:
-          cert: ""
+          # TODO(chrisseto): Uncomment this once the redpanda chart is fixed.
+          # cert: ""
           enabled: false
           requireClientAuth: false
       kafka:

--- a/charts/operator/templates/clusterrole.yaml
+++ b/charts/operator/templates/clusterrole.yaml
@@ -363,4 +363,23 @@ rules:
     - update
     - watch
     - delete
+# Read-Only access to Secrets and Configmaps is required for the NodeWatcher
+# controller to work appropriately due to the usage of helm to retrieve values.
+- apiGroups:
+    - ""
+  resources:
+    - secrets
+    - configmaps
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - persistentvolumes
+  verbs:
+    - get
+    - list
+    - watch
 {{- end }}

--- a/charts/redpanda/templates/_statefulset.go.tpl
+++ b/charts/redpanda/templates/_statefulset.go.tpl
@@ -675,7 +675,9 @@
 {{- define "redpanda.StorageTieredConfig" -}}
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
+{{- $_is_returning = true -}}
 {{- (dict "r" (get (fromJson (include "redpanda.Storage.GetTieredStorageConfig" (dict "a" (list $values.storage) ))) "r")) | toJson -}}
 {{- break -}}
 {{- end -}}


### PR DESCRIPTION
This commit bumps the app version of the operator helm chart to v2.1.26-24.1.9.

It also fixes some merge skew which resulted in a redpanda chart file being out of date.