### PR TITLE
console: convert service.yaml to go

### DIFF
--- a/charts/console/service.go
+++ b/charts/console/service.go
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +gotohelm:filename=_service.go.tpl
+package console
+
+import (
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func Service(dot *helmette.Dot) *corev1.Service {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	port := corev1.ServicePort{
+		Name:     "http",
+		Port:     int32(values.Service.Port),
+		Protocol: corev1.ProtocolTCP,
+	}
+
+	if values.Service.TargetPort != nil {
+		port.TargetPort = intstr.FromInt32(*values.Service.TargetPort)
+	}
+
+	if helmette.Contains("NodePort", string(values.Service.Type)) && values.Service.NodePort != nil {
+		port.NodePort = *values.Service.NodePort
+	}
+
+	return &corev1.Service{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Service",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        Fullname(dot),
+			Namespace:   dot.Release.Namespace,
+			Labels:      Labels(dot),
+			Annotations: values.Service.Annotations,
+		},
+		Spec: corev1.ServiceSpec{
+			Type:     values.Service.Type,
+			Selector: SelectorLabels(dot),
+			Ports:    []corev1.ServicePort{port},
+		},
+	}
+}

--- a/charts/console/templates/_service.go.tpl
+++ b/charts/console/templates/_service.go.tpl
@@ -1,0 +1,20 @@
+{{- /* Generated from "service.go" */ -}}
+
+{{- define "console.Service" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $port := (mustMergeOverwrite (dict "port" 0 "targetPort" 0 ) (dict "name" "http" "port" (($values.service.port | int) | int) "protocol" "TCP" )) -}}
+{{- if (ne $values.service.targetPort (coalesce nil)) -}}
+{{- $_ := (set $port "targetPort" $values.service.targetPort) -}}
+{{- end -}}
+{{- if (and (contains "NodePort" (toString $values.service.type)) (ne $values.service.nodePort (coalesce nil))) -}}
+{{- $_ := (set $port "nodePort" $values.service.nodePort) -}}
+{{- end -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict ) "status" (dict "loadBalancer" (dict ) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Service" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (get (fromJson (include "console.Fullname" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "console.Labels" (dict "a" (list $dot) ))) "r") "annotations" $values.service.annotations )) "spec" (mustMergeOverwrite (dict ) (dict "type" $values.service.type "selector" (get (fromJson (include "console.SelectorLabels" (dict "a" (list $dot) ))) "r") "ports" (list $port) )) ))) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/console/templates/service.yaml
+++ b/charts/console/templates/service.yaml
@@ -14,24 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */}}
+{{ $svc := (get ((include "console.Service" (dict "a" (list .))) | fromJson) "r") }}
+{{- if ne $svc nil -}}
 ---
-apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "console.fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  labels: {{- include "console.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
-  annotations: {{- toYaml . | nindent 4 }}
-  {{- end }}
-spec:
-  type: {{ .Values.service.type }}
-  ports:
-    - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.targetPort }}
-      protocol: TCP
-      name: http
-      {{- if and (contains "NodePort" .Values.service.type) .Values.service.nodePort }}
-      nodePort: {{ .Values.service.nodePort }}
-      {{- end }}
-  selector: {{- include "console.selectorLabels" . | nindent 4 }}
+{{ toYaml $svc }}
+{{- end }}

--- a/charts/console/testdata/template-cases.golden.txtar
+++ b/charts/console/testdata/template-cases.golden.txtar
@@ -81,24 +81,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -325,24 +329,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -563,24 +571,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -804,8 +816,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hvGoJL
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     "": 31q1Pbz
     app.kubernetes.io/instance: console
@@ -813,16 +825,20 @@ metadata:
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: hvGoJL
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: "n"
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1029,24 +1045,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: T50cZi
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: T50cZi
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: Sh
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1290,24 +1310,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: xZty
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: xZty
+  namespace: default
 spec:
-  type: ILpSX2Cy
   ports:
-    - port: 413
-      targetPort: 267
-      protocol: TCP
-      name: http
+  - name: http
+    port: 413
+    protocol: TCP
+    targetPort: 267
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: vN4yH7I
+  type: ILpSX2Cy
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1518,24 +1542,28 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 8nE
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: 8nE
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: w6
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -1682,8 +1710,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console-YMl
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     "": PtQ7JxIAdPjt
     app.kubernetes.io/instance: console
