### PR TITLE
Bump chart version

### DIFF
--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.1.11
+version: 0.1.12
 
 # The app version is the default version of Redpanda Connectors to install.
 appVersion: v1.0.29
@@ -44,6 +44,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: connectors
-      image: docker.redpanda.com/redpandadata/connectors:v1.0.6
+      image: docker.redpanda.com/redpandadata/connectors:v1.0.29
     - name: rpk
       image: docker.redpanda.com/redpandadata/redpanda:latest

--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connectors Helm chart.
 ---
 
-![Version: 0.1.11](https://img.shields.io/badge/Version-0.1.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.29](https://img.shields.io/badge/AppVersion-v1.0.29-informational?style=flat-square)
+![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.29](https://img.shields.io/badge/AppVersion-v1.0.29-informational?style=flat-square)
 
 This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/connectors/testdata/template-cases.golden.txtar
+++ b/charts/connectors/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pO5m
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: rpVz
 spec:
   ipFamilies:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pO5m
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: rpVz
 spec:
   progressDeadlineSeconds: 600
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nZ
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 5wkC
 spec:
   ipFamilies:
@@ -259,7 +259,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nZ
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: WtC
 spec:
   progressDeadlineSeconds: 600
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZZ5
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: AN
   namespace: default
 ---
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZZ5
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: xp6vcIlb
 spec:
   ipFamilies:
@@ -464,7 +464,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZZ5
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: xp6vcIlb
 spec:
   progressDeadlineSeconds: 600
@@ -633,7 +633,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Wvpgs
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: kNrkCdEuw9V
 spec:
   ipFamilies:
@@ -665,7 +665,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Wvpgs
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: kNrkCdEuw9V
 spec:
   progressDeadlineSeconds: 600
@@ -825,7 +825,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xhLPt0
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 74qyne
 spec:
   ipFamilies:
@@ -857,7 +857,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xhLPt0
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 74qyne
 spec:
   progressDeadlineSeconds: 600
@@ -1015,7 +1015,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: J
 spec:
   ipFamilies:
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: J
 spec:
   progressDeadlineSeconds: 600
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vlci
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     m2DRq: cS
   name: "7"
   namespace: default
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vlci
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     m2DRq: cS
   name: gkX
 spec:
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vlci
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     m2DRq: cS
   name: R93VG
 spec:
@@ -1448,7 +1448,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gb7J7k
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 9PY0
 spec:
   ipFamilies:
@@ -1480,7 +1480,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gb7J7k
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: NUTO
 spec:
   progressDeadlineSeconds: 600
@@ -1639,7 +1639,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPhRiQRK
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: PNw8
 spec:
   ipFamilies:
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPhRiQRK
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: PNw8
 spec:
   progressDeadlineSeconds: 467220788
@@ -1828,7 +1828,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wCD97n
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: eyeD
   namespace: default
 ---
@@ -1842,7 +1842,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wCD97n
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: H
 spec:
   ipFamilies:
@@ -1878,7 +1878,7 @@ metadata:
     cUt: YvDFEsYlU
     g3hOh91HKI: CHwTjLYe2XS
     h4yNA: fJL
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: LsGZn
 spec:
   ipFamilies:
@@ -1916,7 +1916,7 @@ metadata:
     cUt: YvDFEsYlU
     g3hOh91HKI: CHwTjLYe2XS
     h4yNA: fJL
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: LsGZn
 spec:
   progressDeadlineSeconds: 600
@@ -2112,7 +2112,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xiBXju
     bX: vmmkhH2NHvdt
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     mO: pT
   name: etuP
 spec:
@@ -2148,7 +2148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xiBXju
     bX: vmmkhH2NHvdt
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     mO: pT
   name: etuP
 spec:
@@ -2364,7 +2364,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MexiU
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: Ac
 spec:
   ipFamilies:
@@ -2397,7 +2397,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w8tCi3K
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: InI
 spec:
   ipFamilies:
@@ -2452,7 +2452,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dA1zsc
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: u7DU
 spec:
   ipFamilies:
@@ -2484,7 +2484,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dA1zsc
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: u7DU
 spec:
   progressDeadlineSeconds: 600
@@ -2673,7 +2673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bpgtWxol
     etW: "9"
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: x
 spec:
   ipFamilies:
@@ -2711,7 +2711,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cex3v
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: B5Y
 spec:
   ipFamilies:
@@ -2747,7 +2747,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cex3v
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: bGMfavR
 spec:
   progressDeadlineSeconds: 600
@@ -2906,7 +2906,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DAE
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     wR: GAm
   name: u1Dk
 spec:
@@ -2941,7 +2941,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DAE
     fet: YGwnq
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     wR: GAm
   name: u1Dk
 spec:
@@ -3153,7 +3153,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: C
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: CVJfMb
 spec:
   ipFamilies:
@@ -3185,7 +3185,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: C
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: hX1VdtP7gp7c
 spec:
   progressDeadlineSeconds: 600
@@ -3370,7 +3370,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qQY
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: iPsih4
 spec:
   ipFamilies:
@@ -3406,7 +3406,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qQY
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: S9NS5c
 spec:
   progressDeadlineSeconds: 600
@@ -3597,7 +3597,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kUuRn
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: IAukfjAiE
 spec:
   ipFamilies:
@@ -3633,7 +3633,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cg
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     "y": TxHhxVY2tRx1i
   name: ABdKo
   namespace: default
@@ -3650,7 +3650,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cg
     g: Haj2trb
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     nQCD85u: 7ENE
     "y": TxHhxVY2tRx1i
   name: kt3xi
@@ -3692,7 +3692,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cg
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     "y": TxHhxVY2tRx1i
   name: console-Cg
 spec:
@@ -3962,7 +3962,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6MJPA
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: x4Vu7vj
 spec:
   ipFamilies:
@@ -4000,7 +4000,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6MJPA
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: cZ4G4
 spec:
   progressDeadlineSeconds: 457348204
@@ -4284,7 +4284,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZI341xw
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 9tds
 spec:
   ipFamilies:
@@ -4316,7 +4316,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZI341xw
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 9tds
 spec:
   progressDeadlineSeconds: 600
@@ -4476,7 +4476,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Y47
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: e4W
 spec:
   ipFamilies:
@@ -4510,7 +4510,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Y47
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: e4W
 spec:
   progressDeadlineSeconds: 5438195
@@ -4686,7 +4686,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: z3C
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: UFYrvO
 spec:
   ipFamilies:
@@ -4720,7 +4720,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: z3C
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     p7R: EjfLOeG
     th6: enWXwqe
   name: uv4tHoO
@@ -4984,7 +4984,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATJ
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     op: VnL9o7
   name: jmzfCmHq
   namespace: default
@@ -4999,7 +4999,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATJ
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     op: VnL9o7
   name: XfK7
 spec:
@@ -5038,7 +5038,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ffe2
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: maeWLc
   namespace: default
 ---
@@ -5055,7 +5055,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ffe2
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: uSz
 spec:
   ipFamilies:
@@ -5089,7 +5089,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ffe2
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: OL1
 spec:
   progressDeadlineSeconds: 600
@@ -5262,7 +5262,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "3"
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 9VQ
 spec:
   ipFamilies:
@@ -5294,7 +5294,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "3"
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: ZvvoA
 spec:
   progressDeadlineSeconds: 600
@@ -5530,7 +5530,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tl2YFI
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: IyM
 spec:
   ipFamilies:
@@ -5570,7 +5570,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tl2YFI
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: IyM
 spec:
   progressDeadlineSeconds: 533336746
@@ -5849,7 +5849,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P7
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: UQ27oL
   namespace: default
 ---
@@ -5864,7 +5864,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P7
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: IVe
 spec:
   ipFamilies:
@@ -5899,7 +5899,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pLehdV
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: MnW8I02
 spec:
   ipFamilies:
@@ -5935,7 +5935,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pLehdV
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: pPZgwOOt
 spec:
   progressDeadlineSeconds: 600
@@ -6136,7 +6136,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 8geRNocLQ
 spec:
   ipFamilies:
@@ -6173,7 +6173,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bz0yr
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: LVtVe0en
   namespace: default
 ---
@@ -6190,7 +6190,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bz0yr
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     kt: ""
   name: crWrH
 spec:
@@ -6236,7 +6236,7 @@ metadata:
     app.kubernetes.io/name: Pt
     c: fgV
     eHykHSeD: M0vI4
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     ik: hu
     trc: W
   name: 1hV
@@ -6280,7 +6280,7 @@ metadata:
     app.kubernetes.io/name: PeueQ
     co: MffSo
     fdioW3StBvzyh: z
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     ofToM: "n"
     wle: mprjb
   name: mC3vFeP
@@ -6347,7 +6347,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: taotfWzUIl
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     lp92O: 1QnD84Dhxl
   name: GxFDpR9IkU
 spec:
@@ -6382,7 +6382,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: taotfWzUIl
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: VW0lF
 spec:
   progressDeadlineSeconds: -1260879447
@@ -6690,7 +6690,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 03U7
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: "87"
 spec:
   ipFamilies:
@@ -6731,7 +6731,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 03U7
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: vRXgQsUzl3
 spec:
   progressDeadlineSeconds: -1761307563
@@ -7047,7 +7047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BX8JrNja9K1E
     eYdK: Cku
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     ztF1: wwq1
   name: mCI
 spec:
@@ -7085,7 +7085,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mn
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: ZkHM
   namespace: default
 ---
@@ -7101,7 +7101,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mn
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: El70
 spec:
   ipFamilies:
@@ -7137,7 +7137,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mn
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: jio8f
 spec:
   progressDeadlineSeconds: -1221802348
@@ -7400,7 +7400,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4iNcef5
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     "n": ""
   name: FKhGHe3aO
   namespace: default
@@ -7418,7 +7418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4iNcef5
     g: 0z9gQt4Yj
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     "n": ""
   name: KxK
 spec:
@@ -7465,7 +7465,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4iNcef5
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     "n": ""
   name: NCw6T6UcQY
 spec:
@@ -7754,7 +7754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ur
     eP0gw: ZlmzgOXE
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: bjGFkzr
 spec:
   ipFamilies:
@@ -7796,7 +7796,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ur
     eP0gw: ZlmzgOXE
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: AqjekuF
 spec:
   progressDeadlineSeconds: 1079618075
@@ -8109,7 +8109,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s9WyH2Y
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: w
   namespace: default
 ---
@@ -8127,7 +8127,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s9WyH2Y
     fzz: CLoaDJm9w
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     rryVp: TZ
   name: 8Tb8k
 spec:
@@ -8169,7 +8169,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WdYlcGB
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     xYCcuP: zC
   name: L
 spec:
@@ -8234,7 +8234,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: R64C
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: c
   namespace: default
 ---
@@ -8248,7 +8248,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: R64C
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     t7u5eHUdpR: nq6injR
   name: L
 spec:
@@ -8286,7 +8286,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: R64C
     e1: EPUL4
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: ZNfeDYT
 spec:
   progressDeadlineSeconds: -1210754760
@@ -8631,7 +8631,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8UJFy
     h52qwPFCCL1xE: q
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: Vk
   namespace: default
 ---
@@ -8648,7 +8648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8UJFy
     h52qwPFCCL1xE: q
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: 58KMN
 spec:
   ipFamilies:
@@ -8717,7 +8717,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fa1XvkvO
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: cl
   namespace: default
 ---
@@ -8732,7 +8732,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fa1XvkvO
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: UrU9Bs
 spec:
   ipFamilies:
@@ -8795,7 +8795,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wN
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     ytV2tl: icxW
   name: 3m
   namespace: default
@@ -8812,7 +8812,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wN
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     ytV2tl: icxW
   name: xW
 spec:
@@ -8851,7 +8851,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wN
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     ytV2tl: icxW
   name: Bl0rL2
 spec:
@@ -9131,7 +9131,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: r7G
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     x3: e1lz
   name: w4DG
 spec:
@@ -9165,7 +9165,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: r7G
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     x3: e1lz
   name: xPmln
 spec:
@@ -9495,7 +9495,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pyCdF
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     wy9DijfF9: pY
   name: zr1OY
   namespace: default
@@ -9512,7 +9512,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pyCdF
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
     uH: o
     wy9DijfF9: pY
   name: 37ihe
@@ -9550,7 +9550,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   ipFamilies:
@@ -9582,7 +9582,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -9742,7 +9742,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   ipFamilies:
@@ -9774,7 +9774,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -9931,7 +9931,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   ipFamilies:
@@ -9963,7 +9963,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -10120,7 +10120,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   ipFamilies:
@@ -10152,7 +10152,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.11
+    helm.sh/chart: connectors-0.1.12
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.7.26
+version: 0.7.27
 
 # The app version is the version of the Chart application
 appVersion: v2.7.0
@@ -46,4 +46,4 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/console:v2.4.6
+      image: docker.redpanda.com/redpandadata/console:v2.7.0

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Console Helm chart.
 ---
 
-![Version: 0.7.26](https://img.shields.io/badge/Version-0.7.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.7.0](https://img.shields.io/badge/AppVersion-v2.7.0-informational?style=flat-square)
+![Version: 0.7.27](https://img.shields.io/badge/Version-0.7.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.7.0](https://img.shields.io/badge/AppVersion-v2.7.0-informational?style=flat-square)
 
 This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml).
 Each of the settings is listed and described on this page, along with any default values.

--- a/charts/console/testdata/template-cases.golden.txtar
+++ b/charts/console/testdata/template-cases.golden.txtar
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -82,7 +82,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -120,7 +120,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -202,7 +202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 spec:
   maxReplicas: 100
@@ -236,7 +236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -261,7 +261,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -275,7 +275,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -356,7 +356,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -369,7 +369,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 spec:
   maxReplicas: 100
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -560,7 +560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -612,7 +612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -694,7 +694,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 spec:
   maxReplicas: 100
@@ -722,7 +722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: HRoLg
   namespace: default
 ---
@@ -763,7 +763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: hvGoJL
 stringData:
   enterprise-license: ""
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: hvGoJL
 ---
 # Source: console/templates/service.yaml
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: hvGoJL
   namespace: default
 spec:
@@ -848,7 +848,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: hvGoJL
   namespace: default
 spec:
@@ -862,7 +862,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 25c8070fc004db4abedf0271bf72a2bbe704a30c7f1b306afca2cb1a4eb08055
+        checksum/config: dd6b2660225e985a0bb3c6b66cdf05aefd376f4cfa9dad91779c19a59527b045
         lyW: mn
         pjq6fDr: YA2w301
         uXvFB: VQ5gP9
@@ -956,7 +956,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -981,7 +981,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: T50cZi
   namespace: default
 ---
@@ -995,7 +995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: T50cZi
 stringData:
   enterprise-license: ""
@@ -1037,7 +1037,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: T50cZi
 ---
 # Source: console/templates/service.yaml
@@ -1051,7 +1051,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: T50cZi
   namespace: default
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: T50cZi
   namespace: default
 spec:
@@ -1089,7 +1089,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f6897648bdd7a6cc0d50cf17450940cf08a6f8a8d8b78e6d94a1c6e9fa6a046e
+        checksum/config: 627603944599b4c6e8368c56baa4caa3a79072bedeacc496a13908ded12d68be
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: R1Yar8
   namespace: default
 ---
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: xZty
 stringData:
   enterprise-license: ""
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: xZty
 ---
 # Source: console/templates/service.yaml
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: xZty
   namespace: default
 spec:
@@ -1343,7 +1343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: xZty
   namespace: default
 spec:
@@ -1358,7 +1358,7 @@ spec:
       annotations:
         8vRMfVroYC2: QXbUbLea
         VV4w: s4sL
-        checksum/config: a91f3d6c5f7683a364d0d6a729ac88c0af591b0beae637ffe04d1c988be58e19
+        checksum/config: 3d21ca949f21bb15e1999e5bc0f98f094da6397a6170209f69c429cc4c644f32
         upwTMuIqflmD: 9J0H45zXX
       creationTimestamp: null
       labels:
@@ -1470,7 +1470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1498,7 +1498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 8nE
   namespace: default
 ---
@@ -1512,7 +1512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 8nE
 stringData:
   enterprise-license: ""
@@ -1551,7 +1551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 8nE
   namespace: default
 spec:
@@ -1576,7 +1576,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 8nE
 spec:
   ingressClassName: EqUYi
@@ -1612,7 +1612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1638,7 +1638,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console-YMl
   namespace: default
 ---
@@ -1653,7 +1653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console-YMl
 stringData:
   enterprise-license: ""
@@ -1696,7 +1696,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console-YMl
 ---
 # Source: console/templates/service.yaml
@@ -1711,7 +1711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console-YMl
   namespace: default
 spec:
@@ -1737,7 +1737,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console-YMl
   namespace: default
 spec:
@@ -1754,7 +1754,7 @@ spec:
         1iK8Ic: Qo3FCg9qi
         63SsVxDT: v
         A1Q4J4: U9jygY2t1F
-        checksum/config: 415afb0105c4b89f08e247eb09f993d0def5907a2273c0038b8a6ee59aba5dbf
+        checksum/config: 259c78f2eff3694362c1925332111e4c8a6d0b0cb26271bfa2911795bdca79b6
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -1852,7 +1852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1877,7 +1877,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: pN
   namespace: default
 ---
@@ -1891,7 +1891,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: pN
 stringData:
   enterprise-license: ""
@@ -1930,7 +1930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: pN
   namespace: default
 spec:
@@ -1955,7 +1955,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: pN
   namespace: default
 spec:
@@ -2078,7 +2078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -2106,7 +2106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: nd7TSb2mNTS
   namespace: default
 ---
@@ -2120,7 +2120,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: rzd
 stringData:
   enterprise-license: ""
@@ -2162,7 +2162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: rzd
 ---
 # Source: console/templates/service.yaml
@@ -2176,7 +2176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: rzd
   namespace: default
 spec:
@@ -2201,7 +2201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: rzd
   namespace: default
 spec:
@@ -2214,7 +2214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a6da1dd7808415738d10674dd1aab2551239d70a2ddf2e1e82cf6dee43d2d15c
+        checksum/config: 5cddb73f57b9885ed0ddeb08897272056609e8137f99c696ec30fd8c8073dd21
         s2D: DMU7
       creationTimestamp: null
       labels:
@@ -2348,7 +2348,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: RFjc7
   namespace: default
 ---
@@ -2364,7 +2364,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: "y"
 stringData:
   enterprise-license: ""
@@ -2412,7 +2412,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: "y"
 ---
 # Source: console/templates/service.yaml
@@ -2428,7 +2428,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: "y"
   namespace: default
 spec:
@@ -2455,7 +2455,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: "y"
   namespace: default
 spec:
@@ -2468,7 +2468,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 048743aace35dec919372aaaee3669db119dadf69264faf6d70c2304996e1f12
+        checksum/config: 2140347e08ce4a061a9919de003fe8f18d559737bc126f90fe7f02c2ee693ee3
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -2609,7 +2609,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -2634,7 +2634,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: YcV5zP8
   namespace: default
 ---
@@ -2652,7 +2652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GbgHqD
 ---
 # Source: console/templates/service.yaml
@@ -2666,7 +2666,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GbgHqD
   namespace: default
 spec:
@@ -2692,7 +2692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GbgHqD
   namespace: default
 spec:
@@ -2709,7 +2709,7 @@ spec:
       annotations:
         BTlN: z8t
         a: Pqjhw
-        checksum/config: eec7402e7693b56cf7328ad2c9de337f4f2ec9b63cf8d0a250da84819871179f
+        checksum/config: 47d7a51b7ff2692f07af47c1f96aa400d74254750edfa3934739fc53825c611e
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -2814,7 +2814,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -2839,7 +2839,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: l1Bnpx
   namespace: default
 ---
@@ -2853,7 +2853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: l1Bnpx
 stringData:
   enterprise-license: ""
@@ -2893,7 +2893,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: l1Bnpx
   namespace: default
 spec:
@@ -2918,7 +2918,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: l1Bnpx
   namespace: default
 spec:
@@ -3052,7 +3052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -3081,7 +3081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: kIzbDF
   namespace: default
 ---
@@ -3096,7 +3096,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: ivK
   namespace: default
 spec:
@@ -3121,7 +3121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: ivK
   namespace: default
 spec:
@@ -3359,7 +3359,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -3385,7 +3385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     v7E: 1g6JB
   name: hbe
   namespace: default
@@ -3401,7 +3401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     v7E: 1g6JB
   name: hbe
 stringData:
@@ -3445,7 +3445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     v7E: 1g6JB
   name: hbe
 ---
@@ -3464,7 +3464,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     v7E: 1g6JB
   name: hbe
   namespace: default
@@ -3492,7 +3492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     v7E: 1g6JB
   name: hbe
   namespace: default
@@ -3506,7 +3506,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 27cbed38792f4474082343c71478de0c29bbc3b9be83037788eb26ceafa2a508
+        checksum/config: f64726a4726459f59ea24bf1816b811098f4b281d11a478f473eadbc4979f63e
       creationTimestamp: null
       labels:
         "2": RgUAFm
@@ -3711,7 +3711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     v7E: 1g6JB
   annotations:
     "helm.sh/hook": test
@@ -3737,7 +3737,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: tmn2Kt
   namespace: default
 ---
@@ -3751,7 +3751,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: tmn2Kt
 stringData:
   enterprise-license: ""
@@ -3793,7 +3793,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: tmn2Kt
 ---
 # Source: console/templates/service.yaml
@@ -3807,7 +3807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: tmn2Kt
   namespace: default
 spec:
@@ -3833,7 +3833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: tmn2Kt
   namespace: default
 spec:
@@ -3848,7 +3848,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2c59dbb4e3d783232187065a1d16a6d91b40f49df238829759d9d54f9d0c4533
+        checksum/config: a9f6ea656a524364ef3fd8d44561ac07f6f641a204432c29b02156da24480a68
       creationTimestamp: null
       labels:
         "": S7BNyT
@@ -4081,7 +4081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4106,7 +4106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: RttlJN
   namespace: default
 ---
@@ -4120,7 +4120,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: RttlJN
 stringData:
   enterprise-license: ""
@@ -4162,7 +4162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: RttlJN
 ---
 # Source: console/templates/service.yaml
@@ -4176,7 +4176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: RttlJN
   namespace: default
 spec:
@@ -4201,7 +4201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: RttlJN
   namespace: default
 spec:
@@ -4214,7 +4214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8e6ca8711d123128a96e7bfd2503e24ff9284d4c6d8eed4effefdbe14b94dab5
+        checksum/config: 59fd15b9ebcbe052ec8dd617fc56d602db7e89f72dfee2a5f4202dbdec4c4232
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -4386,7 +4386,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4411,7 +4411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: h6eHrUr
   namespace: default
 ---
@@ -4425,7 +4425,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: htymHJ
 stringData:
   enterprise-license: ""
@@ -4470,7 +4470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: htymHJ
 ---
 # Source: console/templates/service.yaml
@@ -4484,7 +4484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: htymHJ
   namespace: default
 spec:
@@ -4509,7 +4509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4540,7 +4540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: zmr
   namespace: default
 ---
@@ -4557,7 +4557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9RweMGWqBs
 stringData:
   enterprise-license: ""
@@ -4602,7 +4602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9RweMGWqBs
 ---
 # Source: console/templates/service.yaml
@@ -4619,7 +4619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9RweMGWqBs
   namespace: default
 spec:
@@ -4649,7 +4649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9RweMGWqBs
   namespace: default
 spec:
@@ -4662,7 +4662,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4b4e48234780513edd15ff8289bcdb281de336335e092a7e8add8c53c07b7eb0
+        checksum/config: 0593b04582f1182b4c1b6f2468bd94410cbeda87149fc5b81d5f8bd15a0e2c4c
       creationTimestamp: null
       labels:
         FlwBgvWNMrbg5: YKgnz8q
@@ -4898,7 +4898,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9RweMGWqBs
 spec:
   ingressClassName: x7Um
@@ -4936,7 +4936,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4961,7 +4961,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: DdF7ALq
   namespace: default
 ---
@@ -4975,7 +4975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 6maz
 stringData:
   enterprise-license: ""
@@ -5021,7 +5021,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 6maz
 ---
 # Source: console/templates/service.yaml
@@ -5035,7 +5035,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 6maz
   namespace: default
 spec:
@@ -5060,7 +5060,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 6maz
   namespace: default
 spec:
@@ -5076,7 +5076,7 @@ spec:
     metadata:
       annotations:
         JYLUc483y: gTnWiG
-        checksum/config: 6ff63b195e810767af5b4dc7bc15c38bc2a743120e741f371996329ac6d86a73
+        checksum/config: bf32ef8217f211485bf3f6b62753806974440cf9af07ec8b40b3b9b3ec197e60
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -5344,7 +5344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -5369,7 +5369,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9XG3SZW
   namespace: default
 ---
@@ -5383,7 +5383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9XG3SZW
 stringData:
   enterprise-license: ""
@@ -5432,7 +5432,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9XG3SZW
 ---
 # Source: console/templates/service.yaml
@@ -5446,7 +5446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9XG3SZW
   namespace: default
 spec:
@@ -5474,7 +5474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9XG3SZW
   namespace: default
 spec:
@@ -5487,7 +5487,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0d5852bdd6b942482d2c79ccfa444e3ed155cae036bb25ed02c780c258f08656
+        checksum/config: 3bae1b572a1cf2acd085cc10cdbc6e657cae85b25ae987a39615c766e561b6fc
       creationTimestamp: null
       labels:
         LBQpbD: AHB4hNVL
@@ -5919,7 +5919,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: uAvlOXf
   namespace: default
 ---
@@ -5933,7 +5933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: ExFU3
 stringData:
   enterprise-license: ""
@@ -5972,7 +5972,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: ExFU3
   namespace: default
 spec:
@@ -5998,7 +5998,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: ExFU3
   namespace: default
 spec:
@@ -6322,7 +6322,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -6349,7 +6349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: NZ7h9
   namespace: default
 ---
@@ -6363,7 +6363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: NZ7h9
 stringData:
   enterprise-license: ""
@@ -6405,7 +6405,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: NZ7h9
 ---
 # Source: console/templates/service.yaml
@@ -6419,7 +6419,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: NZ7h9
   namespace: default
 spec:
@@ -6446,7 +6446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: NZ7h9
   namespace: default
 spec:
@@ -6460,7 +6460,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 49634999690e36a8d642a6ce05e1656298bb83d5e7f26dad8e236c5a2d5a73f3
+        checksum/config: cdb3ddbf6125cd4ab186be19ef3abf2cd8d872a30261acb5ca564e5439ab0d45
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -6588,7 +6588,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -6616,7 +6616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: HMpc
   namespace: default
 ---
@@ -6630,7 +6630,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Om7
 stringData:
   enterprise-license: ""
@@ -6672,7 +6672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Om7
 ---
 # Source: console/templates/service.yaml
@@ -6686,7 +6686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Om7
   namespace: default
 spec:
@@ -6714,7 +6714,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Om7
   namespace: default
 spec:
@@ -6729,7 +6729,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9666a7c89dd55ea912f3e394ca39954ecfd73ede9b8231a1918373bfb3652e28
+        checksum/config: fc241d8acbb12740b4df4506dd0683cec575079a2787ddc9df644ee566fa0591
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -7107,7 +7107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -7138,7 +7138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: tW
   namespace: default
 ---
@@ -7154,7 +7154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: PhRk
 stringData:
   enterprise-license: ""
@@ -7198,7 +7198,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: PhRk
 ---
 # Source: console/templates/service.yaml
@@ -7217,7 +7217,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: PhRk
   namespace: default
 spec:
@@ -7243,7 +7243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: PhRk
 spec:
   maxReplicas: 421
@@ -7279,7 +7279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -7304,7 +7304,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GVjeLRc
   namespace: default
 ---
@@ -7318,7 +7318,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GVjeLRc
 stringData:
   enterprise-license: ""
@@ -7360,7 +7360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GVjeLRc
 ---
 # Source: console/templates/service.yaml
@@ -7374,7 +7374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GVjeLRc
   namespace: default
 spec:
@@ -7400,7 +7400,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: GVjeLRc
   namespace: default
 spec:
@@ -7413,7 +7413,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 78d17bad8524d5344af709ae74a74971f1e4553c1719e8865afd35a357911baf
+        checksum/config: 611017621b1737439ee4cb54616c2de79811308762f8211bc64eebf855c845da
       creationTimestamp: null
       labels:
         "": thv6Fja
@@ -7948,7 +7948,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -7977,7 +7977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Pga
   namespace: default
 ---
@@ -7991,7 +7991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: fXCb
 stringData:
   enterprise-license: ""
@@ -8033,7 +8033,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: fXCb
   namespace: default
 spec:
@@ -8058,7 +8058,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: fXCb
   namespace: default
 spec:
@@ -8336,7 +8336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: fXCb
 spec:
   ingressClassName: r3Vd
@@ -8364,7 +8364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -8389,7 +8389,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wpq
   namespace: default
 ---
@@ -8415,7 +8415,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wpq
 ---
 # Source: console/templates/service.yaml
@@ -8429,7 +8429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wpq
   namespace: default
 spec:
@@ -8454,7 +8454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -8481,7 +8481,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: H5TDAALUdD
   namespace: default
 ---
@@ -8496,7 +8496,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Uo
   namespace: default
 spec:
@@ -8523,7 +8523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Uo
   namespace: default
 spec:
@@ -9042,7 +9042,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9075,7 +9075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     kuKPk7: ""
   name: Utu8ZHG2
   namespace: default
@@ -9092,7 +9092,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     kuKPk7: ""
   name: qhaD
   namespace: default
@@ -9119,7 +9119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     kuKPk7: ""
   name: qhaD
   namespace: default
@@ -9329,7 +9329,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     kuKPk7: ""
   name: qhaD
 spec:
@@ -9393,7 +9393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 55C9f3
   namespace: default
 ---
@@ -9413,7 +9413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 61hunk
   namespace: default
 spec:
@@ -9442,7 +9442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 61hunk
 spec:
   ingressClassName: Ijdd3
@@ -9476,7 +9476,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9502,7 +9502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: odFI2M4
 stringData:
   enterprise-license: ""
@@ -9545,7 +9545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: odFI2M4
 ---
 # Source: console/templates/service.yaml
@@ -9560,7 +9560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: odFI2M4
   namespace: default
 spec:
@@ -9587,7 +9587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: odFI2M4
   namespace: default
 spec:
@@ -9603,7 +9603,7 @@ spec:
     metadata:
       annotations:
         YefFO9J: uVUZra
-        checksum/config: 9c03061f7e2b7027c1da7924cf67c1d613022ce9921fea9a810f0fcb3a54d143
+        checksum/config: 1e641667fd24704ad0980aa18bcaaafc17b9998165c03cb7541f2d6a15541127
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -9892,7 +9892,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9919,7 +9919,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     xi7L: ibI45
   name: HK
 stringData:
@@ -9967,7 +9967,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     xi7L: ibI45
   name: HK
 ---
@@ -9984,7 +9984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     xi7L: ibI45
   name: HK
   namespace: default
@@ -10014,7 +10014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     xi7L: ibI45
   name: HK
   namespace: default
@@ -10030,7 +10030,7 @@ spec:
     metadata:
       annotations:
         IVy: ho3qpcI
-        checksum/config: ebda3d7785ecb06b07d0ff5ee7217c0d5c8ff74f5758f61f3c9b3db87be3c072
+        checksum/config: e7ce8eda132231369bec7a4b74cd17733891cd6ad6dfae9d9cd00f36f6e7fa43
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -10523,7 +10523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     xi7L: ibI45
   annotations:
     "helm.sh/hook": test
@@ -10548,7 +10548,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   name: G9
@@ -10590,7 +10590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   name: G9
@@ -10617,7 +10617,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   name: G9
@@ -10654,7 +10654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   annotations:
@@ -10692,7 +10692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10708,7 +10708,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10734,7 +10734,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10773,7 +10773,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10827,7 +10827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   annotations:
@@ -10878,7 +10878,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: llK4G
 ---
 # Source: console/templates/service.yaml
@@ -10895,7 +10895,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: llK4G
   namespace: default
 spec:
@@ -10924,7 +10924,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: llK4G
   namespace: default
 spec:
@@ -10939,7 +10939,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 980b64e9305466e4c9aef6c6951848ec5c3602886c8da30da787121658d3c1c0
+        checksum/config: 6f11d45d7713d29b8a241744e23d27448c4a7f4cef703b4319fc2ceaf676b321
       creationTimestamp: null
       labels:
         So: waKMMvnY
@@ -11566,7 +11566,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: llK4G
 spec:
   maxReplicas: 459
@@ -11605,7 +11605,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: llK4G
 spec:
   ingressClassName: EXqR
@@ -11646,7 +11646,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -11684,7 +11684,7 @@ metadata:
     app.kubernetes.io/name: bCPeYVWao
     app.kubernetes.io/version: v2.7.0
     gZ85uw3T: e
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     qO: F4dqLo67vKYZ
   name: foGC
 ---
@@ -11701,7 +11701,7 @@ metadata:
     app.kubernetes.io/name: bCPeYVWao
     app.kubernetes.io/version: v2.7.0
     gZ85uw3T: e
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     qO: F4dqLo67vKYZ
   name: foGC
   namespace: default
@@ -11728,7 +11728,7 @@ metadata:
     app.kubernetes.io/name: bCPeYVWao
     app.kubernetes.io/version: v2.7.0
     gZ85uw3T: e
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     qO: F4dqLo67vKYZ
   name: foGC
   namespace: default
@@ -11744,7 +11744,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 9087183fe8e6ce0aa096ce99afa71e8fa0ec1a30b34d8b8149dbfa7e2a91a8b8
+        checksum/config: 0c3f17880f8844f2f8d67dbe6e883f089da2b2c9d2cbf2f6a9783739e0a869e0
       creationTimestamp: null
       labels:
         1bb6: ""
@@ -12732,7 +12732,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: QxrM
   namespace: default
 ---
@@ -12766,7 +12766,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: l
 ---
 # Source: console/templates/service.yaml
@@ -12784,7 +12784,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: l
   namespace: default
 spec:
@@ -12811,7 +12811,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -12844,7 +12844,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: HMyYp
   namespace: default
 ---
@@ -12870,7 +12870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Bv0I
 ---
 # Source: console/templates/service.yaml
@@ -12888,7 +12888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Bv0I
   namespace: default
 spec:
@@ -12916,7 +12916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Bv0I
   namespace: default
 spec:
@@ -12931,7 +12931,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3e078bff6f789b0b5954cf48c6a5f7364632fa75f6262ac8f3855f362530844d
+        checksum/config: d21df84b239cf5765730e82c87c4fe09fb9b128a4903b6fa6ff551dcf825f1bb
       creationTimestamp: null
       labels:
         Klzm: we
@@ -13842,7 +13842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Bv0I
 spec:
   ingressClassName: vg
@@ -13916,7 +13916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -13945,7 +13945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: AumW
 stringData:
   enterprise-license: ""
@@ -13987,7 +13987,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: AumW
   namespace: default
 spec:
@@ -14018,7 +14018,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: AumW
   namespace: default
 spec:
@@ -14938,7 +14938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     uEVMkDkYRvnn: zvptNai
   name: ItYso
   namespace: default
@@ -14971,7 +14971,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
 ---
@@ -14988,7 +14988,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
   namespace: default
@@ -15017,7 +15017,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
 spec:
@@ -15082,7 +15082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     uEVMkDkYRvnn: zvptNai
   annotations:
     "helm.sh/hook": test
@@ -15112,7 +15112,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: fP77cJ3T
   namespace: default
 ---
@@ -15138,7 +15138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: j1dUk8TGy8Np
 ---
 # Source: console/templates/service.yaml
@@ -15152,7 +15152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: j1dUk8TGy8Np
   namespace: default
 spec:
@@ -15177,7 +15177,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -15207,7 +15207,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 8s2qVhKEW
   namespace: default
 ---
@@ -15230,7 +15230,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: bbshm
 ---
 # Source: console/templates/service.yaml
@@ -15247,7 +15247,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: bbshm
   namespace: default
 spec:
@@ -15272,7 +15272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: bbshm
 spec:
   ingressClassName: qyKUEOUT4u
@@ -15310,7 +15310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: KchYZFsbB3
 ---
 # Source: console/templates/service.yaml
@@ -15326,7 +15326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: KchYZFsbB3
   namespace: default
 spec:
@@ -15353,7 +15353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: KchYZFsbB3
   namespace: default
 spec:
@@ -15368,7 +15368,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 2290149b885f014ca0a2d4e123e748127eb7e669637672673c0921c2e6f24027
+        checksum/config: f4a59bdb95e718965a9a93d0c8fcc83a457d2751b31542b83a25c4627c934749
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -16399,7 +16399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -16433,7 +16433,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 0Z71mJNQUx
   namespace: default
 ---
@@ -16449,7 +16449,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wq
 stringData:
   enterprise-license: ""
@@ -16500,7 +16500,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wq
 ---
 # Source: console/templates/service.yaml
@@ -16517,7 +16517,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wq
   namespace: default
 spec:
@@ -16545,7 +16545,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wq
   namespace: default
 spec:
@@ -16560,7 +16560,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cbbdf08f78340b9cad3907b167cbaa2ae8af0e13bf653f8e84a51d18f6fc5d7f
+        checksum/config: 3948702ad79b07a9ac053f1708969e5d40b65c907cd6a3ab41f22db6c5164184
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -17128,7 +17128,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wq
 spec:
   maxReplicas: 309
@@ -17166,7 +17166,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Wq
 spec:
   ingressClassName: 9Kl
@@ -17214,7 +17214,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: eHZ
 ---
 # Source: console/templates/service.yaml
@@ -17230,7 +17230,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: eHZ
   namespace: default
 spec:
@@ -17260,7 +17260,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: eHZ
   namespace: default
 spec:
@@ -17276,7 +17276,7 @@ spec:
     metadata:
       annotations:
         JkW1: feghYA7
-        checksum/config: fb96d22ee3ae014b4b45aff32e12c5981a66eb7bd06aa0100bbd8adeb84ba116
+        checksum/config: 92a48d91fe87a76964bec2b45d322dc3310629b66d33a1672997917fbf48b511
         okSVM8H: 7Pau
         yYrmYn: uT
       creationTimestamp: null
@@ -18196,7 +18196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: eHZ
 spec:
   maxReplicas: 165
@@ -18232,7 +18232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -18257,7 +18257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: Gma
   namespace: default
 ---
@@ -18272,7 +18272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: y0pa6pm83
   namespace: default
 spec:
@@ -18300,7 +18300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: y0pa6pm83
 spec:
   ingressClassName: 4Z1r6JSTY
@@ -18343,7 +18343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: W9k
   namespace: default
 ---
@@ -18378,7 +18378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: resP
 ---
 # Source: console/templates/service.yaml
@@ -18394,7 +18394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: resP
   namespace: default
 spec:
@@ -18423,7 +18423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: resP
   namespace: default
 spec:
@@ -18439,7 +18439,7 @@ spec:
     metadata:
       annotations:
         N0F: vSjZxkjW
-        checksum/config: 5429d32165cc55d8110c80adbb0b22371bbb566c8942c1886b731f37fcc743b0
+        checksum/config: 483ab5015f962638d71d1ad374773894baa5ecd48e6ad927ecd3d7ccb350b125
       creationTimestamp: null
       labels:
         K1uahi: UMygEU2O2
@@ -19083,7 +19083,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -19111,7 +19111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: nX5G
   namespace: default
 ---
@@ -19126,7 +19126,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9gCm5xz
 stringData:
   enterprise-license: ""
@@ -19166,7 +19166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9gCm5xz
   namespace: default
 spec:
@@ -19191,7 +19191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9gCm5xz
 spec:
   maxReplicas: 305
@@ -19226,7 +19226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 9gCm5xz
 spec:
   ingressClassName: y6u9o
@@ -19272,7 +19272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -19299,7 +19299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     rHtDM6k: ZY6Kw
   name: fB6TF
 stringData:
@@ -19341,7 +19341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     rHtDM6k: ZY6Kw
   name: fB6TF
   namespace: default
@@ -19371,7 +19371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     rHtDM6k: ZY6Kw
   name: fB6TF
 spec:
@@ -19413,7 +19413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: DSw7
   namespace: default
 ---
@@ -19431,7 +19431,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: YUi5JpG
   namespace: default
 spec:
@@ -19458,7 +19458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: YUi5JpG
   namespace: default
 spec:
@@ -20093,7 +20093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: YUi5JpG
 spec:
   maxReplicas: 122
@@ -20132,7 +20132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: sKa
   namespace: default
 ---
@@ -20160,7 +20160,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 3um
 ---
 # Source: console/templates/service.yaml
@@ -20179,7 +20179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 3um
   namespace: default
 spec:
@@ -20208,7 +20208,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 3um
   namespace: default
 spec:
@@ -20223,7 +20223,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dac41fc00bf7bb588f3c2be4059fcb72e045e53ad183a33fe6a65ee1535764f6
+        checksum/config: c86ce201e0461fdc70624b07030321bb214933704156f30627266e3e2cf9c391
         eG: vxInc0
         g: BI6yk
         xCtSP: rQ
@@ -21035,7 +21035,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: 3um
 spec:
   maxReplicas: 1
@@ -21076,7 +21076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     ztm: qegfb80
   name: z12W
   namespace: default
@@ -21093,7 +21093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     ztm: qegfb80
   name: 0BIfuN
 stringData:
@@ -21138,7 +21138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     ztm: qegfb80
   name: 0BIfuN
   namespace: default
@@ -21167,7 +21167,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     ztm: qegfb80
   name: 0BIfuN
   namespace: default
@@ -21975,7 +21975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     ztm: qegfb80
   name: 0BIfuN
 spec:
@@ -22012,7 +22012,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
     ztm: qegfb80
   annotations:
     "helm.sh/hook": test
@@ -22040,7 +22040,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -22054,7 +22054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -22097,7 +22097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22111,7 +22111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22136,7 +22136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22149,7 +22149,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ada95c0d590a341f97ff93b9236dbe30b3a375f5ae27e7369cb7f9008853b129
+        checksum/config: f688dc3f862ad2c604e5181c586c8eef097aa333c11d6f043649958e7aaba817
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22232,7 +22232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22257,7 +22257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -22271,7 +22271,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -22314,7 +22314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22328,7 +22328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22353,7 +22353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22366,7 +22366,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: ada95c0d590a341f97ff93b9236dbe30b3a375f5ae27e7369cb7f9008853b129
+        checksum/config: f688dc3f862ad2c604e5181c586c8eef097aa333c11d6f043649958e7aaba817
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22449,7 +22449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22474,7 +22474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -22488,7 +22488,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -22539,7 +22539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22553,7 +22553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22578,7 +22578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22591,7 +22591,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: cb0e9be81ffd2d4cf98c605031874fc2cb2a637c4bdec8613263d1a66221bbf7
+        checksum/config: edfa2bbc86d42336aaa757d862e62b7c2a8f476ef9420c90840dedca96b27f59
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22674,7 +22674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22699,7 +22699,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -22713,7 +22713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -22775,7 +22775,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22789,7 +22789,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22814,7 +22814,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -22827,7 +22827,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: dc10412d7fe7e9675e0280f923683c4cbe1f43a6c2cd69abfdbf5b073050b941
+        checksum/config: ff92c0b60c7e15697daf4043e021b0b48c6183b73b67cf3c9007ad72197dc982
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22910,7 +22910,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22935,7 +22935,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -22949,7 +22949,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -23002,7 +23002,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23016,7 +23016,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23041,7 +23041,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23054,7 +23054,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 913f100623f7b1ac2165753400399451207838fb2cea9645274ecfb833e62b5e
+        checksum/config: ae51ef1ddd2ae3380191c34563e97b8e6bb34ba6773bf8f572718c605ff9639f
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23137,7 +23137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23162,7 +23162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -23176,7 +23176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -23218,7 +23218,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23232,7 +23232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23257,7 +23257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23270,7 +23270,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23353,7 +23353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23378,7 +23378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -23392,7 +23392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -23434,7 +23434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23448,7 +23448,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23473,7 +23473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23486,7 +23486,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23569,7 +23569,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23594,7 +23594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -23608,7 +23608,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -23650,7 +23650,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23664,7 +23664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23689,7 +23689,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23702,7 +23702,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23794,7 +23794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23819,7 +23819,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -23833,7 +23833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -23875,7 +23875,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23889,7 +23889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23914,7 +23914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -23927,7 +23927,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24011,7 +24011,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 spec:
   ingressClassName: null
@@ -24042,7 +24042,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -24067,7 +24067,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -24081,7 +24081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -24123,7 +24123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -24137,7 +24137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -24162,7 +24162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -24175,7 +24175,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24258,7 +24258,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -24283,7 +24283,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -24297,7 +24297,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -24339,7 +24339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -24353,7 +24353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -24378,7 +24378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -24391,7 +24391,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24474,7 +24474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:
@@ -24499,7 +24499,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 ---
@@ -24513,7 +24513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 stringData:
   enterprise-license: ""
@@ -24555,7 +24555,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -24570,7 +24570,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -24596,7 +24596,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   name: console
   namespace: default
 spec:
@@ -24609,7 +24609,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f43dc9cf448fe7d01bb2e301b8135797164ae8b94805397bfdff177f19997009
+        checksum/config: 0d8cd108cc142c478b56f052e03e8a02c85de95db65e2275d0d484e042492689
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24692,7 +24692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.26
+    helm.sh/chart: console-0.7.27
   annotations:
     "helm.sh/hook": test
 spec:

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.25
+version: 0.4.26
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
@@ -34,11 +34,11 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda-operator
-      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.26-24.1.9
+      image: docker.redpanda.com/redpandadata/redpanda-operator:v2.1.28-24.2.1
     - name: configurator
-      image: docker.redpanda.com/redpandadata/configurator:v2.1.26-24.1.9
+      image: docker.redpanda.com/redpandadata/configurator:v2.1.28-24.2.1
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v24.1.9
+      image: docker.redpanda.com/redpandadata/redpanda:v24.2.1
     - name: kube-rbac-proxy
       image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.0
   artifacthub.io/crds: |

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.25](https://img.shields.io/badge/Version-0.4.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.28-24.2.1](https://img.shields.io/badge/AppVersion-v2.1.28--24.2.1-informational?style=flat-square)
+![Version: 0.4.26](https://img.shields.io/badge/Version-0.4.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.28-24.2.1](https://img.shields.io/badge/AppVersion-v2.1.28--24.2.1-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.8.13
+version: 5.8.14
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
@@ -56,7 +56,7 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v24.1.11
+      image: docker.redpanda.com/redpandadata/redpanda:v24.2.1
     - name: busybox
       image: busybox:latest
     - name: mintel/docker-alpine-bash-curl-jq

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.8.13](https://img.shields.io/badge/Version-5.8.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.1](https://img.shields.io/badge/AppVersion-v24.2.1-informational?style=flat-square)
+![Version: 5.8.14](https://img.shields.io/badge/Version-5.8.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.1](https://img.shields.io/badge/AppVersion-v24.2.1-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -424,7 +424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -455,7 +455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -591,7 +591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -735,7 +735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -750,14 +750,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -1051,7 +1051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -1077,7 +1077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1141,7 +1141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1179,7 +1179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -1228,7 +1228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -1272,7 +1272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1359,7 +1359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -1438,7 +1438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1474,7 +1474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -1569,7 +1569,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -1608,7 +1608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -1761,7 +1761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1787,7 +1787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -1875,7 +1875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -1921,7 +1921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -2041,7 +2041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -2057,14 +2057,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 1ae46243a59f44eb3b1f184cc3784db4afb4b63cbc276dd285374a21398b2bc7
+        config.redpanda.com/checksum: 494e825050f808d055962a05938e8bf1b2d2745abcb4a0308f8ad21c5a2541d1
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
     spec:
@@ -2362,7 +2362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -2439,7 +2439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     testlabel: exercise_common_labels_template
   name: redpanda-post-upgrade
   namespace: default
@@ -2509,7 +2509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -2544,7 +2544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -2638,7 +2638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -2676,7 +2676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -2894,7 +2894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -2921,7 +2921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -3008,7 +3008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -3053,7 +3053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -3197,7 +3197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -3212,14 +3212,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 85a9ca949232240ed0438d715ea18d6e3f4db7a4703df8fc0faa346f3d2dff4c
+        config.redpanda.com/checksum: f5b2750b621c8087538e74a83dac9c709de87bf70c1fd7bb78b24f759495be23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -3513,7 +3513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -3539,7 +3539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -3565,7 +3565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -3603,7 +3603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -3641,7 +3641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -3657,7 +3657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -3674,7 +3674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -3690,7 +3690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -3734,7 +3734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -3821,7 +3821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -3900,7 +3900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -3935,7 +3935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -4033,7 +4033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-users
   namespace: default
 stringData:
@@ -4050,7 +4050,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -4176,7 +4176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -4336,7 +4336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -4361,7 +4361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -4448,7 +4448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -4493,7 +4493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -4619,7 +4619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -4634,14 +4634,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4b03467b18b95824b1211dfa5c831c3f4d0ef6f0d1043163952054b95441258a
+        config.redpanda.com/checksum: 7240590a67a70c8684b262281c2dee95eff8399aaf27ca444b2f49bb9b1a4f75
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -4952,7 +4952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -5033,7 +5033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -5106,7 +5106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -5141,7 +5141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -5239,7 +5239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-users
   namespace: default
 stringData:
@@ -5256,7 +5256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -5382,7 +5382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -5620,7 +5620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -5647,7 +5647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -5734,7 +5734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -5779,7 +5779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -5930,7 +5930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -5945,14 +5945,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 645bf8c7f59c62684e451a8e85642672f3a1550bc7b66152fc504a286cfb278a
+        config.redpanda.com/checksum: ec548137ccfea0a871a80d98c75ef83ba6ee130195dc6a894878330b55ff7ecd
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -6261,7 +6261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -6287,7 +6287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -6313,7 +6313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -6351,7 +6351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -6389,7 +6389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -6405,7 +6405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -6422,7 +6422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -6438,7 +6438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -6482,7 +6482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -6575,7 +6575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -6661,7 +6661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -6697,7 +6697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -6711,7 +6711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -6804,7 +6804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -6842,7 +6842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -7096,7 +7096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -7127,7 +7127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -7195,7 +7195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
 rules:
 - apiGroups:
@@ -7217,7 +7217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -7249,7 +7249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7271,7 +7271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7316,7 +7316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -7361,7 +7361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -7505,7 +7505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -7520,14 +7520,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 18e52cff4ca67c93c715c559b94e79fb12b9cdbc4328b653c5e00f4988f6b91a
+        config.redpanda.com/checksum: d1daa9f6409a70bce1f8c6fa0dd61307c533eb60950f8f9d9a1efd1fba15b860
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -7821,7 +7821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -7847,7 +7847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -7873,7 +7873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -7911,7 +7911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -7949,7 +7949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -7965,7 +7965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -7982,7 +7982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -7998,7 +7998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -8042,7 +8042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -8129,7 +8129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -8208,7 +8208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -8243,7 +8243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -8336,7 +8336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -8374,7 +8374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -8679,7 +8679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -8709,7 +8709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -8800,7 +8800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -8845,7 +8845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -9001,7 +9001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -9016,14 +9016,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: c2877a9de04b27bd0e5c161687f9d6707f347e95c94d2894fe3532380ca72684
+        config.redpanda.com/checksum: b3321cddd1b14629c83aceae8314fc9e6160ac7eb0e3948ccc794a4113371b62
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -9341,7 +9341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-cert2-root-certificate
   namespace: default
 spec:
@@ -9367,7 +9367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -9393,7 +9393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -9419,7 +9419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -9457,7 +9457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -9495,7 +9495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -9533,7 +9533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-cert2-selfsigned-issuer
   namespace: default
 spec:
@@ -9549,7 +9549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-cert2-root-issuer
   namespace: default
 spec:
@@ -9566,7 +9566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -9582,7 +9582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -9599,7 +9599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -9659,7 +9659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -9752,7 +9752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -9837,7 +9837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -9872,7 +9872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -9965,7 +9965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -10003,7 +10003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -10251,7 +10251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -10282,7 +10282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -10373,7 +10373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -10418,7 +10418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -10562,7 +10562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -10577,14 +10577,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -10877,7 +10877,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -10903,7 +10903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -10929,7 +10929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -10967,7 +10967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -11005,7 +11005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -11021,7 +11021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -11038,7 +11038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -11054,7 +11054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -11098,7 +11098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -11185,7 +11185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -11264,7 +11264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -11299,7 +11299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -11392,7 +11392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -11430,7 +11430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -11490,7 +11490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -11733,7 +11733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -11764,7 +11764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -11855,7 +11855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -11900,7 +11900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -12044,7 +12044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -12059,14 +12059,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -12444,7 +12444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -12470,7 +12470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -12496,7 +12496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -12534,7 +12534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -12572,7 +12572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -12588,7 +12588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -12605,7 +12605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -12621,7 +12621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -12665,7 +12665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -12752,7 +12752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -12831,7 +12831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -12866,7 +12866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -12959,7 +12959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -12997,7 +12997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -13245,7 +13245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -13276,7 +13276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -13367,7 +13367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -13412,7 +13412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -13556,7 +13556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -13571,14 +13571,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ff4567639710623bd32b7515d8d67b632b9cdc95a2c5d62a061e49dc316764e1
+        config.redpanda.com/checksum: 9e1901c4c43e72c1fe1383bc99ed5b6f61162032818590e2f2e180c86ae9261c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -13872,7 +13872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -13898,7 +13898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -13924,7 +13924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -13964,7 +13964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -14004,7 +14004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -14020,7 +14020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -14037,7 +14037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -14053,7 +14053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -14097,7 +14097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -14184,7 +14184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -14263,7 +14263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -14298,7 +14298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -14395,7 +14395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: some-users
   namespace: default
 stringData:
@@ -14416,7 +14416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -14542,7 +14542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -14806,7 +14806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -14837,7 +14837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -14928,7 +14928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -14973,7 +14973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -15124,7 +15124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -15139,14 +15139,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: c759af55e54557d83b19c86782b6cce929afe93167cf860f66d429e58e679229
+        config.redpanda.com/checksum: b2a5ee1ffa7e7f567d1044062814b43303ba35ed958d3156d043d9e44665a334
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -15455,7 +15455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -15481,7 +15481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -15507,7 +15507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -15545,7 +15545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -15583,7 +15583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -15599,7 +15599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -15616,7 +15616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -15632,7 +15632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -15676,7 +15676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -15769,7 +15769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -15854,7 +15854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -15889,7 +15889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -15982,7 +15982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -16020,7 +16020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -16268,7 +16268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -16299,7 +16299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -16390,7 +16390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -16435,7 +16435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -16579,7 +16579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -16594,14 +16594,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 1090ee56e4bb8d5804e675b167f9a80d669fb4f1226ef8a6a7ff3426c6514eb0
+        config.redpanda.com/checksum: de406ba399dae397d28a56b6ab22d431bcfc2502635ae9d2984764fb8fc20812
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -16895,7 +16895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -16921,7 +16921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -16961,7 +16961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -16977,7 +16977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -17021,7 +17021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -17108,7 +17108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -17187,7 +17187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -17222,7 +17222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -17315,7 +17315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -17353,7 +17353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -17601,7 +17601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -17632,7 +17632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -17723,7 +17723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -17768,7 +17768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -17812,7 +17812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -17856,7 +17856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -17999,7 +17999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -18014,14 +18014,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9fcaad34a794f0e7c0ad8563861340cd5a009527577bc108b92d22fdd777149b
+        config.redpanda.com/checksum: e3d1e6e6f2168f40a234c628d5091d65e7295a915d65cb6849fb2a7f2f1c257c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -18315,7 +18315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -18341,7 +18341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -18381,7 +18381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -18397,7 +18397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -18441,7 +18441,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -18528,7 +18528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -18607,7 +18607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -18642,7 +18642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -18735,7 +18735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -18773,7 +18773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -18953,7 +18953,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -18982,7 +18982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -19073,7 +19073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -19118,7 +19118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -19237,7 +19237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -19252,14 +19252,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e5d61b20bc865d886854a64c8b99ac519a1265ab1486b932a8fbb0092e6726f8
+        config.redpanda.com/checksum: f7648361172fc5d9e6d22b3af5fd8fb6aa50d452dc288ca4beb0aa73cc8bfaec
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -19528,7 +19528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -19581,7 +19581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -19656,7 +19656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -19723,7 +19723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -19758,7 +19758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -19851,7 +19851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -19889,7 +19889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -20137,7 +20137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -20168,7 +20168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -20259,7 +20259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -20304,7 +20304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -20448,7 +20448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -20463,14 +20463,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -20764,7 +20764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -20790,7 +20790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -20816,7 +20816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -20854,7 +20854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -20892,7 +20892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -20908,7 +20908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -20925,7 +20925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -20941,7 +20941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -20958,7 +20958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -21016,7 +21016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -21103,7 +21103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -21182,7 +21182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -21217,7 +21217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -21310,7 +21310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -21348,7 +21348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -21596,7 +21596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -21627,7 +21627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -21695,7 +21695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -21729,7 +21729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
 rules:
 - apiGroups:
@@ -21751,7 +21751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -21783,7 +21783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21805,7 +21805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21827,7 +21827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21849,7 +21849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -21902,7 +21902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -21948,7 +21948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -21993,7 +21993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -22137,7 +22137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -22152,14 +22152,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -22468,7 +22468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -22494,7 +22494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -22520,7 +22520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -22558,7 +22558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -22596,7 +22596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -22612,7 +22612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -22629,7 +22629,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -22645,7 +22645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -22689,7 +22689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -22776,7 +22776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -22855,7 +22855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -22890,7 +22890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -22983,7 +22983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -23021,7 +23021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -23269,7 +23269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -23300,7 +23300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -23391,7 +23391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -23436,7 +23436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -23580,7 +23580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -23595,14 +23595,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 3d3afad4af40d3d91ec522a6a6f8ec9426b5d2c5665221a085373dd532ab5d6a
+        config.redpanda.com/checksum: f3a7c0fc980f6190d8c218d0922faaf604b5441799dfdc7abba873bab0fd006b
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -23899,7 +23899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -23925,7 +23925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -23951,7 +23951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -23989,7 +23989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -24027,7 +24027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -24043,7 +24043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -24060,7 +24060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -24076,7 +24076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -24120,7 +24120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -24207,7 +24207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -24286,7 +24286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -24321,7 +24321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -24414,7 +24414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -24452,7 +24452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -24700,7 +24700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -24731,7 +24731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -24822,7 +24822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -24867,7 +24867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -25011,7 +25011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -25026,14 +25026,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 5c5a0f8c9f12d1056ba5e17e248461438b51d5599038d3644f846b43f206b136
+        config.redpanda.com/checksum: d40d7379765f5f6e64e06bb51ef56562408981c7d21f392b0f4f9638bd5dca07
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -25327,7 +25327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -25353,7 +25353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -25379,7 +25379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -25419,7 +25419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -25459,7 +25459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -25475,7 +25475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -25492,7 +25492,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -25508,7 +25508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -25552,7 +25552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -25639,7 +25639,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -25718,7 +25718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -25800,7 +25800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -25893,7 +25893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -25931,7 +25931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -26189,7 +26189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -26220,7 +26220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -26311,7 +26311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -26356,7 +26356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -26516,7 +26516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -26531,14 +26531,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7fd24299cc2024fce8c54b411ee8dd0c7cb527b1a2dc303fd8839a3f0f6d1015
+        config.redpanda.com/checksum: a3b602a16823eb51351e773d3269d45ae861a65a6f24353b562bde2225313f17
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -26853,7 +26853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -26879,7 +26879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -26905,7 +26905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -26943,7 +26943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -26981,7 +26981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -26997,7 +26997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -27014,7 +27014,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -27030,7 +27030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -27074,7 +27074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -27183,7 +27183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -27262,7 +27262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -27344,7 +27344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -27437,7 +27437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -27475,7 +27475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -27734,7 +27734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -27765,7 +27765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -27856,7 +27856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -27901,7 +27901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -28061,7 +28061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -28076,14 +28076,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 895c7b67acb463163ccc12231d31d5a0cf7843764f705be46f531f3d6d535791
+        config.redpanda.com/checksum: 06d9af8bb5af79160ff0d996103bc889f4f8dbb78880cde3beb2e60a6c43aad1
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -28398,7 +28398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -28424,7 +28424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -28450,7 +28450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -28488,7 +28488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -28526,7 +28526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -28542,7 +28542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -28559,7 +28559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -28575,7 +28575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -28619,7 +28619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -28730,7 +28730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -28809,7 +28809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -28891,7 +28891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -28984,7 +28984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -29022,7 +29022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -29279,7 +29279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -29310,7 +29310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -29401,7 +29401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -29446,7 +29446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -29606,7 +29606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -29621,14 +29621,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a5412bbf8f158a5c63225a820c5f4e18ec0f7ed02406f96958bac034c732f519
+        config.redpanda.com/checksum: c61e024538e4894534f31211674454f074cfe7b92bd809e74bf4e9686cd206fc
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -29944,7 +29944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -29970,7 +29970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -29996,7 +29996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -30034,7 +30034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -30072,7 +30072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -30088,7 +30088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -30105,7 +30105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -30121,7 +30121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -30165,7 +30165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -30272,7 +30272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -30351,7 +30351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -30386,7 +30386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -30479,7 +30479,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -30517,7 +30517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -30774,7 +30774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -30805,7 +30805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -30896,7 +30896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -30941,7 +30941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -31085,7 +31085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -31100,14 +31100,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7b1af16fc4ae9356e8ba0662a11441d6c246e9ac12c0ccfabe9ae04aa351c69e
+        config.redpanda.com/checksum: f3a11b64a8f9b7fdf035f40cc265103dc35f92343069dfea052c8f54445b8af9
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -31423,7 +31423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -31449,7 +31449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -31475,7 +31475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -31513,7 +31513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -31551,7 +31551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -31567,7 +31567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -31584,7 +31584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -31600,7 +31600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -31644,7 +31644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -31749,7 +31749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -31828,7 +31828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -31910,7 +31910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -32003,7 +32003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -32041,7 +32041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -32299,7 +32299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -32330,7 +32330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -32421,7 +32421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -32466,7 +32466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -32626,7 +32626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -32641,14 +32641,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7fd24299cc2024fce8c54b411ee8dd0c7cb527b1a2dc303fd8839a3f0f6d1015
+        config.redpanda.com/checksum: a3b602a16823eb51351e773d3269d45ae861a65a6f24353b562bde2225313f17
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -32975,7 +32975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -33001,7 +33001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -33027,7 +33027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -33065,7 +33065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -33103,7 +33103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -33119,7 +33119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -33136,7 +33136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -33152,7 +33152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -33196,7 +33196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -33305,7 +33305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -33384,7 +33384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -33466,7 +33466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -33559,7 +33559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -33597,7 +33597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -33856,7 +33856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -33887,7 +33887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -33978,7 +33978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -34023,7 +34023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -34183,7 +34183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -34198,14 +34198,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 895c7b67acb463163ccc12231d31d5a0cf7843764f705be46f531f3d6d535791
+        config.redpanda.com/checksum: 06d9af8bb5af79160ff0d996103bc889f4f8dbb78880cde3beb2e60a6c43aad1
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -34532,7 +34532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -34558,7 +34558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -34584,7 +34584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -34622,7 +34622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -34660,7 +34660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -34676,7 +34676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -34693,7 +34693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -34709,7 +34709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -34753,7 +34753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -34864,7 +34864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -34943,7 +34943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -35025,7 +35025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -35118,7 +35118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -35156,7 +35156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -35413,7 +35413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -35444,7 +35444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -35535,7 +35535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -35580,7 +35580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -35740,7 +35740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -35755,14 +35755,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a5412bbf8f158a5c63225a820c5f4e18ec0f7ed02406f96958bac034c732f519
+        config.redpanda.com/checksum: c61e024538e4894534f31211674454f074cfe7b92bd809e74bf4e9686cd206fc
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -36091,7 +36091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -36117,7 +36117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -36143,7 +36143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -36181,7 +36181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -36219,7 +36219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -36235,7 +36235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -36252,7 +36252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -36268,7 +36268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -36312,7 +36312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -36419,7 +36419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -36498,7 +36498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -36533,7 +36533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -36626,7 +36626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -36664,7 +36664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -36921,7 +36921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -36952,7 +36952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -37043,7 +37043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -37088,7 +37088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -37232,7 +37232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -37247,14 +37247,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a5412bbf8f158a5c63225a820c5f4e18ec0f7ed02406f96958bac034c732f519
+        config.redpanda.com/checksum: c61e024538e4894534f31211674454f074cfe7b92bd809e74bf4e9686cd206fc
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -37583,7 +37583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -37609,7 +37609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -37635,7 +37635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -37673,7 +37673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -37711,7 +37711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -37727,7 +37727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -37744,7 +37744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -37760,7 +37760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -37804,7 +37804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -37909,7 +37909,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -37988,7 +37988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -38070,7 +38070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -38163,7 +38163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -38201,7 +38201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -38459,7 +38459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -38490,7 +38490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -38581,7 +38581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -38626,7 +38626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -38786,7 +38786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -38801,14 +38801,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7fd24299cc2024fce8c54b411ee8dd0c7cb527b1a2dc303fd8839a3f0f6d1015
+        config.redpanda.com/checksum: a3b602a16823eb51351e773d3269d45ae861a65a6f24353b562bde2225313f17
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -39135,7 +39135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -39161,7 +39161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -39187,7 +39187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -39225,7 +39225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -39263,7 +39263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -39279,7 +39279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -39296,7 +39296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -39312,7 +39312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -39356,7 +39356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -39465,7 +39465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -39544,7 +39544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -39626,7 +39626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -39719,7 +39719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -39757,7 +39757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -40016,7 +40016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -40047,7 +40047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -40138,7 +40138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -40183,7 +40183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -40343,7 +40343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -40358,14 +40358,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 895c7b67acb463163ccc12231d31d5a0cf7843764f705be46f531f3d6d535791
+        config.redpanda.com/checksum: 06d9af8bb5af79160ff0d996103bc889f4f8dbb78880cde3beb2e60a6c43aad1
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -40692,7 +40692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -40718,7 +40718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -40744,7 +40744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -40782,7 +40782,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -40820,7 +40820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -40836,7 +40836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -40853,7 +40853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -40869,7 +40869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -40913,7 +40913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -41024,7 +41024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -41103,7 +41103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -41185,7 +41185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -41278,7 +41278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -41316,7 +41316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -41573,7 +41573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -41604,7 +41604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -41695,7 +41695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -41740,7 +41740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -41900,7 +41900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -41915,14 +41915,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a5412bbf8f158a5c63225a820c5f4e18ec0f7ed02406f96958bac034c732f519
+        config.redpanda.com/checksum: c61e024538e4894534f31211674454f074cfe7b92bd809e74bf4e9686cd206fc
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -42251,7 +42251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -42277,7 +42277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -42303,7 +42303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -42341,7 +42341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -42379,7 +42379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -42395,7 +42395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -42412,7 +42412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -42428,7 +42428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -42472,7 +42472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -42579,7 +42579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -42658,7 +42658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -42693,7 +42693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -42786,7 +42786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -42824,7 +42824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -43081,7 +43081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -43112,7 +43112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -43203,7 +43203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -43248,7 +43248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -43392,7 +43392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -43407,14 +43407,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a5412bbf8f158a5c63225a820c5f4e18ec0f7ed02406f96958bac034c732f519
+        config.redpanda.com/checksum: c61e024538e4894534f31211674454f074cfe7b92bd809e74bf4e9686cd206fc
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -43743,7 +43743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -43769,7 +43769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -43795,7 +43795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -43833,7 +43833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -43871,7 +43871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -43887,7 +43887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -43904,7 +43904,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -43920,7 +43920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -43964,7 +43964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -44069,7 +44069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -44148,7 +44148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -44183,7 +44183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -44276,7 +44276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -44314,7 +44314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -44562,7 +44562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -44593,7 +44593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -44684,7 +44684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -44729,7 +44729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -44873,7 +44873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -44888,14 +44888,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: b7e107f9a24d799acaee7949890bc80601f45f44f1c59bc5934b391a13edb869
+        config.redpanda.com/checksum: f6953ac0554b7aa4e81e50913b132c48a04479c7dff5bdb0153b17d774fe6032
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -45189,7 +45189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -45215,7 +45215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -45241,7 +45241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -45279,7 +45279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -45317,7 +45317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -45333,7 +45333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -45350,7 +45350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -45366,7 +45366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -45410,7 +45410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -45497,7 +45497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -45576,7 +45576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -45611,7 +45611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -45704,7 +45704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -45742,7 +45742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -45990,7 +45990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -46021,7 +46021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -46112,7 +46112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -46157,7 +46157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -46301,7 +46301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -46316,7 +46316,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
@@ -46324,7 +46324,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -46618,7 +46618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -46644,7 +46644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -46670,7 +46670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -46708,7 +46708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -46746,7 +46746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -46762,7 +46762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -46779,7 +46779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -46795,7 +46795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -46839,7 +46839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -46926,7 +46926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -47005,7 +47005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -47040,7 +47040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -47133,7 +47133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -47171,7 +47171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -47419,7 +47419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -47450,7 +47450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -47541,7 +47541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -47586,7 +47586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -47730,7 +47730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -47745,14 +47745,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -48050,7 +48050,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -48076,7 +48076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -48102,7 +48102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -48140,7 +48140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -48178,7 +48178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -48194,7 +48194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -48211,7 +48211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -48227,7 +48227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -48271,7 +48271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -48358,7 +48358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -48437,7 +48437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -48472,7 +48472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -48565,7 +48565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -48603,7 +48603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -48905,7 +48905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -48937,7 +48937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -49030,7 +49030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -49075,7 +49075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -49230,7 +49230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -49245,14 +49245,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ba383f146f8fda26edd3dbaa214d415c035e09c969c111fe118b5a667355a812
+        config.redpanda.com/checksum: 8e96671b0f2ac0888fa886e8c2bab1b58388f287bc0f82965146f2bfaa16b3d4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -49554,7 +49554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -49580,7 +49580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -49606,7 +49606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -49644,7 +49644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -49682,7 +49682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -49698,7 +49698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -49715,7 +49715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -49731,7 +49731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -49775,7 +49775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -49862,7 +49862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -49941,7 +49941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -49979,7 +49979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -50072,7 +50072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -50110,7 +50110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -50358,7 +50358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -50389,7 +50389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -50480,7 +50480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -50528,7 +50528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -50675,7 +50675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -50693,14 +50693,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -51003,7 +51003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -51029,7 +51029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -51055,7 +51055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -51093,7 +51093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -51131,7 +51131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -51147,7 +51147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -51164,7 +51164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -51180,7 +51180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -51224,7 +51224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -51311,7 +51311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -51390,7 +51390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -51425,7 +51425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -51518,7 +51518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -51556,7 +51556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -51804,7 +51804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -51835,7 +51835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -51903,7 +51903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -51937,7 +51937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
 rules:
 - apiGroups:
@@ -51959,7 +51959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -51991,7 +51991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52013,7 +52013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52035,7 +52035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52057,7 +52057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -52110,7 +52110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -52156,7 +52156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -52201,7 +52201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -52345,7 +52345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -52360,14 +52360,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -52688,7 +52688,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -52714,7 +52714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -52740,7 +52740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -52778,7 +52778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -52816,7 +52816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -52832,7 +52832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -52849,7 +52849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -52865,7 +52865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -52909,7 +52909,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -52996,7 +52996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -53075,7 +53075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -53110,7 +53110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -53203,7 +53203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -53241,7 +53241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -53301,7 +53301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -53544,7 +53544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -53575,7 +53575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -53643,7 +53643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -53677,7 +53677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53699,7 +53699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -53752,7 +53752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -53798,7 +53798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -53843,7 +53843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -53987,7 +53987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -54002,14 +54002,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -54344,7 +54344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -54370,7 +54370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -54396,7 +54396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -54434,7 +54434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -54472,7 +54472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -54488,7 +54488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -54505,7 +54505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -54521,7 +54521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -54565,7 +54565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -54652,7 +54652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -54731,7 +54731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -54766,7 +54766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -54859,7 +54859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -54897,7 +54897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -55145,7 +55145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -55176,7 +55176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -55315,7 +55315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -55360,7 +55360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -55649,7 +55649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -55664,14 +55664,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -55965,7 +55965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -55991,7 +55991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -56017,7 +56017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -56055,7 +56055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -56093,7 +56093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -56109,7 +56109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -56126,7 +56126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -56142,7 +56142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -56186,7 +56186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -56273,7 +56273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -56352,7 +56352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -56387,7 +56387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -56480,7 +56480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -56518,7 +56518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -56766,7 +56766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -56797,7 +56797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -56888,7 +56888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -56933,7 +56933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -57077,7 +57077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -57092,14 +57092,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: cb348f29f094df7937ba2c2636b987767982a4f4a6464867204b7d2d666492eb
+        config.redpanda.com/checksum: 1d94ca9eba5c93c80e51c55d4e1647a5a92b127b805ad37aa18f996cf84c7a92
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -57393,7 +57393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -57419,7 +57419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -57445,7 +57445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -57485,7 +57485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -57525,7 +57525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -57541,7 +57541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -57558,7 +57558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -57574,7 +57574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -57618,7 +57618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -57705,7 +57705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -57784,7 +57784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -57820,7 +57820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -57913,7 +57913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -57951,7 +57951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -58199,7 +58199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -58230,7 +58230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -58322,7 +58322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -58368,7 +58368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: change-name-external
   namespace: default
 spec:
@@ -58513,7 +58513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -58529,14 +58529,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d6351f07fc1c47d35d3bfd6fe20c2a9a8e6931127038e530ab518c05eeabe661
+        config.redpanda.com/checksum: 989af01b7a0f962df7ef3122f7223e768cdb746eed032d8dfc7d9adf6adc16d0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
         test: test
     spec:
@@ -58833,7 +58833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -58859,7 +58859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -58885,7 +58885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -58923,7 +58923,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -58961,7 +58961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -58977,7 +58977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -58994,7 +58994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -59010,7 +59010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -59027,7 +59027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -59085,7 +59085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -59172,7 +59172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -59251,7 +59251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -59286,7 +59286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -59379,7 +59379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -59417,7 +59417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -59665,7 +59665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -59696,7 +59696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -59787,7 +59787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -59832,7 +59832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -59976,7 +59976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -59991,14 +59991,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -60307,7 +60307,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -60333,7 +60333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -60359,7 +60359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -60397,7 +60397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -60435,7 +60435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -60451,7 +60451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -60468,7 +60468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -60484,7 +60484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -60528,7 +60528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -60634,7 +60634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -60728,7 +60728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -60763,7 +60763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -60856,7 +60856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -60894,7 +60894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -61142,7 +61142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -61173,7 +61173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -61264,7 +61264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -61309,7 +61309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -61453,7 +61453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -61468,14 +61468,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -61784,7 +61784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -61810,7 +61810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -61836,7 +61836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -61874,7 +61874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -61912,7 +61912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -61928,7 +61928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -61945,7 +61945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -61961,7 +61961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -62005,7 +62005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -62113,7 +62113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -62207,7 +62207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -62242,7 +62242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -62335,7 +62335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -62373,7 +62373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -62621,7 +62621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -62652,7 +62652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -62743,7 +62743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -62788,7 +62788,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -62932,7 +62932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -62947,14 +62947,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -63250,7 +63250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -63276,7 +63276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -63302,7 +63302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -63340,7 +63340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -63378,7 +63378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -63394,7 +63394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -63411,7 +63411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -63427,7 +63427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -63471,7 +63471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -63560,7 +63560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -63641,7 +63641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -63663,7 +63663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -63756,7 +63756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -63794,7 +63794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -64019,7 +64019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -64051,7 +64051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -64066,7 +64066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -64111,7 +64111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -64155,7 +64155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -64170,14 +64170,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e75c4b493de2df49e562177ad2eab237eba8ec4c65c73cf5484ffc43d28d97b3
+        config.redpanda.com/checksum: f487dfeb2ad7307a796d358188dc9134903d5b45745caec602dda836f616c4a1
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -64480,7 +64480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -64506,7 +64506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -64532,7 +64532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -64558,7 +64558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -64596,7 +64596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -64634,7 +64634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -64672,7 +64672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -64697,7 +64697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -64713,7 +64713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -64730,7 +64730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -64746,7 +64746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -64763,7 +64763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -64779,7 +64779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -64800,7 +64800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -64893,7 +64893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -64978,7 +64978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -65013,7 +65013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -65106,7 +65106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -65144,7 +65144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -65392,7 +65392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -65423,7 +65423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -65514,7 +65514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -65559,7 +65559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -65703,7 +65703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -65718,14 +65718,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -66019,7 +66019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -66045,7 +66045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -66071,7 +66071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -66097,7 +66097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -66123,7 +66123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -66140,7 +66140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -66184,7 +66184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -66271,7 +66271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -66350,7 +66350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -66432,7 +66432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -66529,7 +66529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-users
   namespace: default
 stringData:
@@ -66546,7 +66546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -66672,7 +66672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -66946,7 +66946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -66977,7 +66977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -67068,7 +67068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -67113,7 +67113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -67280,7 +67280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -67295,14 +67295,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: c6b3332631125b35e3ba2be5e551153059d6b265f3972eb220d96e474a40ef07
+        config.redpanda.com/checksum: c0a7aa551fb9e2ca7ae1e041a8c998023277a5ae7b8a7697f1140bdba9da3715
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -67611,7 +67611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -67637,7 +67637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -67663,7 +67663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -67701,7 +67701,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -67739,7 +67739,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -67755,7 +67755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -67772,7 +67772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -67788,7 +67788,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -67832,7 +67832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -67927,7 +67927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -68012,7 +68012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -68094,7 +68094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -68187,7 +68187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -68225,7 +68225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -68473,7 +68473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -68504,7 +68504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -68595,7 +68595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -68640,7 +68640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -68800,7 +68800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -68815,14 +68815,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -69116,7 +69116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -69142,7 +69142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -69168,7 +69168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -69206,7 +69206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -69244,7 +69244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -69260,7 +69260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -69277,7 +69277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -69293,7 +69293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -69337,7 +69337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -69426,7 +69426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -69505,7 +69505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -69540,7 +69540,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -69633,7 +69633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -69671,7 +69671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -69919,7 +69919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -69950,7 +69950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -70041,7 +70041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -70086,7 +70086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -70235,7 +70235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -70250,14 +70250,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -70551,7 +70551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -70577,7 +70577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -70603,7 +70603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -70641,7 +70641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -70679,7 +70679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -70695,7 +70695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -70712,7 +70712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -70728,7 +70728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -70772,7 +70772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -70864,7 +70864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -70943,7 +70943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -70978,7 +70978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -71071,7 +71071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -71109,7 +71109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -71368,7 +71368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -71399,7 +71399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -71490,7 +71490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -71535,7 +71535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -71693,7 +71693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -71708,14 +71708,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 99e5be972cf34405423d119fd14f582d60da9cc01d97bc5bdb5889dad2389271
+        config.redpanda.com/checksum: 555fb866624f98c56bd7c65a25308a968e9dee5c3fbe2f3b8777ffe03a85fefd
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -72030,7 +72030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -72056,7 +72056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -72082,7 +72082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -72120,7 +72120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -72158,7 +72158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -72174,7 +72174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -72191,7 +72191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -72207,7 +72207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -72251,7 +72251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -72361,7 +72361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -72440,7 +72440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -72475,7 +72475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -72568,7 +72568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -72606,7 +72606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -72854,7 +72854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -72885,7 +72885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -72976,7 +72976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -73021,7 +73021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -73165,7 +73165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -73180,14 +73180,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -73481,7 +73481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -73507,7 +73507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -73533,7 +73533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -73571,7 +73571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -73609,7 +73609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -73625,7 +73625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -73642,7 +73642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -73658,7 +73658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -73702,7 +73702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -73790,7 +73790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -73870,7 +73870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -73905,7 +73905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -73998,7 +73998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -74036,7 +74036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -74284,7 +74284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -74315,7 +74315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -74406,7 +74406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -74451,7 +74451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -74595,7 +74595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -74610,14 +74610,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -74911,7 +74911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -74937,7 +74937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -74963,7 +74963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -75001,7 +75001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -75039,7 +75039,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -75055,7 +75055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -75072,7 +75072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -75088,7 +75088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -75132,7 +75132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -75220,7 +75220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -75324,7 +75324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -75359,7 +75359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -75452,7 +75452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -75490,7 +75490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -75736,7 +75736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -75767,7 +75767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -75858,7 +75858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -75903,7 +75903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -76047,7 +76047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -76062,14 +76062,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ac3e1bf4ba3ef59edcb10806eca8b4e306b0903d9312ceb2d044e0c1487348fe
+        config.redpanda.com/checksum: 3e6050ce252e6e56ebcfa4c48ab96d632401ddc907facbefaeb182a2bda2c21c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -76363,7 +76363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -76389,7 +76389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -76415,7 +76415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -76453,7 +76453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -76491,7 +76491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -76507,7 +76507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -76524,7 +76524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -76540,7 +76540,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -76584,7 +76584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -76671,7 +76671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -76743,7 +76743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -76825,7 +76825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -76918,7 +76918,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -76956,7 +76956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -77202,7 +77202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -77233,7 +77233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -77324,7 +77324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -77369,7 +77369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -77529,7 +77529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -77544,14 +77544,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ef62f21829220d152fc38e0d9218b556db341c3d71e1e37ed2da38396159a110
+        config.redpanda.com/checksum: b2185a25f424fed359b7578be087ac935ca3f98fe49eb7ddebe4ef7e9f7f923e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -77845,7 +77845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -77871,7 +77871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -77897,7 +77897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -77935,7 +77935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -77973,7 +77973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -77989,7 +77989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -78006,7 +78006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -78022,7 +78022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -78066,7 +78066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -78155,7 +78155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -78227,7 +78227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -78262,7 +78262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -78355,7 +78355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -78393,7 +78393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -78645,7 +78645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -78676,7 +78676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -78767,7 +78767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -78812,7 +78812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -78956,7 +78956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -78971,14 +78971,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a4c2e4ac0c4866f0a94037b706d496a31d933ad82ef1bc36b8f7dc01bd518745
+        config.redpanda.com/checksum: f94e25b0cc546e49669c4db10d7814731b68f295c9607855147db56b583f5642
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -79272,7 +79272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -79298,7 +79298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -79324,7 +79324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -79362,7 +79362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -79400,7 +79400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -79416,7 +79416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -79433,7 +79433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -79449,7 +79449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -79493,7 +79493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -79580,7 +79580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -79664,7 +79664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -79699,7 +79699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -79792,7 +79792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -79830,7 +79830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -80076,7 +80076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -80107,7 +80107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -80198,7 +80198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -80243,7 +80243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -80387,7 +80387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -80402,14 +80402,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ac3e1bf4ba3ef59edcb10806eca8b4e306b0903d9312ceb2d044e0c1487348fe
+        config.redpanda.com/checksum: 3e6050ce252e6e56ebcfa4c48ab96d632401ddc907facbefaeb182a2bda2c21c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -80703,7 +80703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -80729,7 +80729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -80755,7 +80755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -80793,7 +80793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -80831,7 +80831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -80847,7 +80847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -80864,7 +80864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -80880,7 +80880,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -80924,7 +80924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -81011,7 +81011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -81083,7 +81083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -81165,7 +81165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -81258,7 +81258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -81296,7 +81296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -81542,7 +81542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -81573,7 +81573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -81664,7 +81664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -81709,7 +81709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -81869,7 +81869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -81884,14 +81884,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ef62f21829220d152fc38e0d9218b556db341c3d71e1e37ed2da38396159a110
+        config.redpanda.com/checksum: b2185a25f424fed359b7578be087ac935ca3f98fe49eb7ddebe4ef7e9f7f923e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -82185,7 +82185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -82211,7 +82211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -82237,7 +82237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -82275,7 +82275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -82313,7 +82313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -82329,7 +82329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -82346,7 +82346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -82362,7 +82362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -82406,7 +82406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -82495,7 +82495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -82567,7 +82567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -82602,7 +82602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -82695,7 +82695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -82733,7 +82733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -82985,7 +82985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -83016,7 +83016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -83107,7 +83107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -83152,7 +83152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -83296,7 +83296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -83311,14 +83311,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a4c2e4ac0c4866f0a94037b706d496a31d933ad82ef1bc36b8f7dc01bd518745
+        config.redpanda.com/checksum: f94e25b0cc546e49669c4db10d7814731b68f295c9607855147db56b583f5642
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -83612,7 +83612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -83638,7 +83638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -83664,7 +83664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -83702,7 +83702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -83740,7 +83740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -83756,7 +83756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -83773,7 +83773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -83789,7 +83789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -83833,7 +83833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -83920,7 +83920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -83992,7 +83992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -84027,7 +84027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -84120,7 +84120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -84158,7 +84158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -84404,7 +84404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -84435,7 +84435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -84526,7 +84526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -84571,7 +84571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -84715,7 +84715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -84730,14 +84730,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ac3e1bf4ba3ef59edcb10806eca8b4e306b0903d9312ceb2d044e0c1487348fe
+        config.redpanda.com/checksum: 3e6050ce252e6e56ebcfa4c48ab96d632401ddc907facbefaeb182a2bda2c21c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -85031,7 +85031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -85057,7 +85057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -85083,7 +85083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -85121,7 +85121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -85159,7 +85159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -85175,7 +85175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -85192,7 +85192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -85208,7 +85208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -85252,7 +85252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -85339,7 +85339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -85411,7 +85411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -85493,7 +85493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -85586,7 +85586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -85624,7 +85624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -85870,7 +85870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -85901,7 +85901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -85992,7 +85992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -86037,7 +86037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -86197,7 +86197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -86212,14 +86212,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ef62f21829220d152fc38e0d9218b556db341c3d71e1e37ed2da38396159a110
+        config.redpanda.com/checksum: b2185a25f424fed359b7578be087ac935ca3f98fe49eb7ddebe4ef7e9f7f923e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -86513,7 +86513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -86539,7 +86539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -86565,7 +86565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -86603,7 +86603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -86641,7 +86641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -86657,7 +86657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -86674,7 +86674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -86690,7 +86690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -86734,7 +86734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -86823,7 +86823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -86895,7 +86895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -86930,7 +86930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -87023,7 +87023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -87061,7 +87061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -87313,7 +87313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -87344,7 +87344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -87435,7 +87435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -87480,7 +87480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -87624,7 +87624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -87639,14 +87639,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a4c2e4ac0c4866f0a94037b706d496a31d933ad82ef1bc36b8f7dc01bd518745
+        config.redpanda.com/checksum: f94e25b0cc546e49669c4db10d7814731b68f295c9607855147db56b583f5642
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -87940,7 +87940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -87966,7 +87966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -87992,7 +87992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -88030,7 +88030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -88068,7 +88068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -88084,7 +88084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -88101,7 +88101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -88117,7 +88117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -88161,7 +88161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -88248,7 +88248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -88320,7 +88320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -88355,7 +88355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -88448,7 +88448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -88486,7 +88486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -88732,7 +88732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -88763,7 +88763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -88854,7 +88854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -88899,7 +88899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -89043,7 +89043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -89058,14 +89058,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ac3e1bf4ba3ef59edcb10806eca8b4e306b0903d9312ceb2d044e0c1487348fe
+        config.redpanda.com/checksum: 3e6050ce252e6e56ebcfa4c48ab96d632401ddc907facbefaeb182a2bda2c21c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -89359,7 +89359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -89385,7 +89385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -89411,7 +89411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -89449,7 +89449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -89487,7 +89487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -89503,7 +89503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -89520,7 +89520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -89536,7 +89536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -89580,7 +89580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -89667,7 +89667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -89746,7 +89746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -89828,7 +89828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -89921,7 +89921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -89959,7 +89959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -90205,7 +90205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -90236,7 +90236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -90327,7 +90327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -90372,7 +90372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -90532,7 +90532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -90547,14 +90547,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ef62f21829220d152fc38e0d9218b556db341c3d71e1e37ed2da38396159a110
+        config.redpanda.com/checksum: b2185a25f424fed359b7578be087ac935ca3f98fe49eb7ddebe4ef7e9f7f923e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -90848,7 +90848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -90874,7 +90874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -90900,7 +90900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -90938,7 +90938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -90976,7 +90976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -90992,7 +90992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -91009,7 +91009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -91025,7 +91025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -91069,7 +91069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -91158,7 +91158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -91237,7 +91237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -91272,7 +91272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -91365,7 +91365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -91403,7 +91403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -91655,7 +91655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -91686,7 +91686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -91777,7 +91777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -91822,7 +91822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -91966,7 +91966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -91981,14 +91981,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a4c2e4ac0c4866f0a94037b706d496a31d933ad82ef1bc36b8f7dc01bd518745
+        config.redpanda.com/checksum: f94e25b0cc546e49669c4db10d7814731b68f295c9607855147db56b583f5642
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -92282,7 +92282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -92308,7 +92308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -92334,7 +92334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -92372,7 +92372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -92410,7 +92410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -92426,7 +92426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -92443,7 +92443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -92459,7 +92459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -92503,7 +92503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -92590,7 +92590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -92669,7 +92669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -92704,7 +92704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -92797,7 +92797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -92835,7 +92835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -93083,7 +93083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -93114,7 +93114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -93205,7 +93205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -93250,7 +93250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -93394,7 +93394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -93409,14 +93409,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a40cf9251cb5e3fbbbe0073c95718a7a4daaed9902a6b98d79b99c100f6bea19
+        config.redpanda.com/checksum: 0c874b38e894ed6e0e232de93dc72ecc8516a18915df98f334957bf8f605690f
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -93710,7 +93710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -93736,7 +93736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -93762,7 +93762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -93800,7 +93800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -93838,7 +93838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -93854,7 +93854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -93871,7 +93871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -93887,7 +93887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -93931,7 +93931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -94018,7 +94018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -94097,7 +94097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -94179,7 +94179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -94272,7 +94272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -94310,7 +94310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -94558,7 +94558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -94589,7 +94589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -94680,7 +94680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -94725,7 +94725,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -94885,7 +94885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -94900,14 +94900,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -95201,7 +95201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -95227,7 +95227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -95253,7 +95253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -95291,7 +95291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -95329,7 +95329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -95345,7 +95345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -95362,7 +95362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -95378,7 +95378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -95422,7 +95422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -95511,7 +95511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -95590,7 +95590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -95625,7 +95625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -95718,7 +95718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -95756,7 +95756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -96010,7 +96010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -96041,7 +96041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -96132,7 +96132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -96177,7 +96177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -96321,7 +96321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -96336,14 +96336,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 18e52cff4ca67c93c715c559b94e79fb12b9cdbc4328b653c5e00f4988f6b91a
+        config.redpanda.com/checksum: d1daa9f6409a70bce1f8c6fa0dd61307c533eb60950f8f9d9a1efd1fba15b860
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -96637,7 +96637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -96663,7 +96663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -96689,7 +96689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -96727,7 +96727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -96765,7 +96765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -96781,7 +96781,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -96798,7 +96798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -96814,7 +96814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -96858,7 +96858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -96945,7 +96945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -97024,7 +97024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -97059,7 +97059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -97152,7 +97152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -97190,7 +97190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -97438,7 +97438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -97469,7 +97469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -97560,7 +97560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -97605,7 +97605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -97749,7 +97749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -97764,14 +97764,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a40cf9251cb5e3fbbbe0073c95718a7a4daaed9902a6b98d79b99c100f6bea19
+        config.redpanda.com/checksum: 0c874b38e894ed6e0e232de93dc72ecc8516a18915df98f334957bf8f605690f
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -98065,7 +98065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -98091,7 +98091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -98117,7 +98117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -98155,7 +98155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -98193,7 +98193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -98209,7 +98209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -98226,7 +98226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -98242,7 +98242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -98286,7 +98286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -98373,7 +98373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -98452,7 +98452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -98534,7 +98534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -98627,7 +98627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -98665,7 +98665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -98913,7 +98913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -98944,7 +98944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -99035,7 +99035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -99080,7 +99080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -99240,7 +99240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -99255,14 +99255,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -99556,7 +99556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -99582,7 +99582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -99608,7 +99608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -99646,7 +99646,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -99684,7 +99684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -99700,7 +99700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -99717,7 +99717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -99733,7 +99733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -99777,7 +99777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -99866,7 +99866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -99945,7 +99945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -99980,7 +99980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -100073,7 +100073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -100111,7 +100111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -100365,7 +100365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -100396,7 +100396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -100487,7 +100487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -100532,7 +100532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -100676,7 +100676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -100691,14 +100691,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 18e52cff4ca67c93c715c559b94e79fb12b9cdbc4328b653c5e00f4988f6b91a
+        config.redpanda.com/checksum: d1daa9f6409a70bce1f8c6fa0dd61307c533eb60950f8f9d9a1efd1fba15b860
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -100992,7 +100992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -101018,7 +101018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -101044,7 +101044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -101082,7 +101082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -101120,7 +101120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -101136,7 +101136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -101153,7 +101153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -101169,7 +101169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -101213,7 +101213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -101300,7 +101300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -101379,7 +101379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -101414,7 +101414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -101507,7 +101507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -101545,7 +101545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -101793,7 +101793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -101824,7 +101824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -101915,7 +101915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -101960,7 +101960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -102104,7 +102104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -102119,14 +102119,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -102447,7 +102447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -102534,7 +102534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -102613,7 +102613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -102648,7 +102648,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -102741,7 +102741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -102779,7 +102779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -103026,7 +103026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -103056,7 +103056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -103147,7 +103147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -103192,7 +103192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -103318,7 +103318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -103333,14 +103333,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ff44e64a0af9a16456ced762bb2fe7dc8d003636d3db29c5008fd567294b69b1
+        config.redpanda.com/checksum: 8efc4646b14dfdac6423cb36bf717272acf15525d00cd8e4b7af669874c2c121
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -103661,7 +103661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -103748,7 +103748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -103827,7 +103827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -103862,7 +103862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -103955,7 +103955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -103993,7 +103993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -104303,7 +104303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -104334,7 +104334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -104425,7 +104425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -104470,7 +104470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -104634,7 +104634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -104649,14 +104649,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 20974ddac1a7d3c3926c64276431115ab22a06f8e43f9f27c5ee015cf7febdf7
+        config.redpanda.com/checksum: 7efd62498f1a1b51e3443607a1282625226d1814a20d325205a67c54d15fffa5
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -105004,7 +105004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -105030,7 +105030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -105056,7 +105056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -105094,7 +105094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -105132,7 +105132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -105148,7 +105148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -105165,7 +105165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -105181,7 +105181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -105225,7 +105225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -105312,7 +105312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -105391,7 +105391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -105426,7 +105426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -105519,7 +105519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -105557,7 +105557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -105808,7 +105808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -105841,7 +105841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -105932,7 +105932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -105977,7 +105977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -106121,7 +106121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -106136,14 +106136,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: cb3dbc731308c1b096b02e63054a2639fc5d43eba5719fb6d129eb74a1ed6d7e
+        config.redpanda.com/checksum: bd9f2eb7edc785aa9be81ce96f09f1c6a4ca39e1dbe688d0ce4a68700b8f3ea2
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -106449,7 +106449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -106475,7 +106475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -106501,7 +106501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -106527,7 +106527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -106565,7 +106565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -106603,7 +106603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -106641,7 +106641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -106666,7 +106666,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -106682,7 +106682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -106699,7 +106699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -106715,7 +106715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -106732,7 +106732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -106748,7 +106748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -106792,7 +106792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -106885,7 +106885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -106970,7 +106970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -107005,7 +107005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -107098,7 +107098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -107136,7 +107136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -107384,7 +107384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -107415,7 +107415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -107506,7 +107506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -107551,7 +107551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -107695,7 +107695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -107710,14 +107710,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: dcfe69de7978ec8bee81f4ba4123a6c55f9192e1521ebbb5db139a59d08abba0
+        config.redpanda.com/checksum: b12f90384f49518c02506f83f2ed6f5479885f5212a5321ccc5dd65316bfe158
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -108011,7 +108011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -108037,7 +108037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -108063,7 +108063,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -108101,7 +108101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -108139,7 +108139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -108155,7 +108155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -108172,7 +108172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -108188,7 +108188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -108232,7 +108232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -108319,7 +108319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -108398,7 +108398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -108433,7 +108433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -108526,7 +108526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -108564,7 +108564,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -108810,7 +108810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -108841,7 +108841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -108932,7 +108932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -108977,7 +108977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -109121,7 +109121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -109136,14 +109136,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ac3e1bf4ba3ef59edcb10806eca8b4e306b0903d9312ceb2d044e0c1487348fe
+        config.redpanda.com/checksum: 3e6050ce252e6e56ebcfa4c48ab96d632401ddc907facbefaeb182a2bda2c21c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -109437,7 +109437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -109463,7 +109463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -109489,7 +109489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -109527,7 +109527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -109565,7 +109565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -109581,7 +109581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -109598,7 +109598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -109614,7 +109614,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -109658,7 +109658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -109745,7 +109745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -109824,7 +109824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -109906,7 +109906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -109999,7 +109999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -110037,7 +110037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -110283,7 +110283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -110314,7 +110314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -110405,7 +110405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -110450,7 +110450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -110610,7 +110610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -110625,14 +110625,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ef62f21829220d152fc38e0d9218b556db341c3d71e1e37ed2da38396159a110
+        config.redpanda.com/checksum: b2185a25f424fed359b7578be087ac935ca3f98fe49eb7ddebe4ef7e9f7f923e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -110926,7 +110926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -110952,7 +110952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -110978,7 +110978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -111016,7 +111016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -111054,7 +111054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -111070,7 +111070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -111087,7 +111087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -111103,7 +111103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -111147,7 +111147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -111236,7 +111236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -111315,7 +111315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -111350,7 +111350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -111443,7 +111443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -111481,7 +111481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -111733,7 +111733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -111764,7 +111764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -111855,7 +111855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -111900,7 +111900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -112044,7 +112044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -112059,14 +112059,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a4c2e4ac0c4866f0a94037b706d496a31d933ad82ef1bc36b8f7dc01bd518745
+        config.redpanda.com/checksum: f94e25b0cc546e49669c4db10d7814731b68f295c9607855147db56b583f5642
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -112360,7 +112360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -112386,7 +112386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -112412,7 +112412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -112450,7 +112450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -112488,7 +112488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -112504,7 +112504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -112521,7 +112521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -112537,7 +112537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -112581,7 +112581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -112668,7 +112668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -112747,7 +112747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -112782,7 +112782,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -112875,7 +112875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -112913,7 +112913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -113161,7 +113161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -113192,7 +113192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -113283,7 +113283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -113328,7 +113328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -113472,7 +113472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -113487,14 +113487,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a40cf9251cb5e3fbbbe0073c95718a7a4daaed9902a6b98d79b99c100f6bea19
+        config.redpanda.com/checksum: 0c874b38e894ed6e0e232de93dc72ecc8516a18915df98f334957bf8f605690f
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -113788,7 +113788,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -113814,7 +113814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -113840,7 +113840,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -113878,7 +113878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -113916,7 +113916,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -113932,7 +113932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -113949,7 +113949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -113965,7 +113965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -114009,7 +114009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -114096,7 +114096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -114175,7 +114175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -114257,7 +114257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -114350,7 +114350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -114388,7 +114388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -114636,7 +114636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -114667,7 +114667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -114758,7 +114758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -114803,7 +114803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -114963,7 +114963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -114978,14 +114978,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -115279,7 +115279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -115305,7 +115305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -115331,7 +115331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -115369,7 +115369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -115407,7 +115407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -115423,7 +115423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -115440,7 +115440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -115456,7 +115456,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -115500,7 +115500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -115589,7 +115589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -115668,7 +115668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -115703,7 +115703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -115796,7 +115796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -115834,7 +115834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -116088,7 +116088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -116119,7 +116119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -116210,7 +116210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -116255,7 +116255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -116399,7 +116399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -116414,14 +116414,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 18e52cff4ca67c93c715c559b94e79fb12b9cdbc4328b653c5e00f4988f6b91a
+        config.redpanda.com/checksum: d1daa9f6409a70bce1f8c6fa0dd61307c533eb60950f8f9d9a1efd1fba15b860
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -116715,7 +116715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -116741,7 +116741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -116767,7 +116767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -116805,7 +116805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -116843,7 +116843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -116859,7 +116859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -116876,7 +116876,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -116892,7 +116892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -116936,7 +116936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -117023,7 +117023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -117102,7 +117102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -117137,7 +117137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -117230,7 +117230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -117268,7 +117268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -117516,7 +117516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 ---
@@ -117547,7 +117547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-rpk
   namespace: default
 ---
@@ -117638,7 +117638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -117683,7 +117683,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external
   namespace: default
 spec:
@@ -117827,7 +117827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda
   namespace: default
 spec:
@@ -117842,14 +117842,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 73057bdc7860738b146efd0a07c03002ac83b855e0664fcfed80bd6bdfb68641
+        config.redpanda.com/checksum: 7fce856a6cc4ead73ed9d3b404ae9032db36d86fd6b589d0343c57eb9f808b56
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.8.13
+        helm.sh/chart: redpanda-5.8.14
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -118143,7 +118143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -118169,7 +118169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -118195,7 +118195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -118233,7 +118233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -118271,7 +118271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -118287,7 +118287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -118304,7 +118304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -118320,7 +118320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -118364,7 +118364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-configuration
   namespace: default
 spec:
@@ -118451,7 +118451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.8.13
+    helm.sh/chart: redpanda-5.8.14
   name: redpanda-post-upgrade
   namespace: default
 spec:


### PR DESCRIPTION
In https://github.com/redpanda-data/helm-charts/commit/2c4a9ec88a8c1114db88a409d2a9c0d25efee574 4 charts had chart application change. The problem is that users will not see this change until chart version does not change. This commit fixes that problem.