### PR TITLE
redpanda: de-duplicate truststore volume projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Added
 #### Changed
 #### Fixed
+* The `truststores` projected volume no longer duplicates entries when the same
+  trust store is specified across multiple TLS configurations.
 #### Removed
 
 ### [5.9.0](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.0) - 2024-08-09

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -107949,6 +107949,20 @@ spec:
           sources:
           - configMap:
               items:
+              - key: other.crt
+                path: configmaps/admin-cm-other.crt
+              - key: my-admin.crt
+                path: configmaps/admin-cm-my-admin.crt
+              name: admin-cm
+          - configMap:
+              items:
+              - key: ca.crt
+                path: configmaps/http-cm-ca.crt
+              - key: my-http.crt
+                path: configmaps/http-cm-my-http.crt
+              name: http-cm
+          - configMap:
+              items:
               - key: ca.crt
                 path: configmaps/my-ca-bundle-ca.crt
               name: my-ca-bundle
@@ -107957,33 +107971,10 @@ spec:
               - key: my-kafka.crt
                 path: secrets/kafka-secret-my-kafka.crt
               name: kafka-secret
-          - configMap:
-              items:
-              - key: other.crt
-                path: configmaps/admin-cm-other.crt
-              name: admin-cm
-          - configMap:
-              items:
-              - key: my-admin.crt
-                path: configmaps/admin-cm-my-admin.crt
-              name: admin-cm
-          - configMap:
-              items:
-              - key: ca.crt
-                path: configmaps/http-cm-ca.crt
-              name: http-cm
-          - configMap:
-              items:
-              - key: my-http.crt
-                path: configmaps/http-cm-my-http.crt
-              name: http-cm
           - secret:
               items:
               - key: ca.crt
                 path: secrets/sr-secret-ca.crt
-              name: sr-secret
-          - secret:
-              items:
               - key: my-sr.crt
                 path: secrets/sr-secret-my-sr.crt
               name: sr-secret

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -275,3 +275,17 @@ post_upgrade_job:
 listeners:
   admin:
     appProtocol: http