@@ -1691,16 +1719,20 @@ metadata:
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console-YMl
+  namespace: default
 spec:
-  type: dO7eovC
   ports:
-    - port: 112
-      targetPort: 173
-      protocol: TCP
-      name: http
+  - name: http
+    port: 112
+    protocol: TCP
+    targetPort: 173
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: YMl
+  type: dO7eovC
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -1896,24 +1928,28 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: pN
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: pN
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: MW
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -2136,24 +2172,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: rzd
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: rzd
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: gCH15URsJZr
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -2379,8 +2419,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: y
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
@@ -2389,16 +2429,20 @@ metadata:
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
     helm.sh/chart: console-0.7.26
+  name: "y"
+  namespace: default
 spec:
-  type: Vvrvx
   ports:
-    - port: 286
-      targetPort: 404
-      protocol: TCP
-      name: http
+  - name: http
+    port: 286
+    protocol: TCP
+    targetPort: 404
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: HWL
+  type: Vvrvx
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -2605,24 +2649,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: GbgHqD
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: GbgHqD
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: RW
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -2827,26 +2875,29 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: l1Bnpx
-  namespace: "default"
+  annotations:
+    efgehQaV5UI0y: GymqDudh
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    efgehQaV5UI0y: GymqDudh
+  name: l1Bnpx
+  namespace: default
 spec:
-  type: yZy
   ports:
-    - port: 229
-      targetPort: 85
-      protocol: TCP
-      name: http
+  - name: http
+    port: 229
+    protocol: TCP
+    targetPort: 85
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: BKV
+  type: yZy
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -3019,24 +3070,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ivK
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: ivK
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: JFcK
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -3377,8 +3432,11 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hbe
-  namespace: "default"
+  annotations:
+    "": NbuyvXjW
+    2CTz: vRGLHMO53rD
+    yLzpKqz: uBjXvD
+  creationTimestamp: null
   labels:
     JwK5MKTa: WW
     app.kubernetes.io/instance: console
@@ -3387,20 +3445,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
     v7E: 1g6JB
-  annotations:
-    "": NbuyvXjW
-    2CTz: vRGLHMO53rD
-    yLzpKqz: uBjXvD
+  name: hbe
+  namespace: default
 spec:
-  type: sl
   ports:
-    - port: 478
-      targetPort: 90
-      protocol: TCP
-      name: http
+  - name: http
+    port: 478
+    protocol: TCP
+    targetPort: 90
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: Cy9eHCiP
+  type: sl
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -3720,24 +3778,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: tmn2Kt
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: tmn2Kt
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: Qr03ts
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -4085,24 +4147,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: RttlJN
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: RttlJN
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: dDkIKgMwXv
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -4386,24 +4452,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: htymHJ
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: htymHJ
+  namespace: default
 spec:
-  type: Oiwzbmtjpb
   ports:
-    - port: 41
-      targetPort: 168
-      protocol: TCP
-      name: http
+  - name: http
+    port: 41
+    protocol: TCP
+    targetPort: 168
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: Vi2vH
+  type: Oiwzbmtjpb
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -4523,8 +4593,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 9RweMGWqBs
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     B0Pmybnj: gh8
     MdyMnFBP0Cd1: UUVRKbjhv
@@ -4534,16 +4604,20 @@ metadata:
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: 9RweMGWqBs
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: KD8DmV
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -4939,24 +5013,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 6maz
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: 6maz
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: SC
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -5346,24 +5424,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 9XG3SZW
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: 9XG3SZW
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: tPiY
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -5865,24 +5947,28 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ExFU3
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: ExFU3
+  namespace: default
 spec:
-  type: 2cM
   ports:
-    - port: 415
-      targetPort: 489
-      protocol: TCP
-      name: http
+  - name: http
+    port: 415
+    protocol: TCP
+    targetPort: 489
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 1qyLP36T
+  type: 2cM
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -6312,24 +6398,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: NZ7h9
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: NZ7h9
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 8MIg
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -6576,24 +6666,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: Om7
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: Om7
+  namespace: default
 spec:
-  type: 
   ports:
-    - port: 310
-      targetPort: 28
-      protocol: TCP
-      name: http
+  - name: http
+    port: 310
+    protocol: TCP
+    targetPort: 28
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: zzmAR9
+  type: ""
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -7099,8 +7193,11 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: PhRk
-  namespace: "default"
+  annotations:
+    MSOs1: lWjU5y8FrM1
+    cbC69BvSda36u5J: Xk9Lhf
+    pnFEXx: mM4QW5
+  creationTimestamp: null
   labels:
     0pITqVWuPVXcDF: jm5Ve54
     8iyjfh0: Igz
@@ -7109,20 +7206,20 @@ metadata:
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    MSOs1: lWjU5y8FrM1
-    cbC69BvSda36u5J: Xk9Lhf
-    pnFEXx: mM4QW5
+  name: PhRk
+  namespace: default
 spec:
-  type: tptHu3Q
   ports:
-    - port: 278
-      targetPort: 173
-      protocol: TCP
-      name: http
+  - name: http
+    port: 278
+    protocol: TCP
+    targetPort: 173
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: Rys
+  type: tptHu3Q
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/hpa.yaml
 apiVersion: autoscaling/v2
@@ -7269,24 +7366,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: GVjeLRc
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: GVjeLRc
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: xNnu
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -7922,28 +8023,31 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fXCb
-  namespace: "default"
+  annotations:
+    TK4LTMJ: G8y
+    VTdx: Q
+    ie: FNpp8B
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    TK4LTMJ: G8y
-    VTdx: Q
-    ie: FNpp8B
+  name: fXCb
+  namespace: default
 spec:
-  type: Xz6f
   ports:
-    - port: 182
-      targetPort: 413
-      protocol: TCP
-      name: http
+  - name: http
+    port: 182
+    protocol: TCP
+    targetPort: 413
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: s3YOF
+  type: Xz6f
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -8309,24 +8413,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: Wpq
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: Wpq
+  namespace: default
 spec:
-  type: uvupqC6hE4
   ports:
-    - port: 310
-      targetPort: 265
-      protocol: TCP
-      name: http
+  - name: http
+    port: 310
+    protocol: TCP
+    targetPort: 265
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: aD
+  type: uvupqC6hE4
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -8372,24 +8480,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: Uo
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: Uo
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: Mh
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -8957,8 +9069,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: qhaD
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     "": h0uSAPIi
     app.kubernetes.io/instance: console
@@ -8967,16 +9079,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
     kuKPk7: ""
+  name: qhaD
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: vLjrafvp
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -9263,8 +9379,11 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 61hunk
-  namespace: "default"
+  annotations:
+    Gi0OSuP5jF: ARBECJB
+    qId: Bo
+    wPKI: ""
+  creationTimestamp: null
   labels:
     Q0: ""
     T4ZmAFi: nfIb0b
@@ -9273,20 +9392,20 @@ metadata:
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    Gi0OSuP5jF: ARBECJB
-    qId: Bo
-    wPKI: ""
+  name: 61hunk
+  namespace: default
 spec:
-  type: G2gqK
   ports:
-    - port: 376
-      targetPort: 473
-      protocol: TCP
-      name: http
+  - name: http
+    port: 376
+    protocol: TCP
+    targetPort: 473
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: h9P
+  type: G2gqK
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -9421,8 +9540,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: odFI2M4
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     BKrxjHNg8: qlqPhj
     app.kubernetes.io/instance: console
@@ -9430,16 +9549,20 @@ metadata:
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: odFI2M4
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 5XQu4RW
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -9845,8 +9968,9 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: HK
-  namespace: "default"
+  annotations:
+    33Yi: tesf5
+  creationTimestamp: null
   labels:
     HzuQ: mCfbHBQ
     app.kubernetes.io/instance: console
@@ -9855,18 +9979,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
     xi7L: ibI45
-  annotations:
-    33Yi: tesf5
+  name: HK
+  namespace: default
 spec:
-  type: sIQBZD
   ports:
-    - port: 389
-      targetPort: 52
-      protocol: TCP
-      name: http
+  - name: http
+    port: 389
+    protocol: TCP
+    targetPort: 52
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 3Wh
+  type: sIQBZD
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -10453,8 +10579,8 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: G9
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     T: f0
     app.kubernetes.io/instance: console
@@ -10464,16 +10590,20 @@ metadata:
     helm.sh/chart: console-0.7.26
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
+  name: G9
+  namespace: default
 spec:
-  type: QAVsE
   ports:
-    - port: 250
-      targetPort: 475
-      protocol: TCP
-      name: http
+  - name: http
+    port: 250
+    protocol: TCP
+    targetPort: 475
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: J
+  type: QAVsE
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/hpa.yaml
 apiVersion: autoscaling/v2
@@ -10573,8 +10703,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 59cQ0qKLI
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
@@ -10583,16 +10713,20 @@ metadata:
     helm.sh/chart: console-0.7.26
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
+  name: 59cQ0qKLI
+  namespace: default
 spec:
-  type: N9chrF
   ports:
-    - port: 112
-      targetPort: 375
-      protocol: TCP
-      name: http
+  - name: http
+    port: 112
+    protocol: TCP
+    targetPort: 375
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: xknw
+  type: N9chrF
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/hpa.yaml
 apiVersion: autoscaling/v2
@@ -10760,8 +10894,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: llK4G
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     B19ue: 8W
     Kxm5R1: R
@@ -10771,16 +10905,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     e3Cx: MIAO
     helm.sh/chart: console-0.7.26
+  name: llK4G
+  namespace: default
 spec:
-  type: aaIqePq
   ports:
-    - port: 418
-      targetPort: 486
-      protocol: TCP
-      name: http
+  - name: http
+    port: 418
+    protocol: TCP
+    targetPort: 486
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: wB
+  type: aaIqePq
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -11561,8 +11699,9 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: foGC
-  namespace: "default"
+  annotations:
+    lrtdFF: 60R7
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
@@ -11571,18 +11710,20 @@ metadata:
     gZ85uw3T: e
     helm.sh/chart: console-0.7.26
     qO: F4dqLo67vKYZ
-  annotations:
-    lrtdFF: 60R7
+  name: foGC
+  namespace: default
 spec:
-  type: 2K35
   ports:
-    - port: 229
-      targetPort: 59
-      protocol: TCP
-      name: http
+  - name: http
+    port: 229
+    protocol: TCP
+    targetPort: 59
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: bCPeYVWao
+  type: 2K35
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -12631,8 +12772,10 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: l
-  namespace: "default"
+  annotations:
+    W8Ix4: 4kOonr2
+    g93: wNXcKSBg
+  creationTimestamp: null
   labels:
     0fz: qRhpB
     app.kubernetes.io/instance: console
@@ -12641,19 +12784,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     blGSa: Hnim0SflkfpF
     helm.sh/chart: console-0.7.26
-  annotations:
-    W8Ix4: 4kOonr2
-    g93: wNXcKSBg
+  name: l
+  namespace: default
 spec:
-  type: d2QGeqxiX
   ports:
-    - port: 421
-      targetPort: 214
-      protocol: TCP
-      name: http
+  - name: http
+    port: 421
+    protocol: TCP
+    targetPort: 214
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: zE
+  type: d2QGeqxiX
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -12733,8 +12877,9 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: Bv0I
-  namespace: "default"
+  annotations:
+    C3p: uCspVMX
+  creationTimestamp: null
   labels:
     5NU: UG7t
     6NmZI: QxuTdplvdDdc
@@ -12744,18 +12889,20 @@ metadata:
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    C3p: uCspVMX
+  name: Bv0I
+  namespace: default
 spec:
-  type: ZQQlqx7Np
   ports:
-    - port: 51
-      targetPort: 456
-      protocol: TCP
-      name: http
+  - name: http
+    port: 51
+    protocol: TCP
+    targetPort: 456
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ZQQlqx7Np
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -13835,8 +13982,8 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: AumW
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     Nv: YHcp9u
     RMi5: o4
@@ -13846,16 +13993,20 @@ metadata:
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: AumW
+  namespace: default
 spec:
-  type: XHYb2qmrk
   ports:
-    - port: 113
-      targetPort: 414
-      protocol: TCP
-      name: http
+  - name: http
+    port: 113
+    protocol: TCP
+    targetPort: 414
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 9mG8n4Wu4
+  type: XHYb2qmrk
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -14827,8 +14978,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: ADIhC
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     BJ: Gq0Rw
     FPcPYvmbB7dAZe: Cy7WaeI
@@ -14838,16 +14989,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
     uEVMkDkYRvnn: zvptNai
