### PR TITLE
redpanda: handle cert = "" 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,16 @@
 
 ## Redpanda Chart
 
-### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-FILLMEIN) - YYYY-MM-DD
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.8.13) - YYYY-MM-DD
+#### Added
+#### Changed
+#### Fixed
+* Fixed a regression where `post_upgrade_job` would fail if TLS on the admin
+  listener was disabled but had `cert` set to an invalid cert (e.g. `""`)
+* Fixed mTLS configurations between Redpanda and Console [#1402](https://github.com/redpanda-data/helm-charts/pull/1402)
+#### Removed
+
+### [5.8.12](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.8.12) - 2024-07-10
 
 #### Added
 
@@ -61,6 +70,7 @@
 #### Added
 #### Changed
 #### Fixed
+* Added missing permissions for the NodeWatcher controller (`rbac.createAdditionalControllerCRs`)
 #### Removed
 
 ### [0.4.25](https://github.com/redpanda-data/helm-charts/releases/tag/operator-0.4.25) - 2024-07-17

--- a/charts/operator/files/three_node_redpanda.yaml
+++ b/charts/operator/files/three_node_redpanda.yaml
@@ -16,7 +16,7 @@ spec:
         external: {}
         port: 9644
         tls:
-          # TODO(chrisseto): Uncomment this once the redpanda chart is fixed.
+          # TODO(chrisseto): Uncomment once #1428 is released
           # cert: ""
           enabled: false
           requireClientAuth: false
@@ -27,7 +27,7 @@ spec:
         kafkaEndpoint: kafka-default
         port: 8082
         tls:
-          # TODO(chrisseto): Uncomment this once the redpanda chart is fixed.
+          # TODO(chrisseto): Uncomment once #1428 is released
           # cert: ""
           enabled: false
           requireClientAuth: false

--- a/charts/redpanda/ci/40-empty-string-tls-novalues.yaml
+++ b/charts/redpanda/ci/40-empty-string-tls-novalues.yaml
@@ -1,0 +1,57 @@
+# Copied from charts/operator/files/three_node_redpanda.yaml. The inclusion of
+# tls.enabled: false and tls.cert: "" triggered failures.
+console:
+  enabled: false
+image:
+  repository: docker.redpanda.com/redpandadata/redpanda
+  tag: v23.2.2
+listeners:
+  admin:
+    external: {}
+    port: 9644
+    tls:
+      cert: ""
+      enabled: false
+      requireClientAuth: false
+  http:
+    authenticationMethod: none
+    enabled: true
+    external: {}
+    kafkaEndpoint: kafka-default
+    port: 8082
+    tls:
+      cert: ""
+      enabled: false
+      requireClientAuth: false
+  kafka:
+    authenticationMethod: none
+    external: {}
+    port: 9092
+    tls:
+      cert: kafka-internal-0
+      enabled: true
+      requireClientAuth: true
+  rpc:
+    port: 33145
+logging:
+  logLevel: trace
+  usageStats:
+    enabled: false
+resources:
+  cpu:
+    cores: 1
+  memory:
+    container:
+      max: 2Gi
+      min: 2Gi
+statefulset:
+  replicas: 3
+storage:
+  persistentVolume:
+    enabled: true
+    size: 100Gi
+tls:
+  certs:
+    kafka-internal-0:
+      caEnabled: true
+  enabled: true

--- a/charts/redpanda/templates/post_upgrade_job.yaml
+++ b/charts/redpanda/templates/post_upgrade_job.yaml
@@ -69,14 +69,14 @@
 {{- end -}}
 {{- if (get (fromJson (include "redpanda.RedpandaAtLeast_23_2_1" (dict "a" (list $dot) ))) "r") -}}
 {{- $service := $values.listeners.admin -}}
-{{- $cert := (get (fromJson (include "redpanda.TLSCertMap.MustGet" (dict "a" (list (deepCopy $values.tls.certs) $service.tls.cert) ))) "r") -}}
 {{- $caCert := "" -}}
-{{- if $cert.caEnabled -}}
-{{- $caCert = (printf "--cacert /etc/tls/certs/%s/ca.crt" $service.tls.cert) -}}
-{{- end -}}
 {{- $scheme := "http" -}}
 {{- if (get (fromJson (include "redpanda.InternalTLS.IsEnabled" (dict "a" (list $service.tls $values.tls) ))) "r") -}}
 {{- $scheme = "https" -}}
+{{- $cert := (get (fromJson (include "redpanda.TLSCertMap.MustGet" (dict "a" (list (deepCopy $values.tls.certs) $service.tls.cert) ))) "r") -}}
+{{- if $cert.caEnabled -}}
+{{- $caCert = (printf "--cacert /etc/tls/certs/%s/ca.crt" $service.tls.cert) -}}
+{{- end -}}
 {{- end -}}
 {{- $url := (printf "%s://%s:%d/v1/debug/restart_service?service=schema-registry" $scheme (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r") (($service.port | int) | int64)) -}}
 {{- $script = (concat (default (list ) $script) (list `if [ -d "/etc/secrets/users/" ]; then` `    IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))` `    curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \` (printf `    %s \` $caCert) `    -X PUT -u ${USER_NAME}:${PASSWORD} \` (printf `    %s || true` $url) `fi`)) -}}

--- a/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/04-one-node-cluster-no-tls-sasl-values.yaml.golden
@@ -1184,7 +1184,7 @@ spec:
           if [ -d "/etc/secrets/users/" ]; then
               IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
               curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
-              --cacert /etc/tls/certs/default/ca.crt \
+               \
               -X PUT -u ${USER_NAME}:${PASSWORD} \
               http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
           fi

--- a/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
+++ b/charts/redpanda/testdata/ci/14-prometheus-no-tls-values.yaml.golden
@@ -1100,7 +1100,7 @@ spec:
           if [ -d "/etc/secrets/users/" ]; then
               IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
               curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
-              --cacert /etc/tls/certs/default/ca.crt \
+               \
               -X PUT -u ${USER_NAME}:${PASSWORD} \
               http://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
           fi

--- a/charts/redpanda/testdata/ci/40-empty-string-tls-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/40-empty-string-tls-novalues.yaml.golden
@@ -10,7 +10,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
 spec:
@@ -27,19 +26,6 @@ status:
   disruptionsAllowed: 0
   expectedPods: 0
 ---
-# Source: redpanda/charts/console/templates/serviceaccount.yaml
-apiVersion: v1
-kind: ServiceAccount
-automountServiceAccountToken: true
-metadata:
-  name: redpanda-console
-  labels:
-    helm.sh/chart: console-0.7.26
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.6"
-    app.kubernetes.io/managed-by: Helm
----
 # Source: redpanda/templates/secrets.yaml
 apiVersion: v1
 kind: Secret
@@ -51,7 +37,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -130,8 +115,7 @@ stringData:
 
       touch /tmp/preStopHookFinished
     }
-    touch /tmp/preStopHookFinished
-    echo "Not enough replicas or in recovery mode, cannot put a broker into maintenance mode."
+    preStopHook
     true
 type: Opaque
 ---
@@ -146,7 +130,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -185,7 +168,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -202,10 +184,16 @@ stringData:
     cp /tmp/base-config/redpanda.yaml "${CONFIG}"
     cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
 
-    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9092}"
     rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
 
     ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
 
     PREFIX_TEMPLATE=""
     ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
@@ -220,6 +208,12 @@ stringData:
     PREFIX_TEMPLATE=""
     ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
 
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
     rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
 type: Opaque
 ---
@@ -227,9 +221,8 @@ type: Opaque
 apiVersion: v1
 data:
   bootstrap.yaml: |-
-    audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 1
+    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -240,14 +233,14 @@ data:
     log_segment_size_max: 268435456
     log_segment_size_min: 16777216
     max_compacted_log_segment_size: 536870912
-    retention_local_target_ms_default: 21600000
-    storage_min_free_bytes: 161061273
+    storage_min_free_bytes: 5368709120
     topic_partitions_per_shard: 1000
   redpanda.yaml: |-
     config_file: /etc/redpanda/redpanda.yaml
     pandaproxy:
       pandaproxy_api:
       - address: 0.0.0.0
+        authentication_method: none
         name: internal
         port: 8082
       - address: 0.0.0.0
@@ -255,9 +248,19 @@ data:
         port: 8083
       pandaproxy_api_tls: null
     pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/kafka-internal-0/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/kafka-internal-0/tls.key
+        require_client_auth: true
+        truststore_file: /etc/tls/certs/kafka-internal-0/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
+        port: 9092
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9092
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9092
     redpanda:
       admin:
       - address: 0.0.0.0
@@ -267,7 +270,6 @@ data:
         name: default
         port: 9645
       admin_api_tls: null
-      audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
       default_topic_replications: 3
@@ -276,12 +278,25 @@ data:
       group_topic_partitions: 16
       kafka_api:
       - address: 0.0.0.0
+        authentication_method: none
         name: internal
-        port: 9093
+        port: 9092
       - address: 0.0.0.0
         name: default
         port: 9094
-      kafka_api_tls: null
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/kafka-internal-0/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/kafka-internal-0/tls.key
+        name: internal
+        require_client_auth: true
+        truststore_file: /etc/tls/certs/kafka-internal-0/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
       kafka_batch_max_bytes: 1048576
       kafka_connection_rate_limit: 1000
       kafka_enable_authorization: false
@@ -289,31 +304,49 @@ data:
       log_segment_size_max: 268435456
       log_segment_size_min: 16777216
       max_compacted_log_segment_size: 536870912
-      retention_local_target_ms_default: 21600000
       rpc_server:
         address: 0.0.0.0
         port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
       seed_servers:
       - host:
           address: redpanda-0.redpanda.default.svc.cluster.local.
           port: 33145
-      storage_min_free_bytes: 161061273
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 5368709120
       topic_partitions_per_shard: 1000
     rpk:
       additional_start_flags:
-      - --default-log-level=info
-      - --memory=2048M
-      - --reserve-memory=205M
+      - --default-log-level=trace
+      - --memory=1638M
+      - --reserve-memory=204M
       - --smp=1
       admin_api:
         addresses:
         - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
         tls: null
       enable_memory_locking: false
       kafka_api:
         brokers:
-        - redpanda-0.redpanda.default.svc.cluster.local.:9093
-        tls: null
+        - redpanda-0.redpanda.default.svc.cluster.local.:9092
+        - redpanda-1.redpanda.default.svc.cluster.local.:9092
+        - redpanda-2.redpanda.default.svc.cluster.local.:9092
+        tls:
+          cert_file: /etc/tls/certs/redpanda-client/tls.crt
+          key_file: /etc/tls/certs/redpanda-client/tls.key
+          truststore_file: /etc/tls/certs/kafka-internal-0/ca.crt
       overprovisioned: false
       tune_aio_events: true
     schema_registry:
@@ -324,11 +357,33 @@ data:
       - address: 0.0.0.0
         name: default
         port: 8084
-      schema_registry_api_tls: null
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
     schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/kafka-internal-0/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/kafka-internal-0/tls.key
+        require_client_auth: true
+        truststore_file: /etc/tls/certs/kafka-internal-0/ca.crt
       brokers:
       - address: redpanda-0.redpanda.default.svc.cluster.local.
-        port: 9093
+        port: 9092
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9092
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9092
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -338,7 +393,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
 ---
@@ -349,11 +403,18 @@ data:
     admin_api:
       addresses:
       - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
       tls: null
     kafka_api:
       brokers:
       - redpanda-0:31092
-      tls: null
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+        cert_file: /etc/tls/certs/redpanda-client/tls.crt
+        key_file: /etc/tls/certs/redpanda-client/tls.key
     name: default
 kind: ConfigMap
 metadata:
@@ -364,81 +425,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
----
-# Source: redpanda/templates/console/configmap-and-deployment.yaml
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: redpanda-console
-  labels:
-    helm.sh/chart: console-0.7.26
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.6"
-    app.kubernetes.io/managed-by: Helm
-    
-data:
-  config.yaml: |
-    # from .Values.console.config
-    kafka:
-      brokers:
-      - redpanda-0.redpanda.default.svc.cluster.local.:9093
-      sasl:
-        enabled: false
-      schemaRegistry:
-        enabled: true
-        tls:
-          caFilepath: ""
-          certFilepath: ""
-          enabled: false
-          insecureSkipTlsVerify: false
-          keyFilepath: ""
-        urls:
-        - http://redpanda-0.redpanda.default.svc.cluster.local.:8081
-      tls:
-        caFilepath: ""
-        certFilepath: ""
-        enabled: false
-        insecureSkipTlsVerify: false
-        keyFilepath: ""
-    redpanda:
-      adminApi:
-        enabled: true
-        tls:
-          caFilepath: ""
-          certFilepath: ""
-          enabled: false
-          insecureSkipTlsVerify: false
-          keyFilepath: ""
-        urls:
-        - http://redpanda.default.svc.cluster.local.:9644
----
-# Source: redpanda/charts/console/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: redpanda-console
-  labels:
-    helm.sh/chart: console-0.7.26
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.6"
-    app.kubernetes.io/managed-by: Helm
-    
-spec:
-  type: ClusterIP
-  ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
-  selector:
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
 ---
 # Source: redpanda/templates/service.internal.yaml
 apiVersion: v1
@@ -453,7 +441,6 @@ metadata:
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
     monitoring.redpanda.com/enabled: "false"
-    testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
 spec:
@@ -468,9 +455,9 @@ spec:
     protocol: TCP
     targetPort: 8082
   - name: kafka
-    port: 9093
+    port: 9092
     protocol: TCP
-    targetPort: 9093
+    targetPort: 9092
   - name: rpc
     port: 33145
     protocol: TCP
@@ -500,7 +487,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
 spec:
@@ -536,81 +522,6 @@ spec:
 status:
   loadBalancer: {}
 ---
-# Source: redpanda/templates/console/configmap-and-deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: redpanda-console
-  labels:
-    helm.sh/chart: console-0.7.26
-    app.kubernetes.io/name: console
-    app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.6"
-    app.kubernetes.io/managed-by: Helm
-    
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app.kubernetes.io/name: console
-      app.kubernetes.io/instance: redpanda
-  template:
-    metadata:
-      annotations:
-        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
-        checksum-redpanda-chart/config: 82723d6c4dc9da450c91629c7f4743899e41af379466656066723a9cdc123821
-      labels:
-        app.kubernetes.io/name: console
-        app.kubernetes.io/instance: redpanda
-    spec:
-      serviceAccountName: redpanda-console
-      automountServiceAccountToken: true
-      securityContext:
-        fsGroup: 99
-        runAsUser: 99
-      volumes:
-        - name: configs
-          configMap:
-            name: redpanda-console
-      containers:
-        - name: console
-          args:
-            - "--config.filepath=/etc/console/configs/config.yaml"
-          securityContext:
-            runAsNonRoot: true
-          image: docker.redpanda.com/redpandadata/console:v2.4.6
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: http
-              containerPort: 8080
-              protocol: TCP
-          volumeMounts:
-            - name: configs
-              mountPath: /etc/console/configs
-              readOnly: true
-          livenessProbe:
-            initialDelaySeconds: 0
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-            httpGet:
-              path: /admin/health
-              port: http
-          readinessProbe:
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 1
-            successThreshold: 1
-            failureThreshold: 3
-            httpGet:
-              path: /admin/health
-              port: http
-          resources:
-            {}
-          env:
-      priorityClassName:
----
 # Source: redpanda/templates/statefulset.yaml
 apiVersion: apps/v1
 kind: StatefulSet
@@ -622,12 +533,11 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
 spec:
   podManagementPolicy: Parallel
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app.kubernetes.io/component: redpanda-statefulset
@@ -637,7 +547,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 42c4bda70c2a4121c5c80986b90bc9943a2452031fc76a3c6550a0f93854e8be
+        config.redpanda.com/checksum: 7d7e998dba100735893ba73afa92e160d57f0e0f45ce15680dfef3e05bebb3fc
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
@@ -646,7 +556,6 @@ spec:
         app.kubernetes.io/name: redpanda
         helm.sh/chart: redpanda-5.8.12
         redpanda.com/poddisruptionbudget: redpanda
-        testlabel: exercise_common_labels_template
     spec:
       affinity:
         podAntiAffinity:
@@ -676,7 +585,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
         lifecycle:
           postStart:
             exec:
@@ -713,7 +622,7 @@ spec:
           name: http
         - containerPort: 8083
           name: http-default
-        - containerPort: 9093
+        - containerPort: 9092
           name: kafka
         - containerPort: 9094
           name: kafka-default
@@ -741,7 +650,10 @@ spec:
         resources:
           limits:
             cpu: 1
-            memory: 2.5Gi
+            memory: 2Gi
+          requests:
+            cpu: 1
+            memory: 2Gi
         securityContext:
           allowPrivilegeEscalation: null
           runAsGroup: 101
@@ -761,6 +673,14 @@ spec:
           initialDelaySeconds: 1
           periodSeconds: 10
         volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/tls/certs/kafka-internal-0
+          name: redpanda-kafka-internal-0-cert
+        - mountPath: /etc/tls/certs/redpanda-client
+          name: mtls-client
         - mountPath: /etc/redpanda
           name: config
         - mountPath: /tmp/base-config
@@ -775,11 +695,19 @@ spec:
           & wait $!
         command:
         - /bin/sh
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
         name: config-watcher
         resources: {}
         securityContext: {}
         volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/tls/certs/kafka-internal-0
+          name: redpanda-kafka-internal-0-cert
+        - mountPath: /etc/tls/certs/redpanda-client
+          name: mtls-client
         - mountPath: /etc/redpanda
           name: config
         - mountPath: /etc/secrets/config-watcher/scripts
@@ -790,7 +718,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
         name: tuning
         resources: {}
         securityContext:
@@ -801,6 +729,14 @@ spec:
           runAsGroup: 0
           runAsUser: 0
         volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/tls/certs/kafka-internal-0
+          name: redpanda-kafka-internal-0-cert
+        - mountPath: /etc/tls/certs/redpanda-client
+          name: mtls-client
         - mountPath: /etc/redpanda
           name: redpanda
       - command:
@@ -827,7 +763,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -836,6 +772,14 @@ spec:
           runAsNonRoot: null
           runAsUser: 101
         volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/tls/certs/kafka-internal-0
+          name: redpanda-kafka-internal-0-cert
+        - mountPath: /etc/tls/certs/redpanda-client
+          name: mtls-client
         - mountPath: /etc/redpanda
           name: config
         - mountPath: /tmp/base-config
@@ -860,6 +804,18 @@ spec:
         topologyKey: topology.kubernetes.io/zone
         whenUnsatisfiable: ScheduleAnyway
       volumes:
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - name: redpanda-kafka-internal-0-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-kafka-internal-0-cert
       - name: lifecycle-scripts
         secret:
           defaultMode: 509
@@ -894,46 +850,346 @@ spec:
         app.kubernetes.io/component: redpanda
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/name: redpanda
-        testlabel: exercise_common_labels_template
       name: datadir
     spec:
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 3Gi
+          storage: 100Gi
     status: {}
 status:
   availableReplicas: 0
   replicas: 0
 ---
-# Source: redpanda/templates/console/configmap-and-deployment.yaml
-# before license changes, this was not printing a secret, so we gather in which case to print
-# for now only if we have a license do we print, however, this may be an issue for some
-# since if we do include a license we MUST also print all secret items.
----
-# Source: redpanda/charts/console/templates/tests/test-connection.yaml
-apiVersion: v1
-kind: Pod
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
 metadata:
-  name: "redpanda-console-test-connection"
+  creationTimestamp: null
   labels:
-    helm.sh/chart: console-0.7.26
-    app.kubernetes.io/name: console
+    app.kubernetes.io/component: redpanda
     app.kubernetes.io/instance: redpanda
-    app.kubernetes.io/version: "v2.4.6"
     app.kubernetes.io/managed-by: Helm
-    
-  annotations:
-    "helm.sh/hook": test
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-root-certificate
+  namespace: default
 spec:
-  containers:
-    - name: wget
-      image: busybox
-      command: ['wget']
-      args: ['redpanda-console:8080']
-  restartPolicy: Never
-  priorityClassName:
+  commonName: redpanda-default-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-root-certificate
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-external-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-root-certificate
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-kafka-internal-0-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-kafka-internal-0-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-kafka-internal-0-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-kafka-internal-0-root-certificate
+status: {}
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-cert
+status: {}
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-cert
+status: {}
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-kafka-internal-0-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-kafka-internal-0-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-kafka-internal-0-cert
+status: {}
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-client
+spec:
+  commonName: redpanda-client
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-kafka-internal-0-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-client
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-kafka-internal-0-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-kafka-internal-0-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-kafka-internal-0-root-certificate
+status: {}
 ---
 # Source: redpanda/templates/post-install-upgrade-job.yaml
 apiVersion: batch/v1
@@ -950,7 +1206,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
 spec:
@@ -962,7 +1217,6 @@ spec:
         app.kubernetes.io/component: redpanda-post-install
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/name: redpanda
-        testlabel: exercise_common_labels_template
     spec:
       affinity: {}
       containers:
@@ -990,7 +1244,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
         name: redpanda-post-install
         resources: {}
         securityContext:
@@ -999,6 +1253,14 @@ spec:
         volumeMounts:
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/tls/certs/kafka-internal-0
+          name: redpanda-kafka-internal-0-cert
+        - mountPath: /etc/tls/certs/redpanda-client
+          name: mtls-client
       imagePullSecrets: null
       nodeSelector: {}
       restartPolicy: Never
@@ -1011,6 +1273,18 @@ spec:
       - configMap:
           name: redpanda
         name: config
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - name: redpanda-kafka-internal-0-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-kafka-internal-0-cert
 status: {}
 ---
 # Source: redpanda/templates/post-upgrade.yaml
@@ -1028,7 +1302,6 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.8.12
-    testlabel: exercise_common_labels_template
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -1040,7 +1313,6 @@ spec:
         app.kubernetes.io/component: redpanda-post-upgrade
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/name: redpanda
-        testlabel: exercise_common_labels_template
       name: redpanda
     spec:
       affinity: {}
@@ -1049,9 +1321,8 @@ spec:
         - |
           set -e
 
-          rpk cluster config set default_topic_replications 1
-          rpk cluster config set retention_local_target_ms_default 21600000
-          rpk cluster config set storage_min_free_bytes 161061273
+          rpk cluster config set default_topic_replications 3
+          rpk cluster config set storage_min_free_bytes 5368709120
           if [ -d "/etc/secrets/users/" ]; then
               IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
               curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
@@ -1064,7 +1335,7 @@ spec:
         - -c
         env: null
         envFrom: null
-        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        image: docker.redpanda.com/redpandadata/redpanda:v23.2.2
         name: redpanda-post-upgrade
         resources: null
         securityContext:
@@ -1073,6 +1344,14 @@ spec:
         volumeMounts:
         - mountPath: /etc/redpanda
           name: config
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/tls/certs/kafka-internal-0
+          name: redpanda-kafka-internal-0-cert
+        - mountPath: /etc/tls/certs/redpanda-client
+          name: mtls-client
       imagePullSecrets: null
       nodeSelector: {}
       restartPolicy: Never
@@ -1085,4 +1364,16 @@ spec:
       - configMap:
           name: redpanda
         name: config
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - name: redpanda-kafka-internal-0-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-kafka-internal-0-cert
 status: {}


### PR DESCRIPTION
Prior to this commit, the redpanda chart would fail to render if the admin's
internal TLS set cert to "" due to the order of operations in
post_upgrade_job.go. The regression appeared during the conversion to go as
there was previously no error handling if an invalid certificate was
referenced.

This failure surfaced during an attempted release of the operator as a helm
test for the operator chart did exactly this. (See
https://github.com/redpanda-data/helm-charts/pull/1422)

This commit corrects the issue by checking TLS.IsEnabled _before_ calling
MustGet which will only trigger a failure if TLS is enabled and references an
invalid certificate.