+
+-- trust-stores-only-one --
+# Showcase that trustStore may not have more than 1 property.
+# ASSERT-ERROR-CONTAINS ["Must have at most 1 properties"]
+listeners:
+  admin:
+    tls:
+      trustStore:
+        configMapKeyRef:
+          key: redpanda-truststore.pem
+          name: redpanda-truststore.crt
+        secretKeyRef:
+          key: redpanda-truststore.pem
+          name: redpanda-truststore.crt

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -958,6 +958,8 @@
                           "type": "boolean"
                         },
                         "trustStore": {
+                          "maxProperties": 1,
+                          "minProperties": 1,
                           "properties": {
                             "configMapKeyRef": {
                               "properties": {
@@ -1017,6 +1019,8 @@
                   "type": "boolean"
                 },
                 "trustStore": {
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
                     "configMapKeyRef": {
                       "properties": {
@@ -1132,6 +1136,8 @@
                           "type": "boolean"
                         },
                         "trustStore": {
+                          "maxProperties": 1,
+                          "minProperties": 1,
                           "properties": {
                             "configMapKeyRef": {
                               "properties": {
@@ -1195,6 +1201,8 @@
                   "type": "boolean"
                 },
                 "trustStore": {
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
                     "configMapKeyRef": {
                       "properties": {
@@ -1311,6 +1319,8 @@
                           "type": "boolean"
                         },
                         "trustStore": {
+                          "maxProperties": 1,
+                          "minProperties": 1,
                           "properties": {
                             "configMapKeyRef": {
                               "properties": {
@@ -1370,6 +1380,8 @@
                   "type": "boolean"
                 },
                 "trustStore": {
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
                     "configMapKeyRef": {
                       "properties": {
@@ -1433,6 +1445,8 @@
                   "type": "boolean"
                 },
                 "trustStore": {
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
                     "configMapKeyRef": {
                       "properties": {
@@ -1545,6 +1559,8 @@
                           "type": "boolean"
                         },
                         "trustStore": {
+                          "maxProperties": 1,
+                          "minProperties": 1,
                           "properties": {
                             "configMapKeyRef": {
                               "properties": {
@@ -1605,6 +1621,8 @@
                   "type": "boolean"
                 },
                 "trustStore": {
+                  "maxProperties": 1,
+                  "minProperties": 1,
                   "properties": {
                     "configMapKeyRef": {
                       "properties": {

--- a/charts/redpanda/values_test.go
+++ b/charts/redpanda/values_test.go
@@ -1,0 +1,511 @@
+package redpanda
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+func TestListeners_TrustStoreVolumes(t *testing.T) {
+	// Closures for more terse definitions.
+	cmKeyRef := func(name, key string) *corev1.ConfigMapKeySelector {
+		return &corev1.ConfigMapKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+			Key: key,
+		}
+	}
+
+	sKeyRef := func(name, key string) *corev1.SecretKeySelector {
+		return &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{
+				Name: name,
+			},
+			Key: key,
+		}
+	}
+
+	// Common TLS used by all cases.
+	tls := TLS{
+		Enabled: true,
+		Certs: TLSCertMap{
+			"disabled": TLSCert{Enabled: ptr.To(false)},
+			"enabled":  TLSCert{Enabled: ptr.To(true)},
+		},
+	}
+
+	cases := []struct {
+		Name      string
+		Listeners Listeners
+		Out       *corev1.Volume
+	}{
+		{Name: "zeros"},
+		{
+			Name: "all unique secrets",
+			Listeners: Listeners{
+				Admin: AdminListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+					},
+					External: ExternalListeners[AdminExternal]{
+						"admin-1": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-2", "KEY-2")},
+							},
+						},
+					},
+				},
+				Kafka: KafkaListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-3", "KEY-3")},
+					},
+					External: ExternalListeners[KafkaExternal]{
+						"kafka-1": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-4", "KEY-4")},
+							},
+						},
+					},
+				},
+				HTTP: HTTPListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-5", "KEY-5")},
+					},
+					External: ExternalListeners[HTTPExternal]{
+						"http-1": HTTPExternal{
+							Port: 999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-6", "KEY-6")},
+							},
+						},
+					},
+				},
+			},
+			Out: &corev1.Volume{
+				Name: "truststores",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-1"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "secrets/SECRET-1-KEY-1"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-2"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-2", Path: "secrets/SECRET-2-KEY-2"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-3"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-3", Path: "secrets/SECRET-3-KEY-3"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-4"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-4", Path: "secrets/SECRET-4-KEY-4"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-5"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-5", Path: "secrets/SECRET-5-KEY-5"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-6"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-6", Path: "secrets/SECRET-6-KEY-6"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "all unique configmaps",
+			Listeners: Listeners{
+				Admin: AdminListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+					},
+					External: ExternalListeners[AdminExternal]{
+						"admin-1": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-2", "KEY-2")},
+							},
+						},
+					},
+				},
+				Kafka: KafkaListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-3", "KEY-3")},
+					},
+					External: ExternalListeners[KafkaExternal]{
+						"kafka-1": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-4", "KEY-4")},
+							},
+						},
+					},
+				},
+				HTTP: HTTPListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-5", "KEY-5")},
+					},
+					External: ExternalListeners[HTTPExternal]{
+						"http-1": HTTPExternal{
+							Port: 999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-6", "KEY-6")},
+							},
+						},
+					},
+				},
+			},
+			Out: &corev1.Volume{
+				Name: "truststores",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-1"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "configmaps/CM-1-KEY-1"},
+								},
+							}},
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-2"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-2", Path: "configmaps/CM-2-KEY-2"},
+								},
+							}},
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-3"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-3", Path: "configmaps/CM-3-KEY-3"},
+								},
+							}},
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-4"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-4", Path: "configmaps/CM-4-KEY-4"},
+								},
+							}},
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-5"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-5", Path: "configmaps/CM-5-KEY-5"},
+								},
+							}},
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-6"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-6", Path: "configmaps/CM-6-KEY-6"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "all duplicate secrets",
+			Listeners: Listeners{
+				Admin: AdminListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+					},
+					External: ExternalListeners[AdminExternal]{
+						"admin-1": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+							},
+						},
+					},
+				},
+				Kafka: KafkaListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+					},
+					External: ExternalListeners[KafkaExternal]{
+						"kafka-1": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+							},
+						},
+					},
+				},
+				HTTP: HTTPListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+					},
+					External: ExternalListeners[HTTPExternal]{
+						"http-1": HTTPExternal{
+							Port: 999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+							},
+						},
+					},
+				},
+			},
+			Out: &corev1.Volume{
+				Name: "truststores",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-1"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "secrets/SECRET-1-KEY-1"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "all duplicate configmaps",
+			Listeners: Listeners{
+				Admin: AdminListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+					},
+					External: ExternalListeners[AdminExternal]{
+						"admin-1": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+							},
+						},
+					},
+				},
+				Kafka: KafkaListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+					},
+					External: ExternalListeners[KafkaExternal]{
+						"kafka-1": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+							},
+						},
+					},
+				},
+				HTTP: HTTPListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+					},
+					External: ExternalListeners[HTTPExternal]{
+						"http-1": HTTPExternal{
+							Port: 999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+							},
+						},
+					},
+				},
+			},
+			Out: &corev1.Volume{
+				Name: "truststores",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-1"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "configmaps/CM-1-KEY-1"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "mixture",
+			Listeners: Listeners{
+				Admin: AdminListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+					},
+					External: ExternalListeners[AdminExternal]{
+						"admin-1": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-1")},
+							},
+						},
+						"admin-2": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-2")},
+							},
+						},
+						"admin-3": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("disabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-3")},
+							},
+						},
+						"admin-4": AdminExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-2", "KEY-1")},
+							},
+						},
+					},
+				},
+				Kafka: KafkaListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+					},
+					External: ExternalListeners[KafkaExternal]{
+						"kafka-1": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+							},
+						},
+						"kafka-2": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-2")},
+							},
+						},
+						"kafka-3": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("disabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-3")},
+							},
+						},
+						"kafka-4": KafkaExternal{
+							Port: 9999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-2", "KEY-1")},
+							},
+						},
+					},
+				},
+				HTTP: HTTPListeners{
+					TLS: InternalTLS{
+						Cert:       "enabled",
+						TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-2", "KEY-2")},
+					},
+					External: ExternalListeners[HTTPExternal]{
+						"http-1": HTTPExternal{
+							Port: 999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{SecretKeyRef: sKeyRef("SECRET-1", "KEY-1")},
+							},
+						},
+						"http-2": HTTPExternal{
+							Port: 999,
+							TLS: &ExternalTLS{
+								Cert:       ptr.To("enabled"),
+								TrustStore: &TrustStore{ConfigMapKeyRef: cmKeyRef("CM-1", "KEY-2")},
+							},
+						},
+					},
+				},
+			},
+			Out: &corev1.Volume{
+				Name: "truststores",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						Sources: []corev1.VolumeProjection{
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-1"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "configmaps/CM-1-KEY-1"},
+									{Key: "KEY-2", Path: "configmaps/CM-1-KEY-2"},
+									{Key: "KEY-3", Path: "configmaps/CM-1-KEY-3"},
+								},
+							}},
+							{ConfigMap: &corev1.ConfigMapProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "CM-2"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "configmaps/CM-2-KEY-1"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-1"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "secrets/SECRET-1-KEY-1"},
+									{Key: "KEY-2", Path: "secrets/SECRET-1-KEY-2"},
+									{Key: "KEY-3", Path: "secrets/SECRET-1-KEY-3"},
+								},
+							}},
+							{Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "SECRET-2"},
+								Items: []corev1.KeyToPath{
+									{Key: "KEY-1", Path: "secrets/SECRET-2-KEY-1"},
+									{Key: "KEY-2", Path: "secrets/SECRET-2-KEY-2"},
+								},
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			vol := tc.Listeners.TrustStoreVolume(&tls)
+			require.Equal(t, tc.Out, vol)
+		})
+	}
+}

