### PR TITLE
Remove irrelevant test

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -137,11 +137,12 @@ jobs:
       - test-charts-kminion
       - test-charts-operator
       - test-charts-redpanda
+      - test-charts-redpanda-integration
       - test-go
     runs-on: ubuntu-22.04
     steps:
       - name: Summarize the results of the test matrix pass/fail
         uses: re-actors/alls-green@release/v1
         with:
-          allowed-skips: test-go, test-charts-connectors, test-charts-kminion, test-charts-operator, test-charts-redpanda
+          allowed-skips: test-go, test-charts-connectors, test-charts-kminion, test-charts-operator, test-charts-redpanda, test-charts-redpanda-integration
           jobs: ${{ toJSON(needs)}}


### PR DESCRIPTION
In Redpanda starting from 24.2.1 it has self configuration check which shutdown whole Redpanda process if tiered storage have fake API credentials.

The error from Redpanda:
```
ERROR 2024-08-06 14:03:28,285 [shard 0:main] s3 - s3_client.cc:622 - Couldn't reach S3 storage with either path style or virtual_host style requests.

ERROR 2024-08-06 14:03:28,285 [shard 0:main] client_pool - client_pool.cc:79 - Self configuration of the cloud storage client failed. This indicates a misconfiguration of Redpanda. Aborting start-up ...
```