+  name: ADIhC
+  namespace: default
 spec:
-  type: At
   ports:
-    - port: 226
-      targetPort: 87
-      protocol: TCP
-      name: http
+  - name: http
+    port: 226
+    protocol: TCP
+    targetPort: 87
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: u2r6
+  type: At
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -14989,24 +15144,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: j1dUk8TGy8Np
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: j1dUk8TGy8Np
+  namespace: default
 spec:
-  type: uqFB
   ports:
-    - port: 46
-      targetPort: 43
-      protocol: TCP
-      name: http
+  - name: http
+    port: 46
+    protocol: TCP
+    targetPort: 43
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: ld
+  type: uqFB
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -15078,28 +15237,31 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: bbshm
-  namespace: "default"
+  annotations:
+    4yhZo: zLVEslN
+    Amz4VM: QAvK
+    IPCS: b1R
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    4yhZo: zLVEslN
-    Amz4VM: QAvK
-    IPCS: b1R
+  name: bbshm
+  namespace: default
 spec:
-  type: dPOD9Kzb
   ports:
-    - port: 400
-      targetPort: 329
-      protocol: TCP
-      name: http
+  - name: http
+    port: 400
+    protocol: TCP
+    targetPort: 329
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: o2F37Lr
+  type: dPOD9Kzb
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -15156,8 +15318,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: KchYZFsbB3
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     X: zjmrl
     "Y": yG0
@@ -15166,16 +15328,20 @@ metadata:
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: KchYZFsbB3
+  namespace: default
 spec:
-  type: oZi
   ports:
-    - port: 424
-      targetPort: 17
-      protocol: TCP
-      name: http
+  - name: http
+    port: 424
+    protocol: TCP
+    targetPort: 17
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 6sW
+  type: oZi
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -16344,8 +16510,9 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: Wq
-  namespace: "default"
+  annotations:
+    Sxsz0HWh: z9cj
+  creationTimestamp: null
   labels:
     T1: pMf7C
     app.kubernetes.io/instance: console
@@ -16354,18 +16521,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     cxAL7zvwvb: tmEjSXwTK6
     helm.sh/chart: console-0.7.26
-  annotations:
-    Sxsz0HWh: z9cj
+  name: Wq
+  namespace: default
 spec:
-  type: tJUW
   ports:
-    - port: 359
-      targetPort: 363
-      protocol: TCP
-      name: http
+  - name: http
+    port: 359
+    protocol: TCP
+    targetPort: 363
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: x
+  type: tJUW
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -17053,8 +17222,8 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: eHZ
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     "": vWjW
     G: qF
@@ -17063,16 +17232,20 @@ metadata:
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: eHZ
+  namespace: default
 spec:
-  type: uTyclgj9tVV
   ports:
-    - port: 190
-      targetPort: 396
-      protocol: TCP
-      name: http
+  - name: http
+    port: 190
+    protocol: TCP
+    targetPort: 396
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 84QIe
+  type: uTyclgj9tVV
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -18085,24 +18258,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: y0pa6pm83
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: y0pa6pm83
+  namespace: default
 spec:
-  type: 9TsjJQkJZ
   ports:
-    - port: 11
-      targetPort: 465
-      protocol: TCP
-      name: http
+  - name: http
+    port: 11
+    protocol: TCP
+    targetPort: 465
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: 9TsjJQkJZ
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -18201,8 +18378,9 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: resP
-  namespace: "default"
+  annotations:
+    CRHNsVY: Nl04
+  creationTimestamp: null
   labels:
     BvJq2xZ: jY6O0
     app.kubernetes.io/instance: console
@@ -18210,18 +18388,20 @@ metadata:
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    CRHNsVY: Nl04
+  name: resP
+  namespace: default
 spec:
-  type: 
   ports:
-    - port: 103
-      targetPort: 329
-      protocol: TCP
-      name: http
+  - name: http
+    port: 103
+    protocol: TCP
+    targetPort: 329
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: tvDI
+  type: ""
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -18974,8 +19154,8 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 9gCm5xz
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     M1diW: PVb
     app.kubernetes.io/instance: console
@@ -18983,16 +19163,20 @@ metadata:
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: 9gCm5xz
+  namespace: default
 spec:
-  type: C
   ports:
