### PR TITLE
redpanda: assert go and helm equivalence

### DIFF
--- a/charts/redpanda/certs.go
+++ b/charts/redpanda/certs.go
@@ -12,9 +12,9 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
+func ClientCerts(dot *helmette.Dot) []*certmanagerv1.Certificate {
 	if !TLSEnabled(dot) {
-		return []certmanagerv1.Certificate{}
+		return []*certmanagerv1.Certificate{}
 	}
 
 	values := helmette.Unwrap[Values](dot.Values)
@@ -24,7 +24,7 @@ func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
 	ns := dot.Release.Namespace
 	domain := strings.TrimSuffix(values.ClusterDomain, ".")
 
-	var certs []certmanagerv1.Certificate
+	var certs []*certmanagerv1.Certificate
 	for name, data := range values.TLS.Certs {
 		if !helmette.Empty(data.SecretRef) || !ptr.Deref(data.Enabled, true) {
 			continue
@@ -58,7 +58,7 @@ func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
 			Name:  fmt.Sprintf("%s-%s-root-issuer", fullname, name),
 		})
 
-		certs = append(certs, certmanagerv1.Certificate{
+		certs = append(certs, &certmanagerv1.Certificate{
 			TypeMeta: metav1.TypeMeta{
 				APIVersion: "cert-manager.io/v1",
 				Kind:       "Certificate",
@@ -106,7 +106,7 @@ func ClientCerts(dot *helmette.Dot) []certmanagerv1.Certificate {
 
 	duration := helmette.Default("43800h", data.Duration)
 
-	return append(certs, certmanagerv1.Certificate{
+	return append(certs, &certmanagerv1.Certificate{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "cert-manager.io/v1",
 			Kind:       "Certificate",

--- a/charts/redpanda/chart.go
+++ b/charts/redpanda/chart.go
@@ -3,10 +3,13 @@ package redpanda
 
 import (
 	_ "embed"
+	"reflect"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/helm-charts/pkg/helm"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/yaml"
@@ -19,6 +22,9 @@ var (
 
 	//go:embed Chart.yaml
 	chartYAML []byte
+
+	//go:embed values.yaml
+	defaultValuesYAML []byte
 
 	chartMeta helmette.Chart
 )
@@ -45,8 +51,69 @@ func ChartMeta() helmette.Chart {
 	return chartMeta
 }
 
+func Template(release helmette.Release, values PartialValues) ([]kube.Object, error) {
+	valuesYaml, err := yaml.Marshal(values)
+	if err != nil {
+		return nil, err
+	}
+
+	// NB: err1 is working around an issue in gotohelm's ASTs rewrites
+	merged, err1 := helm.MergeYAMLValues("", defaultValuesYAML, valuesYaml)
+	if err1 != nil {
+		return nil, err1
+	}
+
+	dot := helmette.Dot{
+		Values:  merged,
+		Chart:   ChartMeta(),
+		Release: release,
+	}
+
+	manifests := []kube.Object{
+		NodePortService(&dot),
+		PodDisruptionBudget(&dot),
+		ServiceAccount(&dot),
+		ServiceInternal(&dot),
+		ServiceMonitor(&dot),
+		SidecarControllersRole(&dot),
+		SidecarControllersRoleBinding(&dot),
+		StatefulSet(&dot),
+		PostUpgrade(&dot),
+		PostInstallUpgradeJob(&dot),
+	}
+
+	manifests = append(manifests, asObj(ConfigMaps(&dot))...)
+	manifests = append(manifests, asObj(CertIssuers(&dot))...)
+	manifests = append(manifests, asObj(RootCAs(&dot))...)
+	manifests = append(manifests, asObj(ClientCerts(&dot))...)
+	manifests = append(manifests, asObj(ClusterRoleBindings(&dot))...)
+	manifests = append(manifests, asObj(ClusterRoles(&dot))...)
+	manifests = append(manifests, asObj(LoadBalancerServices(&dot))...)
+	manifests = append(manifests, asObj(Secrets(&dot))...)
+
+	j := 0
+	for i := range manifests {
+		// Nil unboxing issue
+		if reflect.ValueOf(manifests[i]).IsNil() {
+			continue
+		}
+		manifests[j] = manifests[i]
+		j++
+	}
+
+	return manifests[:j], nil
+}
+
 func must(err error) {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func asObj[T kube.Object](manifests []T) []kube.Object {
+	out := make([]kube.Object, len(manifests))
+	for i := range manifests {
+		out[i] = manifests[i]
+	}
+	return out
 }

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -25,20 +25,20 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-func ConfigMaps(dot *helmette.Dot) []corev1.ConfigMap {
-	cms := []corev1.ConfigMap{RedpandaConfigMap(dot, true)}
+func ConfigMaps(dot *helmette.Dot) []*corev1.ConfigMap {
+	cms := []*corev1.ConfigMap{RedpandaConfigMap(dot, true)}
 	cms = append(cms, RPKProfile(dot)...)
 	return cms
 }
 
-func ConfigMapsWithoutSeedServer(dot *helmette.Dot) []corev1.ConfigMap {
-	cms := []corev1.ConfigMap{RedpandaConfigMap(dot, false)}
+func ConfigMapsWithoutSeedServer(dot *helmette.Dot) []*corev1.ConfigMap {
+	cms := []*corev1.ConfigMap{RedpandaConfigMap(dot, false)}
 	cms = append(cms, RPKProfile(dot)...)
 	return cms
 }
 
-func RedpandaConfigMap(dot *helmette.Dot, includeSeedServer bool) corev1.ConfigMap {
-	return corev1.ConfigMap{
+func RedpandaConfigMap(dot *helmette.Dot, includeSeedServer bool) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "ConfigMap",
 			APIVersion: "v1",
@@ -116,14 +116,14 @@ func RedpandaConfigFile(dot *helmette.Dot, includeSeedServer bool) string {
 	return helmette.ToYaml(redpandaYaml)
 }
 
-func RPKProfile(dot *helmette.Dot) []corev1.ConfigMap {
+func RPKProfile(dot *helmette.Dot) []*corev1.ConfigMap {
 	values := helmette.Unwrap[Values](dot.Values)
 
 	if !values.External.Enabled {
 		return nil
 	}
 
-	return []corev1.ConfigMap{
+	return []*corev1.ConfigMap{
 		{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "ConfigMap",

--- a/charts/redpanda/secrets.go
+++ b/charts/redpanda/secrets.go
@@ -423,7 +423,7 @@ func SecretConfigurator(dot *helmette.Dot) *corev1.Secret {
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("%s-configurator", Fullname(dot)[:51]),
+			Name:      fmt.Sprintf("%.51s-configurator", Fullname(dot)),
 			Namespace: dot.Release.Namespace,
 			Labels:    FullLabels(dot),
 		},

--- a/charts/redpanda/templates/secrets.go.tpl
+++ b/charts/redpanda/templates/secrets.go.tpl
@@ -172,7 +172,7 @@ echo "passed"`) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- $secret := (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Secret" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%s-configurator" (substr 0 (51 | int) (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r"))) "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "type" "Opaque" "stringData" (dict ) )) -}}
+{{- $secret := (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Secret" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (printf "%.51s-configurator" (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r")) "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") )) "type" "Opaque" "stringData" (dict ) )) -}}
 {{- $configuratorSh := (list ) -}}
 {{- $configuratorSh = (concat (default (list ) $configuratorSh) (list `set -xe` `SERVICE_NAME=$1` `KUBERNETES_NODE_NAME=$2` `POD_ORDINAL=${SERVICE_NAME##*-}` "BROKER_INDEX=`expr $POD_ORDINAL + 1`" `` `CONFIG=/etc/redpanda/redpanda.yaml` `` `# Setup config files` `cp /tmp/base-config/redpanda.yaml "${CONFIG}"` `cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml`)) -}}
 {{- if (not (get (fromJson (include "redpanda.RedpandaAtLeast_22_3_0" (dict "a" (list $dot) ))) "r")) -}}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -71,6 +71,7 @@ type Values struct {
 }
 
 type Console struct {
+	Enabled bool `json:"enabled"`
 	Console struct {
 		Config map[string]any `json:"config"`
 	} `json:"console"`
@@ -711,12 +712,12 @@ type RBAC struct {
 }
 
 type Tuning struct {
-	TuneAIOEvents   bool   `json:"tune_aio_events"`
-	TuneClocksource bool   `json:"tune_clocksource"`
-	TuneBallastFile bool   `json:"tune_ballast_file"`
-	BallastFilePath string `json:"ballast_file_path"`
-	BallastFileSize string `json:"ballast_file_size"`
-	WellKnownIO     string `json:"well_known_io"`
+	TuneAIOEvents   bool   `json:"tune_aio_events,omitempty"`
+	TuneClocksource bool   `json:"tune_clocksource,omitempty"`
+	TuneBallastFile bool   `json:"tune_ballast_file,omitempty"`
+	BallastFilePath string `json:"ballast_file_path,omitempty"`
+	BallastFileSize string `json:"ballast_file_size,omitempty"`
+	WellKnownIO     string `json:"well_known_io,omitempty"`
 }
 
 func (t *Tuning) Translate() map[string]any {

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -765,6 +765,9 @@
             }
           },
           "type": "object"
+        },
+        "enabled": {
+          "type": "boolean"
         }
       },
       "type": "object"

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -84,6 +84,7 @@ type PartialRackAwareness struct {
 }
 
 type PartialConsole struct {
+	Enabled *bool "json:\"enabled,omitempty\""
 	Console *struct {
 		Config map[string]any "json:\"config,omitempty\""
 	} "json:\"console,omitempty\""

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	golang.org/x/net v0.25.0
 	golang.org/x/tools v0.20.0
-	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.29.5
 	k8s.io/apimachinery v0.29.5
@@ -178,6 +177,7 @@ require (
 	google.golang.org/protobuf v1.33.1-0.20240408130810-98873a205002 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.5 // indirect
 	k8s.io/apiserver v0.29.5 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect

--- a/pkg/gotohelm/helmette/shims.go
+++ b/pkg/gotohelm/helmette/shims.go
@@ -1,7 +1,6 @@
 package helmette
 
 import (
-	"bytes"
 	"fmt"
 	"math"
 	"reflect"
@@ -10,9 +9,9 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/mitchellh/mapstructure"
 	"github.com/redpanda-data/helm-charts/pkg/valuesutil"
-	"gopkg.in/yaml.v3"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
 )
 
 // TypeTest is an equivalent of `val, ok := x.(type)` that is exercised as a
@@ -150,9 +149,8 @@ func UnmarshalInto[T any](value any) T {
 // UnmarshalYaml fills in the type requested
 // +gotohelm:builtin=fromYamlArray
 func UnmarshalYamlArray[T any](repr string) []T {
-	buf := bytes.NewBufferString(repr)
 	var output []T
-	if err := yaml.NewDecoder(buf).Decode(&output); err != nil {
+	if err := yaml.Unmarshal([]byte(repr), &output); err != nil {
 		panic(fmt.Errorf("cannot unmarshal yaml: %w", err))
 	}
 	return output

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -7,7 +7,7 @@ import (
 )
 
 type AStruct struct {
-	Value int
+	Value int `json:",omitempty"`
 }
 
 // Sprig runs a variety of values through various sprig functions. Assertions
@@ -251,7 +251,10 @@ func empty() []bool {
 		helmette.Empty(""),
 		helmette.Empty("hello"),
 		helmette.Empty(AStruct{}),
-		helmette.Empty(AStruct{Value: 0}),
+		// Go can't differentiate between a zero value that's been explicitly
+		// set and one that's the default. Helm, on the other hand, will see this
+		// as (dict "Value" 0) or (dict).
+		// helmette.Empty(AStruct{Value: 0}),
 		helmette.Empty(AStruct{Value: 1}),
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -8,7 +8,7 @@ import (
 )
 
 type AStruct struct {
-	Value int
+	Value int `json:",omitempty"`
 }
 
 // Sprig runs a variety of values through various sprig functions. Assertions
@@ -260,7 +260,10 @@ func empty() []bool {
 		helmette.Empty(""),
 		helmette.Empty("hello"),
 		helmette.Empty(AStruct{}),
-		helmette.Empty(AStruct{Value: 0}),
+		// Go can't differentiate between a zero value that's been explicitly
+		// set and one that's the default. Helm, on the other hand, will see this
+		// as (dict "Value" 0) or (dict).
+		// helmette.Empty(AStruct{Value: 0}),
 		helmette.Empty(AStruct{Value: 1}),
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -193,7 +193,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (empty (coalesce nil)) (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" (coalesce nil) )) (empty (1 | int)) (empty (0 | int)) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict "Value" 0 ) (dict ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" (0 | int) ))) (empty (mustMergeOverwrite (dict "Value" 0 ) (dict "Value" (1 | int) ))))) | toJson -}}
+{{- (dict "r" (list (empty (coalesce nil)) (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" (coalesce nil) )) (empty (1 | int)) (empty (0 | int)) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict ) (dict ))) (empty (mustMergeOverwrite (dict ) (dict "Value" (1 | int) ))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/helm/util.go
+++ b/pkg/helm/util.go
@@ -1,0 +1,37 @@
+package helm
+
+import (
+	"fmt"
+	"os"
+
+	"helm.sh/helm/v3/pkg/cli/values"
+)
+
+// MergeYAMLValues uses helm's values package to merge a collection of YAML
+// values in accordance with helm's merging logic.
+// Sadly, their merging logic is not exported nor can it accept raw JSON/YAML
+// so we dump files on disk.
+func MergeYAMLValues(tempDir string, vs ...[]byte) (map[string]any, error) {
+	if tempDir == "" {
+		tempDir = os.TempDir()
+	}
+
+	var opts values.Options
+	for i, v := range vs {
+		file, err := os.CreateTemp(tempDir, fmt.Sprintf("values-%d.yaml", i))
+		if err != nil {
+			return nil, err
+		}
+
+		if _, err := file.Write(v); err != nil {
+			return nil, err
+		}
+
+		if err := file.Close(); err != nil {
+			return nil, err
+		}
+		opts.ValueFiles = append(opts.ValueFiles, file.Name())
+	}
+
+	return opts.MergeValues(nil)
+}


### PR DESCRIPTION
This commit adds a basic test for asserting that the Go code and helm templates generate equivalent manifests.

While gotohelm itself has many tests performing these assertions, the complexity of the redpanda chart warrants additional checks.

This commit also includes a handful of fixes for uncovered divergences:
- Use `sigs.k8s.io/yaml` in helmette to ensure consistent encoding/decoding
- Handle structs in `helmette.Empty`
- Fix an out of bounds truncation on a Secret name
- Add `omityempty`'s to `Tuning` to match the sparse behavior of `ToJSON` in helm
- Add trailing newline to `ToYaml` to match helm
- Handle JSON key ordering weirdness in `ToJSON`