--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -78,10 +78,12 @@ func TrimPrefix(prefix, s string) string {
 	return s
 }
 
-// SortAlpha is the go equivalent of sprig's `sortAlpha`
+// SortAlpha is the go equivalent of sprig's `sortAlpha`.
+// It mutates the provided slice in place and returns the mutated slice.
 // +gotohelm:builtin=sortAlpha
-func SortAlpha(x []string) {
+func SortAlpha(x []string) []string {
 	sort.Strings(x)
+	return x
 }
 
 // Printf is the go equivalent of text/templates's `printf`
@@ -461,4 +463,11 @@ func RandAlphaNum(length int) string {
 // +gotohelm:builtin=replace
 func Replace(old, new, s string) string {
 	return strings.ReplaceAll(s, old, new)
+}
+
+// SortedKeys is a convenience function to aid in iterating over maps in a
+// deterministic order.
+func SortedKeys[T any](m map[string]T) []string {
+	keys := Keys(m)
+	return SortAlpha(keys)
 }

--- a/pkg/gotohelm/transpiler.go
+++ b/pkg/gotohelm/transpiler.go
@@ -1076,6 +1076,8 @@ func (t *Transpiler) transpileCallExpr(n *ast.CallExpr) Node {
 	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.MergeTo":
 		dict := DictLiteral{}
 		return &BuiltInCall{FuncName: "merge", Arguments: append([]Node{&dict}, args...)}
+	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.SortedKeys":
+		return &BuiltInCall{FuncName: "sortAlpha", Arguments: []Node{&BuiltInCall{FuncName: "keys", Arguments: args}}}
 
 	case "github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette.Lookup":
 		// Super ugly but it's fairly safe to assume that the return type of


### PR DESCRIPTION
Prior to this commit, the `truststores` projected volume would contain a `VolumeProjection` per configured truststore. This is considered invalid by the Kubernetes API due to `conflicting duplicate paths`

This commit updates `Listeners.TrustStoreVolume` to de-duplicate the synthesized projections by type (configmap or secret), object name, and key.

It also updates the validation of `TrustStore`s to only accept one of `ConfigMapKeyRef` or `SecretKeyRef`.