### PR TITLE
redpanda: correct spelling of privilege

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Fixed a regression where `post_upgrade_job` would fail if TLS on the admin
   listener was disabled but had `cert` set to an invalid cert (e.g. `""`)
 * Fixed mTLS configurations between Redpanda and Console [#1402](https://github.com/redpanda-data/helm-charts/pull/1402)
+* Fixed a typo in `statefulset.securityContext.allowPriviledgeEscalation`. Both the correct
+  and typoed name will be respected with the correct spelling taking
+  precedence. [#1413](https://github.com/redpanda-data/helm-charts/issues/1413)
 #### Removed
 
 ### [5.8.12](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.8.12) - 2024-07-10

--- a/charts/redpanda/helpers.go
+++ b/charts/redpanda/helpers.go
@@ -343,7 +343,7 @@ func ContainerSecurityContext(dot *helmette.Dot) corev1.SecurityContext {
 	return corev1.SecurityContext{
 		RunAsUser:                sc.RunAsUser,
 		RunAsGroup:               helmette.Coalesce(sc.RunAsGroup, sc.FSGroup),
-		AllowPrivilegeEscalation: sc.AllowPriviledgeEscalation,
+		AllowPrivilegeEscalation: helmette.Coalesce(sc.AllowPrivilegeEscalation, sc.AllowPriviledgeEscalation),
 		RunAsNonRoot:             sc.RunAsNonRoot,
 	}
 }

--- a/charts/redpanda/templates/_helpers.go.tpl
+++ b/charts/redpanda/templates/_helpers.go.tpl
@@ -335,7 +335,7 @@
 {{- $values := $dot.Values.AsMap -}}
 {{- $sc := (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.statefulset.podSecurityContext $values.statefulset.securityContext) ))) "r") -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict ) (dict "runAsUser" $sc.runAsUser "runAsGroup" (coalesce $sc.runAsGroup $sc.fsGroup) "allowPrivilegeEscalation" $sc.allowPriviledgeEscalation "runAsNonRoot" $sc.runAsNonRoot ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict ) (dict "runAsUser" $sc.runAsUser "runAsGroup" (coalesce $sc.runAsGroup $sc.fsGroup) "allowPrivilegeEscalation" (coalesce $sc.allowPrivilegeEscalation $sc.allowPriviledgeEscalation) "runAsNonRoot" $sc.runAsNonRoot ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -95,8 +95,13 @@ func (Values) JSONSchemaExtend(schema *jsonschema.Schema) {
 // [corev1.SecurityContext]. It's type exists for backwards compat purposes
 // only.
 type SecurityContext struct {
-	RunAsUser                 *int64                         `json:"runAsUser"`
-	RunAsGroup                *int64                         `json:"runAsGroup"`
+	RunAsUser                *int64 `json:"runAsUser"`
+	RunAsGroup               *int64 `json:"runAsGroup"`
+	AllowPrivilegeEscalation *bool  `json:"allowPrivilegeEscalation"`
+	// AllowPriviledgeEscalation is typoed version of
+	// [SecurityContext.AllowPrivilegeEscalation]. It's respected for backwards
+	// compatibility.
+	// Deprecated: Prefer AllowPrivilegeEscalation.
 	AllowPriviledgeEscalation *bool                          `json:"allowPriviledgeEscalation"`
 	RunAsNonRoot              *bool                          `json:"runAsNonRoot"`
 	FSGroup                   *int64                         `json:"fsGroup"`

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -3602,6 +3602,9 @@
             "allowPriviledgeEscalation": {
               "type": "boolean"
             },
+            "allowPrivilegeEscalation": {
+              "type": "boolean"
+            },
             "fsGroup": {
               "type": "integer"
             },
@@ -3786,6 +3789,9 @@
         "securityContext": {
           "properties": {
             "allowPriviledgeEscalation": {
+              "type": "boolean"
+            },
+            "allowPrivilegeEscalation": {
               "type": "boolean"
             },
             "fsGroup": {

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -368,6 +368,7 @@ type PartialPodTemplate struct {
 type PartialSecurityContext struct {
 	RunAsUser                 *int64                         "json:\"runAsUser,omitempty\""
 	RunAsGroup                *int64                         "json:\"runAsGroup,omitempty\""
+	AllowPrivilegeEscalation  *bool                          "json:\"allowPrivilegeEscalation,omitempty\""
 	AllowPriviledgeEscalation *bool                          "json:\"allowPriviledgeEscalation,omitempty\""
 	RunAsNonRoot              *bool                          "json:\"runAsNonRoot,omitempty\""
 	FSGroup                   *int64                         "json:\"fsGroup,omitempty\""


### PR DESCRIPTION
Previously the `allowPrivilegeEscalation` member of `statefulset.securityContext` was incorrectly spelt as `allowPriviledgeEscalation`. While the output was correctly spelt, the subtle typo made it quite difficult to utilize the field.

This commit corrects the typo and continues to respect the misspelt version for backwards compatibility.

Fixes #1413.