-    - port: 314
-      targetPort: 398
-      protocol: TCP
-      name: http
+  - name: http
+    port: 314
+    protocol: TCP
+    targetPort: 398
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: tOoxEiwdVpT
+  type: C
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/hpa.yaml
 apiVersion: autoscaling/v2
@@ -19156,8 +19340,9 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fB6TF
-  namespace: "default"
+  annotations:
+    aDeGG7F9S: 5d
+  creationTimestamp: null
   labels:
     "": WcYTY
     app.kubernetes.io/instance: console
@@ -19166,18 +19351,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
     rHtDM6k: ZY6Kw
-  annotations:
-    aDeGG7F9S: 5d
+  name: fB6TF
+  namespace: default
 spec:
-  type: PK7oH1pcU3
   ports:
-    - port: 271
-      targetPort: 481
-      protocol: TCP
-      name: http
+  - name: http
+    port: 271
+    protocol: TCP
+    targetPort: 481
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: PK7oH1pcU3
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/ingress.yaml
 apiVersion: networking.k8s.io/v1
@@ -19243,28 +19430,31 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: YUi5JpG
-  namespace: "default"
+  annotations:
+    8v2: JbH
+    95cxbjjD7C: JBMaJ
+    VY: yRV7d
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    8v2: JbH
-    95cxbjjD7C: JBMaJ
-    VY: yRV7d
+  name: YUi5JpG
+  namespace: default
 spec:
-  type: WAAXkZY
   ports:
-    - port: 168
-      targetPort: 227
-      protocol: TCP
-      name: http
+  - name: http
+    port: 168
+    protocol: TCP
+    targetPort: 227
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: nEojiMtRc
+  type: WAAXkZY
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -19978,8 +20168,10 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 3um
-  namespace: "default"
+  annotations:
+    c: DNy
+    kDPtPpnL: kFmmx
+  creationTimestamp: null
   labels:
     4kU: mkn8
     Ro: NFx1P
@@ -19989,19 +20181,20 @@ metadata:
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
-  annotations:
-    c: DNy
-    kDPtPpnL: kFmmx
+  name: 3um
+  namespace: default
 spec:
-  type: l5gj
   ports:
-    - port: 311
-      targetPort: 29
-      protocol: TCP
-      name: http
+  - name: http
+    port: 311
+    protocol: TCP
+    targetPort: 29
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: W7q3X
+  type: l5gj
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -20937,8 +21130,11 @@ data:
 apiVersion: v1
 kind: Service
 metadata:
-  name: 0BIfuN
-  namespace: "default"
+  annotations:
+    L: CP
+    Yf: K4waOjMg
+    tIYLLgy: d1szIPW6xt
+  creationTimestamp: null
   labels:
     0HYkOrz: JCwpSW
     0TgDztQSY: P
@@ -20948,20 +21144,20 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
     ztm: qegfb80
-  annotations:
-    L: CP
-    Yf: K4waOjMg
-    tIYLLgy: d1szIPW6xt
+  name: 0BIfuN
+  namespace: default
 spec:
-  type: IfYfRoHRG
   ports:
-    - port: 269
-      targetPort: 479
-      protocol: TCP
-      name: http
+  - name: http
+    port: 269
+    protocol: TCP
+    targetPort: 479
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: 8dJzE
+  type: IfYfRoHRG
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -21923,24 +22119,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -22152,24 +22352,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -22372,24 +22576,28 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
-  name: console
-  namespace: "default"
+  annotations: {}
+  creationTimestamp: null
   labels:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
 spec:
-  type: ClusterIP
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1
@@ -22581,6 +22789,33 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
+  selector:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console
+  type: ClusterIP
+status:
+  loadBalancer: {}
+---
+# Source: console/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: console
   namespace: "default"
   labels:
@@ -22590,15 +22825,420 @@ metadata:
     app.kubernetes.io/version: v2.4.6
     helm.sh/chart: console-0.7.26
 spec:
