### PR TITLE
redpanda: fix image.repository in nightly task

### DIFF
--- a/.github/workflows/nightly_redpanda_tip.yaml
+++ b/.github/workflows/nightly_redpanda_tip.yaml
@@ -117,5 +117,5 @@ jobs:
           ct install \
             --github-groups \
             --config .github/ct-redpanda.yaml \
-            --helm-extra-set-args="--set=image.tag=${{ steps.latestTag.outputs.TAG }} --set=image.repository=redpandadata/redpanda-nightly" \
+            --helm-extra-set-args="--set=image.tag=${{ steps.latestTag.outputs.TAG }} --set=image.repository=redpandadata/redpanda-unstable" \
             --skip-missing-values


### PR DESCRIPTION
`image.repository` was previously missed. It is now correctly set to redpanda-unstable.