### PR TITLE
redpanda: drop validation of `IssuerRef`

### DIFF
--- a/charts/redpanda/ci/41-external-issuers-novalues.yaml
+++ b/charts/redpanda/ci/41-external-issuers-novalues.yaml
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+# See also https://github.com/redpanda-data/helm-charts/issues/1432
+tls:
+  certs:
+    default:
+      issuerRef:
+        group: cas-issuer.jetstack.io
+        kind: GoogleCASClusterIssuer
+        name: my-cas-issuer
+
+    external:
+      issuerRef:
+        group: cas-issuer.jetstack.io
+        kind: GoogleCASClusterIssuer
+        name: my-cas-issuer

--- a/charts/redpanda/templates/values.go.tpl
+++ b/charts/redpanda/templates/values.go.tpl
@@ -470,9 +470,9 @@
 {{- $name := (index .a 1) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
-{{- $tmp_tuple_12 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (coalesce nil)) ))) "r")) ))) "r") -}}
-{{- $ok := $tmp_tuple_12.T2 -}}
-{{- $cert := $tmp_tuple_12.T1 -}}
+{{- $tmp_tuple_10 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $m $name (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok := $tmp_tuple_10.T2 -}}
+{{- $cert := $tmp_tuple_10.T1 -}}
 {{- if (not $ok) -}}
 {{- $_ := (fail (printf "Certificate %q referenced, but not found in the tls.certs map" $name)) -}}
 {{- end -}}
@@ -1096,8 +1096,8 @@
 {{- $result := (dict ) -}}
 {{- range $k, $v := $c -}}
 {{- if (not (empty $v)) -}}
-{{- $tmp_tuple_15 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_14 := $tmp_tuple_15.T2 -}}
+{{- $tmp_tuple_13 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_14 := $tmp_tuple_13.T2 -}}
 {{- if $ok_14 -}}
 {{- $_ := (set $result $k $v) -}}
 {{- else -}}
@@ -1125,24 +1125,24 @@
 {{- if (and (eq $k "default_topic_replications") (not $skipDefaultTopic)) -}}
 {{- $r := ($replicas | int) -}}
 {{- $input := ($r | int) -}}
-{{- $tmp_tuple_16 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_16 := $tmp_tuple_16.T2 -}}
-{{- $num_15 := ($tmp_tuple_16.T1 | int) -}}
+{{- $tmp_tuple_14 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_16 := $tmp_tuple_14.T2 -}}
+{{- $num_15 := ($tmp_tuple_14.T1 | int) -}}
 {{- if $ok_16 -}}
 {{- $input = $num_15 -}}
 {{- end -}}
-{{- $tmp_tuple_17 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_18 := $tmp_tuple_17.T2 -}}
-{{- $f_17 := ($tmp_tuple_17.T1 | float64) -}}
+{{- $tmp_tuple_15 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $ok_18 := $tmp_tuple_15.T2 -}}
+{{- $f_17 := ($tmp_tuple_15.T1 | float64) -}}
 {{- if $ok_18 -}}
 {{- $input = ($f_17 | int) -}}
 {{- end -}}
 {{- $_ := (set $result $k (min ($input | int64) (((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int) | int64))) -}}
 {{- continue -}}
 {{- end -}}
-{{- $tmp_tuple_18 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
-{{- $ok_20 := $tmp_tuple_18.T2 -}}
-{{- $b_19 := $tmp_tuple_18.T1 -}}
+{{- $tmp_tuple_16 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
+{{- $ok_20 := $tmp_tuple_16.T2 -}}
+{{- $b_19 := $tmp_tuple_16.T1 -}}
 {{- if $ok_20 -}}
 {{- $_ := (set $result $k $b_19) -}}
 {{- continue -}}

--- a/charts/redpanda/testdata/ci/41-external-issuers-novalues.yaml.golden
+++ b/charts/redpanda/testdata/ci/41-external-issuers-novalues.yaml.golden
@@ -1,0 +1,1395 @@
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: redpanda
+      redpanda.com/poddisruptionbudget: redpanda
+status:
+  currentHealthy: 0
+  desiredHealthy: 0
+  disruptionsAllowed: 0
+  expectedPods: 0
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.26
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.6"
+    app.kubernetes.io/managed-by: Helm
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-sts-lifecycle
+  namespace: default
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+type: Opaque
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-config-watcher
+  namespace: default
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    # rpk cluster health can exit non-zero if it's unable to dial brokers. This
+    # can happen for many reasons but we never want this script to crash as it
+    # would take down yet another broker and make a bad situation worse.
+    # Instead, just wait for the command to eventually exit zero.
+    echo "Waiting for cluster to be ready"
+    until rpk cluster health --watch --exit-when-healthy; do
+      echo "rpk cluster health failed. Waiting 5 seconds before trying again..."
+      sleep 5
+    done
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+type: Opaque
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-configurator
+  namespace: default
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+type: Opaque
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
+    compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
+    group_topic_partitions: 16
+    kafka_batch_max_bytes: 1048576
+    kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
+    log_segment_size: 134217728
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    storage_min_free_bytes: 1073741824
+    topic_partitions_per_shard: 1000
+  redpanda.yaml: |-
+    config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      audit_enabled: false
+      compacted_log_segment_size: 67108864
+      crash_loop_limit: 5
+      default_topic_replications: 3
+      empty_seed_starts_cluster: false
+      enable_sasl: false
+      group_topic_partitions: 16
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      kafka_batch_max_bytes: 1048576
+      kafka_connection_rate_limit: 1000
+      kafka_enable_authorization: false
+      log_segment_size: 134217728
+      log_segment_size_max: 268435456
+      log_segment_size_min: 16777216
+      max_compacted_log_segment_size: 536870912
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+      storage_min_free_bytes: 1073741824
+      topic_partitions_per_shard: 1000
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          truststore_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+data:
+  profile: |-
+    admin_api:
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-rpk
+  namespace: default
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.26
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.6"
+    app.kubernetes.io/managed-by: Helm
+    
+data:
+  config.yaml: |
+    # from .Values.console.config
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          caFilepath: /mnt/cert/schemaregistry/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        caFilepath: /mnt/cert/kafka/default/ca.crt
+        certFilepath: ""
+        enabled: true
+        insecureSkipTlsVerify: false
+        keyFilepath: ""
+    redpanda:
+      adminApi:
+        enabled: true
+        tls:
+          caFilepath: /mnt/cert/adminapi/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://redpanda.default.svc.cluster.local.:9644
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.26
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.6"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  type: ClusterIP
+  ports:
+    - port: 8080
+      targetPort: 
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+---
+# Source: redpanda/templates/service.internal.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+    monitoring.redpanda.com/enabled: "false"
+  name: redpanda
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - name: admin
+    port: 9644
+    protocol: TCP
+    targetPort: 9644
+  - name: http
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  - name: kafka
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  - name: rpc
+    port: 33145
+    protocol: TCP
+    targetPort: 33145
+  - name: schemaregistry
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: redpanda-statefulset
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: redpanda
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# Source: redpanda/templates/service.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external
+  namespace: default
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: admin-default
+    nodePort: 31644
+    port: 9645
+    protocol: TCP
+    targetPort: 0
+  - name: kafka-default
+    nodePort: 31092
+    port: 9094
+    protocol: TCP
+    targetPort: 0
+  - name: http-default
+    nodePort: 30082
+    port: 8083
+    protocol: TCP
+    targetPort: 0
+  - name: schema-default
+    nodePort: 30081
+    port: 8084
+    protocol: TCP
+    targetPort: 0
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: redpanda-statefulset
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: redpanda
+  sessionAffinity: None
+  type: NodePort
+status:
+  loadBalancer: {}
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redpanda-console
+  labels:
+    helm.sh/chart: console-0.7.26
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.6"
+    app.kubernetes.io/managed-by: Helm
+    
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: console
+      app.kubernetes.io/instance: redpanda
+  template:
+    metadata:
+      annotations:
+        checksum/config: 01ba4719c80b6fe911b091a7c05124b64eeece964e09c058ef8f9805daca546b
+        checksum-redpanda-chart/config: 65c19475911973d228c79e8d6f1a08b7e0be76e606004dd39d0407f94b49e6c7
+      labels:
+        app.kubernetes.io/name: console
+        app.kubernetes.io/instance: redpanda
+    spec:
+      serviceAccountName: redpanda-console
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: redpanda-console
+        - name: kafka-default-cert
+          secret:
+            defaultMode: 272
+            secretName: redpanda-default-cert
+        - name: schemaregistry-default-cert
+          secret:
+            defaultMode: 272
+            secretName: redpanda-default-cert
+        - name: adminapi-default-cert
+          secret:
+            defaultMode: 272
+            secretName: redpanda-default-cert
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - mountPath: /mnt/cert/kafka/default
+              name: kafka-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/schemaregistry/default
+              name: schemaregistry-default-cert
+              readOnly: true
+            - mountPath: /mnt/cert/adminapi/default
+              name: adminapi-default-cert
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: KAFKA_TLS_CAFILEPATH
+              value: /mnt/cert/kafka/default/ca.crt
+            - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+              value: /mnt/cert/schemaregistry/default/ca.crt
+      priorityClassName:
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: redpanda
+  serviceName: redpanda
+  template:
+    metadata:
+      annotations:
+        config.redpanda.com/checksum: 7cce827ced32bccb833a4e0b24e704e0500a702db7f4b492da61ad7cb24a94db
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: redpanda
+        helm.sh/chart: redpanda-5.8.12
+        redpanda.com/poddisruptionbudget: redpanda
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: redpanda-statefulset
+                app.kubernetes.io/instance: redpanda
+                app.kubernetes.io/name: redpanda
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - rpk
+        - redpanda
+        - start
+        - --advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145
+        env:
+        - name: SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                true
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                true # do not fail and cause the pod to terminate
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+              "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        name: redpanda
+        ports:
+        - containerPort: 9644
+          name: admin
+        - containerPort: 9645
+          name: admin-default
+        - containerPort: 8082
+          name: http
+        - containerPort: 8083
+          name: http-default
+        - containerPort: 9093
+          name: kafka
+        - containerPort: 9094
+          name: kafka-default
+        - containerPort: 33145
+          name: rpc
+        - containerPort: 8081
+          name: schemaregistry
+        - containerPort: 8084
+          name: schema-default
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+              RESULT=$(rpk cluster health)
+              echo $RESULT
+              echo $RESULT | grep 'Healthy:.*true'
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 0
+        resources:
+          limits:
+            cpu: 1
+            memory: 2.5Gi
+        securityContext:
+          allowPrivilegeEscalation: null
+          runAsGroup: 101
+          runAsNonRoot: null
+          runAsUser: 101
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+              echo $RESULT
+              echo $RESULT | grep ready
+          failureThreshold: 120
+          initialDelaySeconds: 1
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /tmp/base-config
+          name: redpanda
+        - mountPath: /var/lifecycle
+          name: lifecycle-scripts
+        - mountPath: /var/lib/redpanda/data
+          name: datadir
+      - args:
+        - -c
+        - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
+          & wait $!
+        command:
+        - /bin/sh
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        name: config-watcher
+        resources: {}
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/secrets/config-watcher/scripts
+          name: redpanda-config-watcher
+      imagePullSecrets: null
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - rpk redpanda tune all
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        name: tuning
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_RESOURCE
+          privileged: true
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: redpanda
+      - command:
+        - /bin/bash
+        - -c
+        - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+          & wait $!
+        env:
+        - name: CONFIGURATOR_SCRIPT
+          value: /etc/secrets/configurator/scripts/configurator.sh
+        - name: SERVICE_NAME
+          valueFrom:
+            configMapKeyRef: null
+            fieldRef:
+              fieldPath: metadata.name
+            resourceFieldRef: null
+            secretKeyRef: null
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        name: redpanda-configurator
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: null
+          runAsGroup: 101
+          runAsNonRoot: null
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /tmp/base-config
+          name: redpanda
+        - mountPath: /etc/secrets/configurator/scripts/
+          name: redpanda-configurator
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 90
+      tolerations: []
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: redpanda-statefulset
+            app.kubernetes.io/instance: redpanda
+            app.kubernetes.io/name: redpanda
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - name: lifecycle-scripts
+        secret:
+          defaultMode: 509
+          secretName: redpanda-sts-lifecycle
+      - configMap:
+          name: redpanda
+        name: redpanda
+      - emptyDir: {}
+        name: config
+      - name: redpanda-configurator
+        secret:
+          defaultMode: 509
+          secretName: redpanda-configurator
+      - name: redpanda-config-watcher
+        secret:
+          defaultMode: 509
+          secretName: redpanda-config-watcher
+      - name: redpanda-fs-validator
+        secret:
+          defaultMode: 509
+          secretName: redpanda-fs-validator
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      annotations: null
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+      name: datadir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+    status: {}
+status:
+  availableReplicas: 0
+  replicas: 0
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-default-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-root-certificate
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-external-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-root-certificate
+status: {}
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-cert
+  namespace: default
+spec:
+  dnsNames: null
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cas-issuer.jetstack.io
+    kind: GoogleCASClusterIssuer
+    name: my-cas-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-cert
+status: {}
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-cert
+  namespace: default
+spec:
+  dnsNames: null
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cas-issuer.jetstack.io
+    kind: GoogleCASClusterIssuer
+    name: my-cas-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-cert
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-default-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+status: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-external-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+status: {}
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  labels:
+    helm.sh/chart: console-0.7.26
+    app.kubernetes.io/name: console
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/version: "v2.4.6"
+    app.kubernetes.io/managed-by: Helm
+    
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-configuration
+  namespace: default
+spec:
+  template:
+    metadata:
+      creationTimestamp: null
+      generateName: redpanda-post-
+      labels:
+        app.kubernetes.io/component: redpanda-post-install
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+    spec:
+      affinity: {}
+      containers:
+      - args:
+        - |
+          set -e
+          if [[ -n "$REDPANDA_LICENSE" ]] then
+            rpk cluster license set "$REDPANDA_LICENSE"
+          fi
+
+
+
+
+          rpk cluster config export -f /tmp/cfg.yml
+
+
+          for KEY in "${!RPK_@}"; do
+            config="${KEY#*RPK_}"
+            rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+          done
+
+
+          rpk cluster config import -f /tmp/cfg.yml
+        command:
+        - bash
+        - -c
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        name: redpanda-post-install
+        resources: {}
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+      imagePullSecrets: null
+      nodeSelector: {}
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      tolerations: null
+      volumes:
+      - configMap:
+          name: redpanda
+        name: config
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+status: {}
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.8.12
+  name: redpanda-post-upgrade
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda-post-upgrade
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+      name: redpanda
+    spec:
+      affinity: {}
+      containers:
+      - args:
+        - |
+          set -e
+
+          rpk cluster config set default_topic_replications 3
+          rpk cluster config set storage_min_free_bytes 1073741824
+          if [ -d "/etc/secrets/users/" ]; then
+              IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+              curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+              --cacert /etc/tls/certs/default/ca.crt \
+              -X PUT -u ${USER_NAME}:${PASSWORD} \
+              https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+          fi
+        command:
+        - /bin/bash
+        - -c
+        env: null
+        envFrom: null
+        image: docker.redpanda.com/redpandadata/redpanda:v24.1.8
+        name: redpanda-post-upgrade
+        resources: null
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+      imagePullSecrets: null
+      nodeSelector: {}
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      tolerations: []
+      volumes:
+      - configMap:
+          name: redpanda
+        name: config
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+status: {}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -4,7 +4,6 @@ package redpanda
 import (
 	"fmt"
 
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/invopop/jsonschema"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -851,18 +850,6 @@ type TLSCert struct {
 	IssuerRef             *cmmeta.ObjectReference      `json:"issuerRef"`
 	SecretRef             *corev1.LocalObjectReference `json:"secretRef"`
 	ClientSecretRef       *corev1.LocalObjectReference `json:"clientSecretRef"`
-}
-
-// +gotohelm:ignore=true
-func (TLSCert) JSONSchemaExtend(schema *jsonschema.Schema) {
-	// An object reference could allow anything but we want to require that the
-	// reference is to either a ClusterIssuer or Issuer.
-	ref, _ := schema.Properties.Get("issuerRef")
-	refKind, _ := ref.Properties.Get("kind")
-	refKind.Enum = []any{
-		certmanagerv1.ClusterIssuerKind,
-		certmanagerv1.IssuerKind,
-	}
 }
 
 type TLSCertMap map[string]TLSCert

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -4580,10 +4580,6 @@
                       "type": "string"
                     },
                     "kind": {
-                      "enum": [
-                        "ClusterIssuer",
-                        "Issuer"
-                      ],
                       "type": "string"
                     },
                     "name": {


### PR DESCRIPTION
Previously, the `issuerRef` of the `tls` map was restricted to either an `Issuer` or `ClusterIssuer`. This prevented users from utilize external issuers such as Google CAS.

This commit removes the validation and add a regression test.

Fixes #1432.