-  type: ClusterIP
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: console
+      app.kubernetes.io/name: console
+  template:
+    metadata:
+      annotations:
+        checksum/config: 50beddb00d4430eeafe26ede2549f0db2164f7529eaee06633bac7d98bd60eab
+      labels:
+        app.kubernetes.io/instance: console
+        app.kubernetes.io/name: console
+    spec:
+      serviceAccountName: console
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: console
+        - name: secrets
+          secret:
+            secretName: console
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: console
+                  key: login-jwt-secret
+      priorityClassName:
+---
+# Source: console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "console-test-connection"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['console:8080']
+  restartPolicy: Never
+  priorityClassName:
+-- testdata/service-nodeport.yaml.golden --
+---
+# Source: console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: console
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+---
+# Source: console/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: console
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: ""
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: console/templates/configmap.yaml
+apiVersion: v1
+data:
+  config.yaml: |
+    # from .Values.console.config
+    {}
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  name: console
+---
+# Source: console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
+spec:
   ports:
-    - port: 8080
-      targetPort: 
-      protocol: TCP
-      name: http
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 2000
   selector:
     app.kubernetes.io/instance: console
     app.kubernetes.io/name: console
+  type: NodePort
+status:
+  loadBalancer: {}
+---
+# Source: console/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: console
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: console
+      app.kubernetes.io/name: console
+  template:
+    metadata:
+      annotations:
+        checksum/config: 50beddb00d4430eeafe26ede2549f0db2164f7529eaee06633bac7d98bd60eab
+      labels:
+        app.kubernetes.io/instance: console
+        app.kubernetes.io/name: console
+    spec:
+      serviceAccountName: console
+      automountServiceAccountToken: true
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      volumes:
+        - name: configs
+          configMap:
+            name: console
+        - name: secrets
+          secret:
+            secretName: console
+      containers:
+        - name: console
+          args:
+            - "--config.filepath=/etc/console/configs/config.yaml"
+          securityContext:
+            runAsNonRoot: true
+          image: docker.redpanda.com/redpandadata/console:v2.4.6
+          imagePullPolicy: "IfNotPresent"
+          ports:
+            - name: http
+              containerPort: 2000
+              protocol: TCP
+          volumeMounts:
+            - name: configs
+              mountPath: /etc/console/configs
+              readOnly: true
+            - name: secrets
+              mountPath: /etc/console/secrets
+              readOnly: true
+          livenessProbe:
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          readinessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            timeoutSeconds: 1
+            successThreshold: 1
+            failureThreshold: 3
+            httpGet:
+              path: /admin/health
+              port: http
+          resources:
+            {}
+          env:
+            - name: LOGIN_JWTSECRET
+              valueFrom:
+                secretKeyRef:
+                  name: console
+                  key: login-jwt-secret
+      priorityClassName:
+---
+# Source: console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "console-test-connection"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['console:8080']
+  restartPolicy: Never
+  priorityClassName:
+-- testdata/service-with-nodeport.yaml.golden --
+---
+# Source: console/templates/serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: console
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+---
+# Source: console/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: console
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+type: Opaque
+data:
+  # Set empty defaults, so that we can always mount them as env variable even if they are not used.
+  # For this reason we can't use `with` to change the scope.
+  # Kafka
+  kafka-sasl-password: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+
+  # Login
+  login-jwt-secret: "U0VDUkVUS0VZ"
+  login-google-oauth-client-secret: ""
+  login-google-groups-service-account.json: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  login-oidc-client-secret: ""
+
+  # Enterprise
+  enterprise-license: ""
+
+  # Redpanda
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+---
+# Source: console/templates/configmap.yaml
+apiVersion: v1
+data:
+  config.yaml: |
+    # from .Values.console.config
+    {}
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  name: console
+---
+# Source: console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    hello: world
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.4.6
+    helm.sh/chart: console-0.7.26
+  name: console
+  namespace: default
+spec:
+  ports:
+  - name: http
+    nodePort: 1000
+    port: 8080
+    protocol: TCP
+    targetPort: 0
+  selector:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console
+  type: NodePort
+status:
+  loadBalancer: {}
 ---
 # Source: console/templates/deployment.yaml
 apiVersion: apps/v1

--- a/charts/console/testdata/template-cases.txtar
+++ b/charts/console/testdata/template-cases.txtar
@@ -68,3 +68,17 @@ autoscaling:
   enabled: true
   targetCPUUtilizationPercentage: 14
   targetMemoryUtilizationPercentage: null
+
+-- service-nodeport --
+# Service type NodePort
+service:
+  type: "NodePort"
+  targetPort: 2000
+
+-- service-with-nodeport --
+# Service w/ NodePort
+service:
+  type: "NodePort"
+  nodePort: 1000
+  annotations:
+    hello: world

--- a/charts/console/values.go
+++ b/charts/console/values.go
@@ -31,7 +31,7 @@ type Values struct {
 	PodLabels                    map[string]string                 `json:"podLabels"`
 	PodSecurityContext           corev1.PodSecurityContext         `json:"podSecurityContext"`
 	SecurityContext              corev1.SecurityContext            `json:"securityContext"`
-	Service                      Service                           `json:"service"`
+	Service                      ServiceConfig                     `json:"service"`
 	Ingress                      Ingress                           `json:"ingress"`
 	Resources                    corev1.ResourceRequirements       `json:"resources"`
 	Autoscaling                  AutoScaling                       `json:"autoscaling"`
@@ -69,12 +69,12 @@ type ServiceAccount struct {
 	Name                         string            `json:"name"`
 }
 
-type Service struct {
-	Type        string            `json:"type"`
-	Port        int               `json:"port"`
-	NodePort    *int              `json:"nodePort,omitempty"`
-	TargetPort  *int              `json:"targetPort"`
-	Annotations map[string]string `json:"annotations"`
+type ServiceConfig struct {
+	Type        corev1.ServiceType `json:"type"`
+	Port        int32              `json:"port"`
+	NodePort    *int32             `json:"nodePort,omitempty"`
+	TargetPort  *int32             `json:"targetPort"`
+	Annotations map[string]string  `json:"annotations"`
 }
 
 type Ingress struct {

--- a/charts/console/values_partial.gen.go
+++ b/charts/console/values_partial.gen.go
@@ -25,7 +25,7 @@ type PartialValues struct {
 	PodLabels                    map[string]string                 "json:\"podLabels,omitempty\""
 	PodSecurityContext           *corev1.PodSecurityContext        "json:\"podSecurityContext,omitempty\""
 	SecurityContext              *corev1.SecurityContext           "json:\"securityContext,omitempty\""
-	Service                      *PartialService                   "json:\"service,omitempty\""
+	Service                      *PartialServiceConfig             "json:\"service,omitempty\""
 	Ingress                      *PartialIngress                   "json:\"ingress,omitempty\""
 	Resources                    *corev1.ResourceRequirements      "json:\"resources,omitempty\""
 	Autoscaling                  *PartialAutoScaling               "json:\"autoscaling,omitempty\""
@@ -66,12 +66,12 @@ type PartialServiceAccount struct {
 	Name                         *string           "json:\"name,omitempty\""
 }
 
-type PartialService struct {
-	Type        *string           "json:\"type,omitempty\""
-	Port        *int              "json:\"port,omitempty\""
-	NodePort    *int              "json:\"nodePort,omitempty\""
-	TargetPort  *int              "json:\"targetPort,omitempty\""
-	Annotations map[string]string "json:\"annotations,omitempty\""
+type PartialServiceConfig struct {
+	Type        *corev1.ServiceType "json:\"type,omitempty\""
+	Port        *int32              "json:\"port,omitempty\""
+	NodePort    *int32              "json:\"nodePort,omitempty\""
+	TargetPort  *int32              "json:\"targetPort,omitempty\""
+	Annotations map[string]string   "json:\"annotations,omitempty\""
 }
 
 type PartialIngress struct {

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -276,7 +276,15 @@ func (t *Transpiler) transpileStatement(stmt ast.Stmt) Node {
 		// TODO could simplify this by performing a type switch on the
 		// transpiled result of lhs.
 		if _, ok := stmt.Lhs[0].(*ast.SelectorExpr); ok {
-			selector := t.transpileExpr(stmt.Lhs[0]).(*Selector)
+			var selector *Selector
+			switch expr := t.transpileExpr(stmt.Lhs[0]).(type) {
+			case *Selector:
+				selector = expr
+			case *Cast:
+				selector = expr.X.(*Selector)
+			default:
+				panic(fmt.Sprintf("unhandled case %T: %v", expr, expr))
+			}
 
 			return &Statement{
 				Expr: &BuiltInCall{


### PR DESCRIPTION
This commit converts service.yaml to go and fixes a small bug in gotohelm where selectors may need to be unwrapped out of `Cast` Nodes.

Fixes #1399