### PR TITLE
release: redpanda 5.9.1 and console 0.7.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 #### Added
 #### Changed
 #### Fixed
+#### Removed
+
+### [5.9.1](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.1) - 2024-8-19
+#### Added
+#### Changed
+#### Fixed
 * The `truststores` projected volume no longer duplicates entries when the same
   trust store is specified across multiple TLS configurations.
 #### Removed
@@ -150,7 +156,13 @@
 
 ## Console Chart
 
-### [0.7.29](https://github.com/redpanda-data/helm-charts/releases/tag/console-0.7.29) - 2024-08-09
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/console-FILLMEIN) - YYYY-MM-DD
+#### Added
+#### Changed
+#### Fixed
+#### Removed
+
+### [0.7.29](https://github.com/redpanda-data/helm-charts/releases/tag/console-0.7.29) - 2024-08-19
 #### Added
 #### Changed
 #### Fixed

--- a/charts/console/Chart.yaml
+++ b/charts/console/Chart.yaml
@@ -27,7 +27,7 @@ type: application
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
 # Chart versions do not track appVersion
-version: 0.7.28
+version: 0.7.29
 
 # The app version is the version of the Chart application
 appVersion: v2.7.0

--- a/charts/console/README.md
+++ b/charts/console/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Console Helm chart.
 ---
 
-![Version: 0.7.28](https://img.shields.io/badge/Version-0.7.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.7.0](https://img.shields.io/badge/AppVersion-v2.7.0-informational?style=flat-square)
+![Version: 0.7.29](https://img.shields.io/badge/Version-0.7.29-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.7.0](https://img.shields.io/badge/AppVersion-v2.7.0-informational?style=flat-square)
 
 This page describes the official Redpanda Console Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/console/values.yaml).
 Each of the settings is listed and described on this page, along with any default values.

--- a/charts/console/testdata/template-cases.golden.txtar
+++ b/charts/console/testdata/template-cases.golden.txtar
@@ -12,7 +12,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -26,7 +26,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -68,7 +68,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -82,7 +82,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -107,7 +107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -120,7 +120,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -202,7 +202,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 spec:
   maxReplicas: 100
@@ -236,7 +236,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -261,7 +261,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -275,7 +275,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -317,7 +317,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -331,7 +331,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -356,7 +356,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -369,7 +369,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -451,7 +451,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 spec:
   maxReplicas: 100
@@ -479,7 +479,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -504,7 +504,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -518,7 +518,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -560,7 +560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -599,7 +599,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -612,7 +612,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -694,7 +694,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 spec:
   maxReplicas: 100
@@ -722,7 +722,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -748,7 +748,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: HRoLg
   namespace: default
 ---
@@ -763,7 +763,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: hvGoJL
 stringData:
   enterprise-license: ""
@@ -806,7 +806,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: hvGoJL
 ---
 # Source: console/templates/service.yaml
@@ -821,7 +821,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: hvGoJL
   namespace: default
 spec:
@@ -848,7 +848,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: hvGoJL
   namespace: default
 spec:
@@ -862,7 +862,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4d79c346f1615f1c562cce2aa870eae018d6f9516524773711b393a45bf7b6f0
+        checksum/config: a2b60d22337ad49c09f2108d08f05fc6590bc4b45c804adc901467f348d564e1
         lyW: mn
         pjq6fDr: YA2w301
         uXvFB: VQ5gP9
@@ -956,7 +956,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "n"
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -981,7 +981,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: T50cZi
   namespace: default
 ---
@@ -995,7 +995,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: T50cZi
 stringData:
   enterprise-license: ""
@@ -1037,7 +1037,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: T50cZi
 ---
 # Source: console/templates/service.yaml
@@ -1051,7 +1051,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: T50cZi
   namespace: default
 spec:
@@ -1076,7 +1076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: T50cZi
   namespace: default
 spec:
@@ -1089,7 +1089,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: f3da1b9e3c3fdf2e6d552ca2f8c82987b53a2bce60b7cadb10606c4805ef4464
+        checksum/config: 6eb5d8456a652d5006051c8425191238a1a7d39e93a9336b0cc8ca98963c2dbd
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Sh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1248,7 +1248,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: R1Yar8
   namespace: default
 ---
@@ -1262,7 +1262,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: xZty
 stringData:
   enterprise-license: ""
@@ -1304,7 +1304,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: xZty
 ---
 # Source: console/templates/service.yaml
@@ -1318,7 +1318,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: xZty
   namespace: default
 spec:
@@ -1343,7 +1343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: xZty
   namespace: default
 spec:
@@ -1358,7 +1358,7 @@ spec:
       annotations:
         8vRMfVroYC2: QXbUbLea
         VV4w: s4sL
-        checksum/config: 51238341ec0ec788abcdcf4aded2fd407aa7a516589a36fb44edf15882abb489
+        checksum/config: 69703ab54946efe744831224dacdb980663f666d8fa5be794fb800135f91d11f
         upwTMuIqflmD: 9J0H45zXX
       creationTimestamp: null
       labels:
@@ -1470,7 +1470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vN4yH7I
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1498,7 +1498,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 8nE
   namespace: default
 ---
@@ -1512,7 +1512,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 8nE
 stringData:
   enterprise-license: ""
@@ -1551,7 +1551,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 8nE
   namespace: default
 spec:
@@ -1576,7 +1576,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 8nE
 spec:
   ingressClassName: EqUYi
@@ -1612,7 +1612,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1638,7 +1638,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console-YMl
   namespace: default
 ---
@@ -1653,7 +1653,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console-YMl
 stringData:
   enterprise-license: ""
@@ -1696,7 +1696,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console-YMl
 ---
 # Source: console/templates/service.yaml
@@ -1711,7 +1711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console-YMl
   namespace: default
 spec:
@@ -1737,7 +1737,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console-YMl
   namespace: default
 spec:
@@ -1754,7 +1754,7 @@ spec:
         1iK8Ic: Qo3FCg9qi
         63SsVxDT: v
         A1Q4J4: U9jygY2t1F
-        checksum/config: 6c11baa5b6c443ddde429f378f8519fe926a6ce83adc5c2b8725a48da242275d
+        checksum/config: 5f83295c905c2d3c9fea06172a38428a89334248aea9df0ebd8b589a29afeb4f
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -1852,7 +1852,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: YMl
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -1877,7 +1877,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: pN
   namespace: default
 ---
@@ -1891,7 +1891,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: pN
 stringData:
   enterprise-license: ""
@@ -1930,7 +1930,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: pN
   namespace: default
 spec:
@@ -1955,7 +1955,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: pN
   namespace: default
 spec:
@@ -2078,7 +2078,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -2106,7 +2106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: nd7TSb2mNTS
   namespace: default
 ---
@@ -2120,7 +2120,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: rzd
 stringData:
   enterprise-license: ""
@@ -2162,7 +2162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: rzd
 ---
 # Source: console/templates/service.yaml
@@ -2176,7 +2176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: rzd
   namespace: default
 spec:
@@ -2201,7 +2201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: gCH15URsJZr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: rzd
   namespace: default
 spec:
@@ -2214,7 +2214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1c9ca70fd0490075c73fb37fa1aebe0e05ce219e6b0252706edeb0ca5c7b4c22
+        checksum/config: f55f3fdc49a4774db4d2377ea9b69fd8da2a190ef99f7fb31aeb393215f878cc
         s2D: DMU7
       creationTimestamp: null
       labels:
@@ -2348,7 +2348,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: RFjc7
   namespace: default
 ---
@@ -2364,7 +2364,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: "y"
 stringData:
   enterprise-license: ""
@@ -2412,7 +2412,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: "y"
 ---
 # Source: console/templates/service.yaml
@@ -2428,7 +2428,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: "y"
   namespace: default
 spec:
@@ -2455,7 +2455,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: "y"
   namespace: default
 spec:
@@ -2468,7 +2468,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 81e4afac9f2930b0146112b1085e956348b0dd2fbd30b5cb4736dffff66a65b7
+        checksum/config: 37ddb9195e66f6743cc901bea8e2e2db0492fbf3e78355ffe8c7f2395ece1e90
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -2609,7 +2609,7 @@ metadata:
     app.kubernetes.io/version: v2.7.0
     cV05TKdtF: 55lItpeJD
     h: 1Y7dqm4wZL
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -2634,7 +2634,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: YcV5zP8
   namespace: default
 ---
@@ -2652,7 +2652,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GbgHqD
 ---
 # Source: console/templates/service.yaml
@@ -2666,7 +2666,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GbgHqD
   namespace: default
 spec:
@@ -2692,7 +2692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GbgHqD
   namespace: default
 spec:
@@ -2709,7 +2709,7 @@ spec:
       annotations:
         BTlN: z8t
         a: Pqjhw
-        checksum/config: 98bfe8f5049393bb5c9506d85cb0584dec2668240625cf4137e77481281f9b63
+        checksum/config: 1ba99bb938e262d91c73069e0caf6c1ce45d5e92491a50db9d1af5d59db59aed
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -2814,7 +2814,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -2839,7 +2839,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: l1Bnpx
   namespace: default
 ---
@@ -2853,7 +2853,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: l1Bnpx
 stringData:
   enterprise-license: ""
@@ -2893,7 +2893,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: l1Bnpx
   namespace: default
 spec:
@@ -2918,7 +2918,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: l1Bnpx
   namespace: default
 spec:
@@ -3052,7 +3052,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BKV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -3081,7 +3081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: kIzbDF
   namespace: default
 ---
@@ -3096,7 +3096,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: ivK
   namespace: default
 spec:
@@ -3121,7 +3121,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: ivK
   namespace: default
 spec:
@@ -3359,7 +3359,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: JFcK
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -3385,7 +3385,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     v7E: 1g6JB
   name: hbe
   namespace: default
@@ -3401,7 +3401,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     v7E: 1g6JB
   name: hbe
 stringData:
@@ -3445,7 +3445,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     v7E: 1g6JB
   name: hbe
 ---
@@ -3464,7 +3464,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     v7E: 1g6JB
   name: hbe
   namespace: default
@@ -3492,7 +3492,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     v7E: 1g6JB
   name: hbe
   namespace: default
@@ -3506,7 +3506,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0148411fb09ec208314ae612e4a8e16f14c0036488436469a3f176f69e13ae5c
+        checksum/config: 0ebeace369c9c96d75109609694bd464d6c28c2e8d1fcbd96529ef96d4ba0ec5
       creationTimestamp: null
       labels:
         "2": RgUAFm
@@ -3711,7 +3711,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cy9eHCiP
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     v7E: 1g6JB
   annotations:
     "helm.sh/hook": test
@@ -3737,7 +3737,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: tmn2Kt
   namespace: default
 ---
@@ -3751,7 +3751,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: tmn2Kt
 stringData:
   enterprise-license: ""
@@ -3793,7 +3793,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: tmn2Kt
 ---
 # Source: console/templates/service.yaml
@@ -3807,7 +3807,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: tmn2Kt
   namespace: default
 spec:
@@ -3833,7 +3833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: tmn2Kt
   namespace: default
 spec:
@@ -3848,7 +3848,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 72503e3096e68df0bea4bba42b85d47506b39d3455905aa36090fa6374f77092
+        checksum/config: f03a44f92485e3dfb6772dc84dec7c868a151f08fa5c04332bebe63251290ce5
       creationTimestamp: null
       labels:
         "": S7BNyT
@@ -4081,7 +4081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Qr03ts
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4106,7 +4106,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: RttlJN
   namespace: default
 ---
@@ -4120,7 +4120,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: RttlJN
 stringData:
   enterprise-license: ""
@@ -4162,7 +4162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: RttlJN
 ---
 # Source: console/templates/service.yaml
@@ -4176,7 +4176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: RttlJN
   namespace: default
 spec:
@@ -4201,7 +4201,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: RttlJN
   namespace: default
 spec:
@@ -4214,7 +4214,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: da29a8cb4c51f5d64438e3ac400929dfa3f6bc869d4e584d70bbacce16aa1446
+        checksum/config: 80fd97b611d09c692bd5e12a12d43f51c7486213c5798a4f57bb8f0866119572
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -4386,7 +4386,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dDkIKgMwXv
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4411,7 +4411,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: h6eHrUr
   namespace: default
 ---
@@ -4425,7 +4425,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: htymHJ
 stringData:
   enterprise-license: ""
@@ -4470,7 +4470,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: htymHJ
 ---
 # Source: console/templates/service.yaml
@@ -4484,7 +4484,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: htymHJ
   namespace: default
 spec:
@@ -4509,7 +4509,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vi2vH
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4540,7 +4540,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: zmr
   namespace: default
 ---
@@ -4557,7 +4557,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9RweMGWqBs
 stringData:
   enterprise-license: ""
@@ -4602,7 +4602,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9RweMGWqBs
 ---
 # Source: console/templates/service.yaml
@@ -4619,7 +4619,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9RweMGWqBs
   namespace: default
 spec:
@@ -4649,7 +4649,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9RweMGWqBs
   namespace: default
 spec:
@@ -4662,7 +4662,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 89b8b14952a64a91be46ca64548102b3c4e5d7e9448f68fd2a5cbc2839b20ecf
+        checksum/config: c07b76ad8263a0560734a09b913b4c726efe461a7f519da293467d20a90d78bf
       creationTimestamp: null
       labels:
         FlwBgvWNMrbg5: YKgnz8q
@@ -4898,7 +4898,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9RweMGWqBs
 spec:
   ingressClassName: x7Um
@@ -4936,7 +4936,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: KD8DmV
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -4961,7 +4961,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: DdF7ALq
   namespace: default
 ---
@@ -4975,7 +4975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 6maz
 stringData:
   enterprise-license: ""
@@ -5021,7 +5021,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 6maz
 ---
 # Source: console/templates/service.yaml
@@ -5035,7 +5035,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 6maz
   namespace: default
 spec:
@@ -5060,7 +5060,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 6maz
   namespace: default
 spec:
@@ -5076,7 +5076,7 @@ spec:
     metadata:
       annotations:
         JYLUc483y: gTnWiG
-        checksum/config: e429e656db2e1c97b6a97e3921a12b0ca799c535988dfb2b73fe36f45e6195f0
+        checksum/config: e4b69acb9132e0c7dea94f0e868bb2c5850883e5487d4cca28762798c1b9dda6
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -5344,7 +5344,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: SC
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -5369,7 +5369,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9XG3SZW
   namespace: default
 ---
@@ -5383,7 +5383,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9XG3SZW
 stringData:
   enterprise-license: ""
@@ -5432,7 +5432,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9XG3SZW
 ---
 # Source: console/templates/service.yaml
@@ -5446,7 +5446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9XG3SZW
   namespace: default
 spec:
@@ -5474,7 +5474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPiY
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9XG3SZW
   namespace: default
 spec:
@@ -5487,7 +5487,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3eb2fbb601826cbe114d7e5eaec52ab12612e8ca25ce40a479589655bfbe4d9e
+        checksum/config: a9353e622b2ed64d835d05830dc4357d8eb982e89685498d39ac88a30931fb87
       creationTimestamp: null
       labels:
         LBQpbD: AHB4hNVL
@@ -5919,7 +5919,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: uAvlOXf
   namespace: default
 ---
@@ -5933,7 +5933,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: ExFU3
 stringData:
   enterprise-license: ""
@@ -5972,7 +5972,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: ExFU3
   namespace: default
 spec:
@@ -5998,7 +5998,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: ExFU3
   namespace: default
 spec:
@@ -6322,7 +6322,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 1qyLP36T
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -6349,7 +6349,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: NZ7h9
   namespace: default
 ---
@@ -6363,7 +6363,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: NZ7h9
 stringData:
   enterprise-license: ""
@@ -6405,7 +6405,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: NZ7h9
 ---
 # Source: console/templates/service.yaml
@@ -6419,7 +6419,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: NZ7h9
   namespace: default
 spec:
@@ -6446,7 +6446,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: NZ7h9
   namespace: default
 spec:
@@ -6460,7 +6460,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 8396f31cb885da546f7d4cae89a320d04a6740165990ee9dfce3e1062d5541c4
+        checksum/config: 9960ac5c5faddbc59ee9638bfac7f4fd7513b7e295e3fcc28b0fdfabc2aba1d3
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -6588,7 +6588,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8MIg
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -6616,7 +6616,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: HMpc
   namespace: default
 ---
@@ -6630,7 +6630,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Om7
 stringData:
   enterprise-license: ""
@@ -6672,7 +6672,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Om7
 ---
 # Source: console/templates/service.yaml
@@ -6686,7 +6686,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Om7
   namespace: default
 spec:
@@ -6714,7 +6714,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Om7
   namespace: default
 spec:
@@ -6729,7 +6729,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 3ebf36dac8210b6626a11e9833b6f27eaa4d9abea70935482b8ffdebc6bba767
+        checksum/config: 2881fbe0f4a9d0f2f17dbbbe515c08d46dd6d4a6d2c84c3482c94ace8ee6b09f
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -7107,7 +7107,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: zzmAR9
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -7138,7 +7138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: tW
   namespace: default
 ---
@@ -7154,7 +7154,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: PhRk
 stringData:
   enterprise-license: ""
@@ -7198,7 +7198,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: PhRk
 ---
 # Source: console/templates/service.yaml
@@ -7217,7 +7217,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: PhRk
   namespace: default
 spec:
@@ -7243,7 +7243,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: PhRk
 spec:
   maxReplicas: 421
@@ -7279,7 +7279,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Rys
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -7304,7 +7304,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GVjeLRc
   namespace: default
 ---
@@ -7318,7 +7318,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GVjeLRc
 stringData:
   enterprise-license: ""
@@ -7360,7 +7360,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GVjeLRc
 ---
 # Source: console/templates/service.yaml
@@ -7374,7 +7374,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GVjeLRc
   namespace: default
 spec:
@@ -7400,7 +7400,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: GVjeLRc
   namespace: default
 spec:
@@ -7413,7 +7413,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 49e1007447bb73e6e3c39dae1a4e364b2a16d80ffac111ad8510a520b98fb55a
+        checksum/config: f3ed29e7a330982454d8f2c70e966a490754ec6c90cc2663ffe058f58de132fe
       creationTimestamp: null
       labels:
         "": thv6Fja
@@ -7948,7 +7948,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xNnu
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -7977,7 +7977,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Pga
   namespace: default
 ---
@@ -7991,7 +7991,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: fXCb
 stringData:
   enterprise-license: ""
@@ -8033,7 +8033,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: fXCb
   namespace: default
 spec:
@@ -8058,7 +8058,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: fXCb
   namespace: default
 spec:
@@ -8336,7 +8336,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: fXCb
 spec:
   ingressClassName: r3Vd
@@ -8364,7 +8364,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s3YOF
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -8389,7 +8389,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wpq
   namespace: default
 ---
@@ -8415,7 +8415,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wpq
 ---
 # Source: console/templates/service.yaml
@@ -8429,7 +8429,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wpq
   namespace: default
 spec:
@@ -8454,7 +8454,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: aD
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -8481,7 +8481,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: H5TDAALUdD
   namespace: default
 ---
@@ -8496,7 +8496,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Uo
   namespace: default
 spec:
@@ -8523,7 +8523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Uo
   namespace: default
 spec:
@@ -9042,7 +9042,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Mh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9075,7 +9075,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     kuKPk7: ""
   name: Utu8ZHG2
   namespace: default
@@ -9092,7 +9092,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     kuKPk7: ""
   name: qhaD
   namespace: default
@@ -9119,7 +9119,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     kuKPk7: ""
   name: qhaD
   namespace: default
@@ -9329,7 +9329,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: vLjrafvp
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     kuKPk7: ""
   name: qhaD
 spec:
@@ -9393,7 +9393,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 55C9f3
   namespace: default
 ---
@@ -9413,7 +9413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 61hunk
   namespace: default
 spec:
@@ -9442,7 +9442,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 61hunk
 spec:
   ingressClassName: Ijdd3
@@ -9476,7 +9476,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: h9P
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9502,7 +9502,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: odFI2M4
 stringData:
   enterprise-license: ""
@@ -9545,7 +9545,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: odFI2M4
 ---
 # Source: console/templates/service.yaml
@@ -9560,7 +9560,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: odFI2M4
   namespace: default
 spec:
@@ -9587,7 +9587,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: odFI2M4
   namespace: default
 spec:
@@ -9603,7 +9603,7 @@ spec:
     metadata:
       annotations:
         YefFO9J: uVUZra
-        checksum/config: 4d168656d2acc7b7ab020bde7de7f28ec55a326622c03c15201466f39d8d20f9
+        checksum/config: cc3f7478d926a8c80ab516ac0060a56c87bbbfdd227b765567fa8644fbee7f09
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -9892,7 +9892,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 5XQu4RW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -9919,7 +9919,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     xi7L: ibI45
   name: HK
 stringData:
@@ -9967,7 +9967,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     xi7L: ibI45
   name: HK
 ---
@@ -9984,7 +9984,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     xi7L: ibI45
   name: HK
   namespace: default
@@ -10014,7 +10014,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     xi7L: ibI45
   name: HK
   namespace: default
@@ -10030,7 +10030,7 @@ spec:
     metadata:
       annotations:
         IVy: ho3qpcI
-        checksum/config: 97e3f588bff317f5f128f5456ad7e11fd3ac9cc9f7c94661dd5f0f969ce44782
+        checksum/config: ed80a6573dafe73ab884b6322e9c75c1018d618e61286f9e61f445266092293d
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -10523,7 +10523,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 3Wh
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     xi7L: ibI45
   annotations:
     "helm.sh/hook": test
@@ -10548,7 +10548,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   name: G9
@@ -10590,7 +10590,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   name: G9
@@ -10617,7 +10617,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   name: G9
@@ -10654,7 +10654,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: J
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     jwrBMvwfg: K6I5HsI5
     nk8eJc: nS
   annotations:
@@ -10692,7 +10692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10708,7 +10708,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10734,7 +10734,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10773,7 +10773,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   name: 59cQ0qKLI
@@ -10827,7 +10827,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xknw
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     q4ZdG9q: IJWaYu9mhun
     sFTTcyl: qVyaa0ULC
   annotations:
@@ -10878,7 +10878,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: llK4G
 ---
 # Source: console/templates/service.yaml
@@ -10895,7 +10895,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: llK4G
   namespace: default
 spec:
@@ -10924,7 +10924,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: llK4G
   namespace: default
 spec:
@@ -10939,7 +10939,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: addd15aebefe821ad790d549812038b55b80a32bba7dac342f7c0f51b99a57c5
+        checksum/config: ae52af057e6331e5caa1d321881f906df93659aa45a5458c4dd4ae890cf7695b
       creationTimestamp: null
       labels:
         So: waKMMvnY
@@ -11566,7 +11566,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: llK4G
 spec:
   maxReplicas: 459
@@ -11605,7 +11605,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: llK4G
 spec:
   ingressClassName: EXqR
@@ -11646,7 +11646,7 @@ metadata:
     app.kubernetes.io/name: wB
     app.kubernetes.io/version: v2.7.0
     e3Cx: MIAO
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -11684,7 +11684,7 @@ metadata:
     app.kubernetes.io/name: bCPeYVWao
     app.kubernetes.io/version: v2.7.0
     gZ85uw3T: e
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     qO: F4dqLo67vKYZ
   name: foGC
 ---
@@ -11701,7 +11701,7 @@ metadata:
     app.kubernetes.io/name: bCPeYVWao
     app.kubernetes.io/version: v2.7.0
     gZ85uw3T: e
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     qO: F4dqLo67vKYZ
   name: foGC
   namespace: default
@@ -11728,7 +11728,7 @@ metadata:
     app.kubernetes.io/name: bCPeYVWao
     app.kubernetes.io/version: v2.7.0
     gZ85uw3T: e
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     qO: F4dqLo67vKYZ
   name: foGC
   namespace: default
@@ -11744,7 +11744,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4bd951e2ea99ae35bbae73a9cbc4831b9de42e51937a69a14fdaa73dc3b4b5d5
+        checksum/config: b3a4b261d0705e207d46ac15067d5c7d7c951cf0c0fa7736607331369bd47b6d
       creationTimestamp: null
       labels:
         1bb6: ""
@@ -12732,7 +12732,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: QxrM
   namespace: default
 ---
@@ -12766,7 +12766,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: l
 ---
 # Source: console/templates/service.yaml
@@ -12784,7 +12784,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: l
   namespace: default
 spec:
@@ -12811,7 +12811,7 @@ metadata:
     app.kubernetes.io/name: zE
     app.kubernetes.io/version: v2.7.0
     blGSa: Hnim0SflkfpF
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -12844,7 +12844,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: HMyYp
   namespace: default
 ---
@@ -12870,7 +12870,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Bv0I
 ---
 # Source: console/templates/service.yaml
@@ -12888,7 +12888,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Bv0I
   namespace: default
 spec:
@@ -12916,7 +12916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Bv0I
   namespace: default
 spec:
@@ -12931,7 +12931,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 0953fcff51ae843d22ee102733a93b568a91617d7c304d4905d2cbccf64ff825
+        checksum/config: 6556f5b75614fc7b5556cf3e548fa463f543604a0e97446ccd74584bf794de97
       creationTimestamp: null
       labels:
         Klzm: we
@@ -13842,7 +13842,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Bv0I
 spec:
   ingressClassName: vg
@@ -13916,7 +13916,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -13945,7 +13945,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: AumW
 stringData:
   enterprise-license: ""
@@ -13987,7 +13987,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: AumW
   namespace: default
 spec:
@@ -14018,7 +14018,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 9mG8n4Wu4
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: AumW
   namespace: default
 spec:
@@ -14938,7 +14938,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     uEVMkDkYRvnn: zvptNai
   name: ItYso
   namespace: default
@@ -14971,7 +14971,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
 ---
@@ -14988,7 +14988,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
   namespace: default
@@ -15017,7 +15017,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     uEVMkDkYRvnn: zvptNai
   name: ADIhC
 spec:
@@ -15082,7 +15082,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: u2r6
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     uEVMkDkYRvnn: zvptNai
   annotations:
     "helm.sh/hook": test
@@ -15112,7 +15112,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: fP77cJ3T
   namespace: default
 ---
@@ -15138,7 +15138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: j1dUk8TGy8Np
 ---
 # Source: console/templates/service.yaml
@@ -15152,7 +15152,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: j1dUk8TGy8Np
   namespace: default
 spec:
@@ -15177,7 +15177,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ld
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -15207,7 +15207,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 8s2qVhKEW
   namespace: default
 ---
@@ -15230,7 +15230,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: bbshm
 ---
 # Source: console/templates/service.yaml
@@ -15247,7 +15247,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: bbshm
   namespace: default
 spec:
@@ -15272,7 +15272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: o2F37Lr
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: bbshm
 spec:
   ingressClassName: qyKUEOUT4u
@@ -15310,7 +15310,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: KchYZFsbB3
 ---
 # Source: console/templates/service.yaml
@@ -15326,7 +15326,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: KchYZFsbB3
   namespace: default
 spec:
@@ -15353,7 +15353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: KchYZFsbB3
   namespace: default
 spec:
@@ -15368,7 +15368,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18a73207ba1a94f82b9348a0e6d5a4303c96dc4c5229b0d75f3c7b9dba96268e
+        checksum/config: 6f40381c972fd418dd311a992b76c4181a57129add8096d427da1c5284bcdd8a
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -16399,7 +16399,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6sW
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -16433,7 +16433,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 0Z71mJNQUx
   namespace: default
 ---
@@ -16449,7 +16449,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wq
 stringData:
   enterprise-license: ""
@@ -16500,7 +16500,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wq
 ---
 # Source: console/templates/service.yaml
@@ -16517,7 +16517,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wq
   namespace: default
 spec:
@@ -16545,7 +16545,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wq
   namespace: default
 spec:
@@ -16560,7 +16560,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: a86b714e4f575a27d9404be60f2db5e8c9ffb06a0135859c1677b27194435d17
+        checksum/config: 2e1f5f5401bac9a6ca8b2205a50f20ebc4a08fcafa78467ca458eb9e8411b634
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -17128,7 +17128,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wq
 spec:
   maxReplicas: 309
@@ -17166,7 +17166,7 @@ metadata:
     app.kubernetes.io/name: x
     app.kubernetes.io/version: v2.7.0
     cxAL7zvwvb: tmEjSXwTK6
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Wq
 spec:
   ingressClassName: 9Kl
@@ -17214,7 +17214,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: eHZ
 ---
 # Source: console/templates/service.yaml
@@ -17230,7 +17230,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: eHZ
   namespace: default
 spec:
@@ -17260,7 +17260,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: eHZ
   namespace: default
 spec:
@@ -17276,7 +17276,7 @@ spec:
     metadata:
       annotations:
         JkW1: feghYA7
-        checksum/config: e6bb9425eab45f0eae7e1b54ec7b3c5714673007cf91c30bb59b15108d7dc961
+        checksum/config: 604d7e2418acc5a892f839adf69e909f154cce5130271c21931af53255f2b65f
         okSVM8H: 7Pau
         yYrmYn: uT
       creationTimestamp: null
@@ -18196,7 +18196,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: eHZ
 spec:
   maxReplicas: 165
@@ -18232,7 +18232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 84QIe
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -18257,7 +18257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: Gma
   namespace: default
 ---
@@ -18272,7 +18272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: y0pa6pm83
   namespace: default
 spec:
@@ -18300,7 +18300,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: y0pa6pm83
 spec:
   ingressClassName: 4Z1r6JSTY
@@ -18343,7 +18343,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: W9k
   namespace: default
 ---
@@ -18378,7 +18378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: resP
 ---
 # Source: console/templates/service.yaml
@@ -18394,7 +18394,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: resP
   namespace: default
 spec:
@@ -18423,7 +18423,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: resP
   namespace: default
 spec:
@@ -18439,7 +18439,7 @@ spec:
     metadata:
       annotations:
         N0F: vSjZxkjW
-        checksum/config: 03d91b268d4dc7aeb708bb59b4988af3293fe2b9f782bb188d1ccc7555a903ee
+        checksum/config: 8ebe1d816245b967e7ea3109d93ad79599a2b8a33eed8e72fc85166d6ffa7aaf
       creationTimestamp: null
       labels:
         K1uahi: UMygEU2O2
@@ -19083,7 +19083,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tvDI
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -19111,7 +19111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: nX5G
   namespace: default
 ---
@@ -19126,7 +19126,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9gCm5xz
 stringData:
   enterprise-license: ""
@@ -19166,7 +19166,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9gCm5xz
   namespace: default
 spec:
@@ -19191,7 +19191,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9gCm5xz
 spec:
   maxReplicas: 305
@@ -19226,7 +19226,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 9gCm5xz
 spec:
   ingressClassName: y6u9o
@@ -19272,7 +19272,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tOoxEiwdVpT
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -19299,7 +19299,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     rHtDM6k: ZY6Kw
   name: fB6TF
 stringData:
@@ -19341,7 +19341,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     rHtDM6k: ZY6Kw
   name: fB6TF
   namespace: default
@@ -19371,7 +19371,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     rHtDM6k: ZY6Kw
   name: fB6TF
 spec:
@@ -19413,7 +19413,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: DSw7
   namespace: default
 ---
@@ -19431,7 +19431,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: YUi5JpG
   namespace: default
 spec:
@@ -19458,7 +19458,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: YUi5JpG
   namespace: default
 spec:
@@ -20093,7 +20093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nEojiMtRc
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: YUi5JpG
 spec:
   maxReplicas: 122
@@ -20132,7 +20132,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: sKa
   namespace: default
 ---
@@ -20160,7 +20160,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 3um
 ---
 # Source: console/templates/service.yaml
@@ -20179,7 +20179,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 3um
   namespace: default
 spec:
@@ -20208,7 +20208,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 3um
   namespace: default
 spec:
@@ -20223,7 +20223,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: c865f5809f9cbed3c5923ccfee94288185921f7e4f34dce04d353620fa4f57f5
+        checksum/config: 1f1200550e8f17e44439daf44ec8c9721945fe5e499d9d558666a7a6516a4bd3
         eG: vxInc0
         g: BI6yk
         xCtSP: rQ
@@ -21035,7 +21035,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W7q3X
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: 3um
 spec:
   maxReplicas: 1
@@ -21076,7 +21076,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     ztm: qegfb80
   name: z12W
   namespace: default
@@ -21093,7 +21093,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     ztm: qegfb80
   name: 0BIfuN
 stringData:
@@ -21138,7 +21138,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     ztm: qegfb80
   name: 0BIfuN
   namespace: default
@@ -21167,7 +21167,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     ztm: qegfb80
   name: 0BIfuN
   namespace: default
@@ -21975,7 +21975,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     ztm: qegfb80
   name: 0BIfuN
 spec:
@@ -22012,7 +22012,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8dJzE
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
     ztm: qegfb80
   annotations:
     "helm.sh/hook": test
@@ -22040,7 +22040,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -22054,7 +22054,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -22097,7 +22097,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22111,7 +22111,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22136,7 +22136,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22149,7 +22149,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 28433195f4291623e1f28b605f6af68514e96896e1d16d324eda0573f54f4293
+        checksum/config: f57fffad24d8562b91b674515ee68bfe758dbbfe634dcd2bb3497934f70538c9
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22232,7 +22232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22257,7 +22257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -22271,7 +22271,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -22314,7 +22314,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22328,7 +22328,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22353,7 +22353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22366,7 +22366,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 28433195f4291623e1f28b605f6af68514e96896e1d16d324eda0573f54f4293
+        checksum/config: f57fffad24d8562b91b674515ee68bfe758dbbfe634dcd2bb3497934f70538c9
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22449,7 +22449,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22474,7 +22474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -22488,7 +22488,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -22539,7 +22539,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22553,7 +22553,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22578,7 +22578,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22591,7 +22591,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: e5b8d3883641cdeaa58b01694f4d73f4e1c26adba1d7b055d689242b2325c69b
+        checksum/config: fb8e6e138b819f5ea3ae5c413e14f624501b139f2294e15c4f188ec463049755
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22674,7 +22674,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22699,7 +22699,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -22713,7 +22713,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -22775,7 +22775,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -22789,7 +22789,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22814,7 +22814,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -22827,7 +22827,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 4ad2dc6edd0cad71873bca295298463fab6ffd2def02ec3b5fb66d5b2226fa1f
+        checksum/config: a586a304567f15fd4a79d95e15044439368fd8985e42a1a93cdcb6d0b540ed57
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22910,7 +22910,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -22935,7 +22935,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -22949,7 +22949,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -23002,7 +23002,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23016,7 +23016,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23041,7 +23041,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23054,7 +23054,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 27f85bf6d9f5002bf814a33aad71e1e6698e8393acd2cbd3b16123f975579543
+        checksum/config: 1afc8dfaddbbe103d0707800bfc71b4cc8f14e12334b3e22484d2b73ef5d57c0
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23137,7 +23137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23162,7 +23162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -23176,7 +23176,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -23218,7 +23218,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23232,7 +23232,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23257,7 +23257,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23270,7 +23270,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23353,7 +23353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23378,7 +23378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -23392,7 +23392,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -23434,7 +23434,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23448,7 +23448,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23473,7 +23473,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23486,7 +23486,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23569,7 +23569,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23594,7 +23594,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -23608,7 +23608,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -23650,7 +23650,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23664,7 +23664,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23689,7 +23689,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23702,7 +23702,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -23794,7 +23794,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -23819,7 +23819,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -23833,7 +23833,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -23875,7 +23875,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -23889,7 +23889,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23914,7 +23914,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -23927,7 +23927,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24011,7 +24011,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 spec:
   ingressClassName: null
@@ -24042,7 +24042,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -24067,7 +24067,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -24081,7 +24081,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -24123,7 +24123,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -24137,7 +24137,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -24162,7 +24162,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -24175,7 +24175,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24258,7 +24258,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -24283,7 +24283,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -24297,7 +24297,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -24339,7 +24339,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -24353,7 +24353,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -24378,7 +24378,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -24391,7 +24391,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24474,7 +24474,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:
@@ -24499,7 +24499,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 ---
@@ -24513,7 +24513,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 stringData:
   enterprise-license: ""
@@ -24555,7 +24555,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
 ---
 # Source: console/templates/service.yaml
@@ -24570,7 +24570,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -24596,7 +24596,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   name: console
   namespace: default
 spec:
@@ -24609,7 +24609,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 18e53aa3fa5b68b96379633c58982cef7b1d9e2dc8085180d7b4eed1bbfc6a77
+        checksum/config: 4f717eb67ef3f4c7e8737af0264bfe0922c76494c9ee31f7f52c63a13b02de86
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -24692,7 +24692,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: console
     app.kubernetes.io/version: v2.7.0
-    helm.sh/chart: console-0.7.28
+    helm.sh/chart: console-0.7.29
   annotations:
     "helm.sh/hook": test
 spec:

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.9.0
+version: 5.9.1
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.0](https://img.shields.io/badge/Version-5.9.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.2](https://img.shields.io/badge/AppVersion-v24.2.2-informational?style=flat-square)
+![Version: 5.9.1](https://img.shields.io/badge/Version-5.9.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.2](https://img.shields.io/badge/AppVersion-v24.2.2-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -45,7 +45,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -138,7 +138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -176,7 +176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -424,7 +424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -455,7 +455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -546,7 +546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -592,7 +592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -736,7 +736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -751,14 +751,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -1051,7 +1051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -1077,7 +1077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -1103,7 +1103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1141,7 +1141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1179,7 +1179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -1195,7 +1195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -1212,7 +1212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -1228,7 +1228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -1272,7 +1272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1360,7 +1360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -1438,7 +1438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1474,7 +1474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -1569,7 +1569,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -1608,7 +1608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -1761,7 +1761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1787,7 +1787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -1875,7 +1875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -1922,7 +1922,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -2042,7 +2042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -2058,14 +2058,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ffe63422c5e2efa4d8be2d85761f3fba0918156537f046e882b17061c48529f9
+        config.redpanda.com/checksum: 4c95985d6d1afa01c8c07fad9735dc4f23b2cc816d427353af2c71080b037a1f
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
     spec:
@@ -2362,7 +2362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -2440,7 +2440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     testlabel: exercise_common_labels_template
   name: redpanda-post-upgrade
   namespace: default
@@ -2509,7 +2509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -2544,7 +2544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -2638,7 +2638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -2676,7 +2676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -2894,7 +2894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -2921,7 +2921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -3008,7 +3008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -3054,7 +3054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -3198,7 +3198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -3213,14 +3213,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7647555ca0faf6f14799901ce1cf18f83e41e2d4e65b68971f5948c47782203a
+        config.redpanda.com/checksum: bf863f92c62cd2ad99dc09f6969966e5e9de1366af12bbcdce67e0ebdf669780
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -3513,7 +3513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -3539,7 +3539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -3565,7 +3565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -3603,7 +3603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -3641,7 +3641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -3657,7 +3657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -3674,7 +3674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -3690,7 +3690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -3734,7 +3734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -3822,7 +3822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -3900,7 +3900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -3935,7 +3935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -4033,7 +4033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-users
   namespace: default
 stringData:
@@ -4050,7 +4050,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -4176,7 +4176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -4336,7 +4336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -4361,7 +4361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -4448,7 +4448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -4494,7 +4494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -4620,7 +4620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -4635,14 +4635,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 5dac89d125197a191f84eb3eaba1926de1d201656b017eebdbb1e924719c05b3
+        config.redpanda.com/checksum: d95bee01dfc92a2dd84bbb95a6565a557d2a389a3c13ac9a543dafd13818c5ed
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -4952,7 +4952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -5034,7 +5034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -5106,7 +5106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -5141,7 +5141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -5239,7 +5239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-users
   namespace: default
 stringData:
@@ -5256,7 +5256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -5382,7 +5382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -5620,7 +5620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -5647,7 +5647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -5734,7 +5734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -5780,7 +5780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -5931,7 +5931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -5946,14 +5946,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d94f8577ec0282c7210840012ebb56b7eebaaf03e1e07352c15272e2e9717d47
+        config.redpanda.com/checksum: b98760abef4a767bbd6b657174a0bb86b2d60f317ee889eb0c76f59b73455260
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -6261,7 +6261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -6287,7 +6287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -6313,7 +6313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -6351,7 +6351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -6389,7 +6389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -6405,7 +6405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -6422,7 +6422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -6438,7 +6438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -6482,7 +6482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -6576,7 +6576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -6661,7 +6661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -6697,7 +6697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -6711,7 +6711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -6804,7 +6804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -6842,7 +6842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -7096,7 +7096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -7127,7 +7127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -7195,7 +7195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
 rules:
 - apiGroups:
@@ -7217,7 +7217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -7249,7 +7249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7271,7 +7271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7316,7 +7316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -7362,7 +7362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -7506,7 +7506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -7521,14 +7521,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 3915ccad139b95370907ae0565018041aa7ed93a7e8909be28f433abab52fb6a
+        config.redpanda.com/checksum: c626646bc1c059385811e7ac429800a2dab657c95c75880b3ec844f2e7ce1183
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -7821,7 +7821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -7847,7 +7847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -7873,7 +7873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -7911,7 +7911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -7949,7 +7949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -7965,7 +7965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -7982,7 +7982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -7998,7 +7998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -8042,7 +8042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -8130,7 +8130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -8208,7 +8208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -8243,7 +8243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -8336,7 +8336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -8374,7 +8374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -8679,7 +8679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -8709,7 +8709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -8800,7 +8800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -8846,7 +8846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -9002,7 +9002,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -9017,14 +9017,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 337527c55b9300abdd6d8aeddf0cefb43524ee18d32e95f1f28cd20f5c853718
+        config.redpanda.com/checksum: 4a783500764d188b99799942cf3b13cf7bfa95a4f85fa4b798809e06fac8109e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -9341,7 +9341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-cert2-root-certificate
   namespace: default
 spec:
@@ -9367,7 +9367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -9393,7 +9393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -9419,7 +9419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -9457,7 +9457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -9495,7 +9495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -9533,7 +9533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-cert2-selfsigned-issuer
   namespace: default
 spec:
@@ -9549,7 +9549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-cert2-root-issuer
   namespace: default
 spec:
@@ -9566,7 +9566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -9582,7 +9582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -9599,7 +9599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -9615,7 +9615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -9659,7 +9659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -9753,7 +9753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -9837,7 +9837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -9872,7 +9872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -9965,7 +9965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -10003,7 +10003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -10251,7 +10251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -10282,7 +10282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -10373,7 +10373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -10419,7 +10419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -10563,7 +10563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -10578,14 +10578,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -10877,7 +10877,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -10903,7 +10903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -10929,7 +10929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -10967,7 +10967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -11005,7 +11005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -11021,7 +11021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -11038,7 +11038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -11054,7 +11054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -11098,7 +11098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -11186,7 +11186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -11264,7 +11264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -11299,7 +11299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -11392,7 +11392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -11430,7 +11430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -11490,7 +11490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -11733,7 +11733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -11764,7 +11764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -11855,7 +11855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -11901,7 +11901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -12045,7 +12045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -12060,14 +12060,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -12444,7 +12444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -12470,7 +12470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -12496,7 +12496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -12534,7 +12534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -12572,7 +12572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -12588,7 +12588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -12605,7 +12605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -12621,7 +12621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -12665,7 +12665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -12753,7 +12753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -12831,7 +12831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -12866,7 +12866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -12959,7 +12959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -12997,7 +12997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -13245,7 +13245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -13276,7 +13276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -13367,7 +13367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -13413,7 +13413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -13557,7 +13557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -13572,14 +13572,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d394eb4146abf30c2174a72a9fcb17e4b08b7dcb97ad3ebb026e849aa5aa091e
+        config.redpanda.com/checksum: 204bb18f59d88d13954a93a202afddc015f7bc93567271b36c1a2f8c99bf6fc9
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -13872,7 +13872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -13898,7 +13898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -13924,7 +13924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -13964,7 +13964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -14004,7 +14004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -14020,7 +14020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -14037,7 +14037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -14053,7 +14053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -14097,7 +14097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -14185,7 +14185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -14263,7 +14263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -14298,7 +14298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -14395,7 +14395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: some-users
   namespace: default
 stringData:
@@ -14416,7 +14416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -14542,7 +14542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -14806,7 +14806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -14837,7 +14837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -14928,7 +14928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -14974,7 +14974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -15125,7 +15125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -15140,14 +15140,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 16d0a8ebdc15a77250feab71518f1421822cda7c348ff44acb2a26d1ca659da4
+        config.redpanda.com/checksum: cfadf6dc7b099acbda1e549d2d914fe3d041db6d1cb14137e154452c60cdf4e7
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -15455,7 +15455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -15481,7 +15481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -15507,7 +15507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -15545,7 +15545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -15583,7 +15583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -15599,7 +15599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -15616,7 +15616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -15632,7 +15632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -15676,7 +15676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -15770,7 +15770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -15854,7 +15854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -15889,7 +15889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -15982,7 +15982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -16020,7 +16020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -16268,7 +16268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -16299,7 +16299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -16390,7 +16390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -16436,7 +16436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -16580,7 +16580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -16595,14 +16595,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9cebc61397de0d289b23d49cb0e777e3a7c53786f0f97016d06f09457d0fd474
+        config.redpanda.com/checksum: 5e39bfa8b47665efe4fd484e2512bfdb8dea9e5405fdc89ca3978c857fe9d7de
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -16895,7 +16895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -16921,7 +16921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -16961,7 +16961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -16977,7 +16977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -17021,7 +17021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -17109,7 +17109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -17187,7 +17187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -17222,7 +17222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -17315,7 +17315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -17353,7 +17353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -17601,7 +17601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -17632,7 +17632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -17723,7 +17723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -17769,7 +17769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -17813,7 +17813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -17857,7 +17857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -18000,7 +18000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -18015,14 +18015,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 82898c99fb8e28cab726e26f33412c26377229f1cb739e887cb6a73caee2584f
+        config.redpanda.com/checksum: da6de7893309a0e067c21770c01d668bd9c873a3f6fcbc3f51fcf524eb9315c9
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -18315,7 +18315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -18341,7 +18341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -18381,7 +18381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -18397,7 +18397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -18441,7 +18441,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -18529,7 +18529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -18607,7 +18607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -18642,7 +18642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -18735,7 +18735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -18773,7 +18773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -18953,7 +18953,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -18982,7 +18982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -19073,7 +19073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -19119,7 +19119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -19238,7 +19238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -19253,14 +19253,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: a25dfc90ead69b150b9aed9eb84a27f4f52cceb566a00b6d5fc9c9c26286cce2
+        config.redpanda.com/checksum: 9aef011fbc1e76886fedee836d84fccc3c8e99276dbe9736893db0d95635d909
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -19528,7 +19528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -19581,7 +19581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -19657,7 +19657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -19723,7 +19723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -19758,7 +19758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -19851,7 +19851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -19889,7 +19889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -20137,7 +20137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -20168,7 +20168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -20259,7 +20259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -20305,7 +20305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -20449,7 +20449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -20464,14 +20464,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -20764,7 +20764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -20790,7 +20790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -20816,7 +20816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -20854,7 +20854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -20892,7 +20892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -20908,7 +20908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -20925,7 +20925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -20941,7 +20941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -20958,7 +20958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -21016,7 +21016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -21104,7 +21104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -21182,7 +21182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -21217,7 +21217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -21310,7 +21310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -21348,7 +21348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -21596,7 +21596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -21627,7 +21627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -21695,7 +21695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -21729,7 +21729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
 rules:
 - apiGroups:
@@ -21751,7 +21751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -21783,7 +21783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21805,7 +21805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21827,7 +21827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21849,7 +21849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -21902,7 +21902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -21948,7 +21948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -21994,7 +21994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -22138,7 +22138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -22153,14 +22153,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -22468,7 +22468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -22494,7 +22494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -22520,7 +22520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -22558,7 +22558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -22596,7 +22596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -22612,7 +22612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -22629,7 +22629,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -22645,7 +22645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -22689,7 +22689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -22777,7 +22777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -22855,7 +22855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -22890,7 +22890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -22983,7 +22983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -23021,7 +23021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -23269,7 +23269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -23300,7 +23300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -23391,7 +23391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -23437,7 +23437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -23581,7 +23581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -23596,14 +23596,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d22f4b920f742f3736fd2ebd1c35257d8e04561dea51509522d84dad4fa498e9
+        config.redpanda.com/checksum: 3e2792db321d67a997dde5c3177fce44470f9fc7a8daca27f3ce9459969d4add
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -23899,7 +23899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -23925,7 +23925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -23951,7 +23951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -23989,7 +23989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -24027,7 +24027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -24043,7 +24043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -24060,7 +24060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -24076,7 +24076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -24120,7 +24120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -24208,7 +24208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -24286,7 +24286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -24321,7 +24321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -24414,7 +24414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -24452,7 +24452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -24700,7 +24700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -24731,7 +24731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -24822,7 +24822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -24868,7 +24868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -25012,7 +25012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -25027,14 +25027,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 653dcc713434e2a7cb52215b7e55093153c5b0140ce7319e1c6256d391490346
+        config.redpanda.com/checksum: 9a535dafc2ac560073ace73fa2bfc32c445759e7c5aa9124d44a6720f20f4b86
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -25327,7 +25327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -25353,7 +25353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -25379,7 +25379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -25419,7 +25419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -25459,7 +25459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -25475,7 +25475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -25492,7 +25492,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -25508,7 +25508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -25552,7 +25552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -25640,7 +25640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -25718,7 +25718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -25800,7 +25800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -25893,7 +25893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -25931,7 +25931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -26189,7 +26189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -26220,7 +26220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -26311,7 +26311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -26357,7 +26357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -26517,7 +26517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -26532,14 +26532,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 38e155da7573f6befb526c52572d507bc687dc0deca6ebca2646de61afcd232c
+        config.redpanda.com/checksum: 4304783db8dda3199ac4da1a78ad770e1922804cca7c0f371228e240fcd569d8
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -26853,7 +26853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -26879,7 +26879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -26905,7 +26905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -26943,7 +26943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -26981,7 +26981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -26997,7 +26997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -27014,7 +27014,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -27030,7 +27030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -27074,7 +27074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -27184,7 +27184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -27262,7 +27262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -27344,7 +27344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -27437,7 +27437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -27475,7 +27475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -27734,7 +27734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -27765,7 +27765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -27856,7 +27856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -27902,7 +27902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -28062,7 +28062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -28077,14 +28077,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9a6f6c832418a9cfb28e3d59d31dd09a0636fdf070018470783231d8442797e9
+        config.redpanda.com/checksum: 6afd7a6b94f7faa4ea53c50ebe8ebaed6937107d28ba611fd2abd9511f251eb4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -28398,7 +28398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -28424,7 +28424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -28450,7 +28450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -28488,7 +28488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -28526,7 +28526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -28542,7 +28542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -28559,7 +28559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -28575,7 +28575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -28619,7 +28619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -28731,7 +28731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -28809,7 +28809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -28891,7 +28891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -28984,7 +28984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -29022,7 +29022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -29279,7 +29279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -29310,7 +29310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -29401,7 +29401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -29447,7 +29447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -29607,7 +29607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -29622,14 +29622,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 527eb76bf62df204842f1ab14e3a0889b7a186caca65a7d724970480a46f7ba8
+        config.redpanda.com/checksum: 4ab6592f6d3428f0061765b00ebdf420f4719362aa1bddad5516c4a501fe248d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -29944,7 +29944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -29970,7 +29970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -29996,7 +29996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -30034,7 +30034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -30072,7 +30072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -30088,7 +30088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -30105,7 +30105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -30121,7 +30121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -30165,7 +30165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -30273,7 +30273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -30351,7 +30351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -30386,7 +30386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -30479,7 +30479,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -30517,7 +30517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -30774,7 +30774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -30805,7 +30805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -30896,7 +30896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -30942,7 +30942,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -31086,7 +31086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -31101,14 +31101,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0ccfc4ee948935c9ac90babc55fc2444f5fff6b7cc6e590d53b2fbc874ec1ddd
+        config.redpanda.com/checksum: 4e83b250be20aed9c9da2386e762644310f67b6c7eaa5fbaef66d55edd089fce
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -31423,7 +31423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -31449,7 +31449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -31475,7 +31475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -31513,7 +31513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -31551,7 +31551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -31567,7 +31567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -31584,7 +31584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -31600,7 +31600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -31644,7 +31644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -31750,7 +31750,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -31828,7 +31828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -31910,7 +31910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -32003,7 +32003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -32041,7 +32041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -32299,7 +32299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -32330,7 +32330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -32421,7 +32421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -32467,7 +32467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -32627,7 +32627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -32642,14 +32642,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 38e155da7573f6befb526c52572d507bc687dc0deca6ebca2646de61afcd232c
+        config.redpanda.com/checksum: 4304783db8dda3199ac4da1a78ad770e1922804cca7c0f371228e240fcd569d8
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -32975,7 +32975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -33001,7 +33001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -33027,7 +33027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -33065,7 +33065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -33103,7 +33103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -33119,7 +33119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -33136,7 +33136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -33152,7 +33152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -33196,7 +33196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -33306,7 +33306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -33384,7 +33384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -33466,7 +33466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -33559,7 +33559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -33597,7 +33597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -33856,7 +33856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -33887,7 +33887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -33978,7 +33978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -34024,7 +34024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -34184,7 +34184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -34199,14 +34199,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9a6f6c832418a9cfb28e3d59d31dd09a0636fdf070018470783231d8442797e9
+        config.redpanda.com/checksum: 6afd7a6b94f7faa4ea53c50ebe8ebaed6937107d28ba611fd2abd9511f251eb4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -34532,7 +34532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -34558,7 +34558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -34584,7 +34584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -34622,7 +34622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -34660,7 +34660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -34676,7 +34676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -34693,7 +34693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -34709,7 +34709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -34753,7 +34753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -34865,7 +34865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -34943,7 +34943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -35025,7 +35025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -35118,7 +35118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -35156,7 +35156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -35413,7 +35413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -35444,7 +35444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -35535,7 +35535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -35581,7 +35581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -35741,7 +35741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -35756,14 +35756,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 527eb76bf62df204842f1ab14e3a0889b7a186caca65a7d724970480a46f7ba8
+        config.redpanda.com/checksum: 4ab6592f6d3428f0061765b00ebdf420f4719362aa1bddad5516c4a501fe248d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -36091,7 +36091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -36117,7 +36117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -36143,7 +36143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -36181,7 +36181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -36219,7 +36219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -36235,7 +36235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -36252,7 +36252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -36268,7 +36268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -36312,7 +36312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -36420,7 +36420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -36498,7 +36498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -36533,7 +36533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -36626,7 +36626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -36664,7 +36664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -36921,7 +36921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -36952,7 +36952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -37043,7 +37043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -37089,7 +37089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -37233,7 +37233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -37248,14 +37248,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 527eb76bf62df204842f1ab14e3a0889b7a186caca65a7d724970480a46f7ba8
+        config.redpanda.com/checksum: 4ab6592f6d3428f0061765b00ebdf420f4719362aa1bddad5516c4a501fe248d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -37583,7 +37583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -37609,7 +37609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -37635,7 +37635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -37673,7 +37673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -37711,7 +37711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -37727,7 +37727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -37744,7 +37744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -37760,7 +37760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -37804,7 +37804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -37910,7 +37910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -37988,7 +37988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -38070,7 +38070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -38163,7 +38163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -38201,7 +38201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -38459,7 +38459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -38490,7 +38490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -38581,7 +38581,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -38627,7 +38627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -38787,7 +38787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -38802,14 +38802,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 38e155da7573f6befb526c52572d507bc687dc0deca6ebca2646de61afcd232c
+        config.redpanda.com/checksum: 4304783db8dda3199ac4da1a78ad770e1922804cca7c0f371228e240fcd569d8
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -39135,7 +39135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -39161,7 +39161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -39187,7 +39187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -39225,7 +39225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -39263,7 +39263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -39279,7 +39279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -39296,7 +39296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -39312,7 +39312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -39356,7 +39356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -39466,7 +39466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -39544,7 +39544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -39626,7 +39626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -39719,7 +39719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -39757,7 +39757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -40016,7 +40016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -40047,7 +40047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -40138,7 +40138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -40184,7 +40184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -40344,7 +40344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -40359,14 +40359,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9a6f6c832418a9cfb28e3d59d31dd09a0636fdf070018470783231d8442797e9
+        config.redpanda.com/checksum: 6afd7a6b94f7faa4ea53c50ebe8ebaed6937107d28ba611fd2abd9511f251eb4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -40692,7 +40692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -40718,7 +40718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -40744,7 +40744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -40782,7 +40782,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -40820,7 +40820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -40836,7 +40836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -40853,7 +40853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -40869,7 +40869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -40913,7 +40913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -41025,7 +41025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -41103,7 +41103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -41185,7 +41185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -41278,7 +41278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -41316,7 +41316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -41573,7 +41573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -41604,7 +41604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -41695,7 +41695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -41741,7 +41741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -41901,7 +41901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -41916,14 +41916,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 527eb76bf62df204842f1ab14e3a0889b7a186caca65a7d724970480a46f7ba8
+        config.redpanda.com/checksum: 4ab6592f6d3428f0061765b00ebdf420f4719362aa1bddad5516c4a501fe248d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -42251,7 +42251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -42277,7 +42277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -42303,7 +42303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -42341,7 +42341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -42379,7 +42379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -42395,7 +42395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -42412,7 +42412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -42428,7 +42428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -42472,7 +42472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -42580,7 +42580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -42658,7 +42658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -42693,7 +42693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -42786,7 +42786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -42824,7 +42824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -43081,7 +43081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -43112,7 +43112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -43203,7 +43203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -43249,7 +43249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -43393,7 +43393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -43408,14 +43408,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 527eb76bf62df204842f1ab14e3a0889b7a186caca65a7d724970480a46f7ba8
+        config.redpanda.com/checksum: 4ab6592f6d3428f0061765b00ebdf420f4719362aa1bddad5516c4a501fe248d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -43743,7 +43743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -43769,7 +43769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -43795,7 +43795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -43833,7 +43833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -43871,7 +43871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -43887,7 +43887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -43904,7 +43904,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -43920,7 +43920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -43964,7 +43964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -44070,7 +44070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -44148,7 +44148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -44183,7 +44183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -44276,7 +44276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -44314,7 +44314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -44562,7 +44562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -44593,7 +44593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -44684,7 +44684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -44730,7 +44730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -44874,7 +44874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -44889,14 +44889,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: da305d05d7b959cfad8c93fdea151cb86b42c92a3fdbaa70cdf02b8b6b65f6b3
+        config.redpanda.com/checksum: c4660a180093245fe2831d9069a00947ba3f86b76aa91ab790817f70e73f3c14
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -45189,7 +45189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -45215,7 +45215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -45241,7 +45241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -45279,7 +45279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -45317,7 +45317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -45333,7 +45333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -45350,7 +45350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -45366,7 +45366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -45410,7 +45410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -45498,7 +45498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -45576,7 +45576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -45611,7 +45611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -45704,7 +45704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -45742,7 +45742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -45990,7 +45990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -46021,7 +46021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -46112,7 +46112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -46158,7 +46158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -46302,7 +46302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -46317,7 +46317,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
@@ -46325,7 +46325,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -46618,7 +46618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -46644,7 +46644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -46670,7 +46670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -46708,7 +46708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -46746,7 +46746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -46762,7 +46762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -46779,7 +46779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -46795,7 +46795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -46839,7 +46839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -46927,7 +46927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -47005,7 +47005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -47040,7 +47040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -47133,7 +47133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -47171,7 +47171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -47419,7 +47419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -47450,7 +47450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -47541,7 +47541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -47587,7 +47587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -47731,7 +47731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -47746,14 +47746,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -48052,7 +48052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -48078,7 +48078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -48104,7 +48104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -48142,7 +48142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -48180,7 +48180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -48196,7 +48196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -48213,7 +48213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -48229,7 +48229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -48273,7 +48273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -48361,7 +48361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -48439,7 +48439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -48474,7 +48474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -48567,7 +48567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -48605,7 +48605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -48907,7 +48907,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -48939,7 +48939,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -49032,7 +49032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -49078,7 +49078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -49233,7 +49233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -49248,14 +49248,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 035dc74c30ffaec12454809c190574be9e283e1cd87a197af86e50af96546284
+        config.redpanda.com/checksum: 341a6ffc9f0af44f58bfafd9ac339f8d4b1ca6d5ef8d838b1ef4949db0ea100e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -49556,7 +49556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -49582,7 +49582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -49608,7 +49608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -49646,7 +49646,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -49684,7 +49684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -49700,7 +49700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -49717,7 +49717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -49733,7 +49733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -49777,7 +49777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -49865,7 +49865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -49943,7 +49943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -49981,7 +49981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -50074,7 +50074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -50112,7 +50112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -50360,7 +50360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -50391,7 +50391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -50482,7 +50482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -50531,7 +50531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -50678,7 +50678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -50696,14 +50696,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -51005,7 +51005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -51031,7 +51031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -51057,7 +51057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -51095,7 +51095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -51133,7 +51133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -51149,7 +51149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -51166,7 +51166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -51182,7 +51182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -51226,7 +51226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -51314,7 +51314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -51392,7 +51392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -51427,7 +51427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -51520,7 +51520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -51558,7 +51558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -51806,7 +51806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -51837,7 +51837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -51905,7 +51905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -51939,7 +51939,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
 rules:
 - apiGroups:
@@ -51961,7 +51961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -51993,7 +51993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52015,7 +52015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52037,7 +52037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52059,7 +52059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -52112,7 +52112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -52158,7 +52158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -52204,7 +52204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -52348,7 +52348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -52363,14 +52363,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -52690,7 +52690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -52716,7 +52716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -52742,7 +52742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -52780,7 +52780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -52818,7 +52818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -52834,7 +52834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -52851,7 +52851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -52867,7 +52867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -52911,7 +52911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -52999,7 +52999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -53077,7 +53077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -53112,7 +53112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -53205,7 +53205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -53243,7 +53243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -53303,7 +53303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -53546,7 +53546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -53577,7 +53577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -53645,7 +53645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -53679,7 +53679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53701,7 +53701,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -53754,7 +53754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -53800,7 +53800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -53846,7 +53846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -53990,7 +53990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -54005,14 +54005,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -54346,7 +54346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -54372,7 +54372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -54398,7 +54398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -54436,7 +54436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -54474,7 +54474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -54490,7 +54490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -54507,7 +54507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -54523,7 +54523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -54567,7 +54567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -54655,7 +54655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -54733,7 +54733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -54768,7 +54768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -54861,7 +54861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -54899,7 +54899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -55147,7 +55147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -55178,7 +55178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -55317,7 +55317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -55363,7 +55363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -55652,7 +55652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -55667,14 +55667,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -55967,7 +55967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -55993,7 +55993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -56019,7 +56019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -56057,7 +56057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -56095,7 +56095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -56111,7 +56111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -56128,7 +56128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -56144,7 +56144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -56188,7 +56188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -56276,7 +56276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -56354,7 +56354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -56389,7 +56389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -56482,7 +56482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -56520,7 +56520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -56768,7 +56768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -56799,7 +56799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -56890,7 +56890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -56936,7 +56936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -57080,7 +57080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -57095,14 +57095,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 69a8810295c4e221a369e649a4fa336b100c5acfa7106716ebb9115ad7f7a328
+        config.redpanda.com/checksum: d759c9627d8d5f934a36a14e12fdbfab6695e6f78974df70d53d56b57a3187aa
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -57395,7 +57395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -57421,7 +57421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -57447,7 +57447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -57487,7 +57487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -57527,7 +57527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -57543,7 +57543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -57560,7 +57560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -57576,7 +57576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -57620,7 +57620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -57708,7 +57708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -57786,7 +57786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -57822,7 +57822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -57915,7 +57915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -57953,7 +57953,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -58201,7 +58201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -58232,7 +58232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -58324,7 +58324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -58371,7 +58371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: change-name-external
   namespace: default
 spec:
@@ -58516,7 +58516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -58532,14 +58532,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 32cff0637c0c3e385378ad5e1b776c830a7aa8fb0b3fee0b3ace51064750bb21
+        config.redpanda.com/checksum: fcc7a3c94b2b82ea4eda49c7dba18ae8b10654f127aaacecb3d4003e06d46fa4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
         test: test
     spec:
@@ -58835,7 +58835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -58861,7 +58861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -58887,7 +58887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -58925,7 +58925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -58963,7 +58963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -58979,7 +58979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -58996,7 +58996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -59012,7 +59012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -59029,7 +59029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -59087,7 +59087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -59175,7 +59175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -59253,7 +59253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -59288,7 +59288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -59381,7 +59381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -59419,7 +59419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -59667,7 +59667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -59698,7 +59698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -59789,7 +59789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -59835,7 +59835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -59979,7 +59979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -59994,14 +59994,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -60309,7 +60309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -60335,7 +60335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -60361,7 +60361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -60399,7 +60399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -60437,7 +60437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -60453,7 +60453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -60470,7 +60470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -60486,7 +60486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -60530,7 +60530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -60637,7 +60637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -60730,7 +60730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -60765,7 +60765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -60858,7 +60858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -60896,7 +60896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -61144,7 +61144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -61175,7 +61175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -61266,7 +61266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -61312,7 +61312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -61456,7 +61456,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -61471,14 +61471,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -61786,7 +61786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -61812,7 +61812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -61838,7 +61838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -61876,7 +61876,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -61914,7 +61914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -61930,7 +61930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -61947,7 +61947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -61963,7 +61963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -62007,7 +62007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -62116,7 +62116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -62209,7 +62209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -62244,7 +62244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -62337,7 +62337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -62375,7 +62375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -62623,7 +62623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -62654,7 +62654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -62745,7 +62745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -62791,7 +62791,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -62935,7 +62935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -62950,14 +62950,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -63252,7 +63252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -63278,7 +63278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -63304,7 +63304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -63342,7 +63342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -63380,7 +63380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -63396,7 +63396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -63413,7 +63413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -63429,7 +63429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -63473,7 +63473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -63563,7 +63563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -63643,7 +63643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -63665,7 +63665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -63758,7 +63758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -63796,7 +63796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -64021,7 +64021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -64053,7 +64053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -64068,7 +64068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -64114,7 +64114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -64158,7 +64158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -64173,14 +64173,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 1c466680c6498c144f2d1fe5b4ff745e9c5e5e0eb408a89fdd89997049998627
+        config.redpanda.com/checksum: 21f786529807615813e8a71aa0ac8932561164c115d96aca87fc385915ecf254
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -64482,7 +64482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -64508,7 +64508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -64534,7 +64534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -64560,7 +64560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -64598,7 +64598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -64636,7 +64636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -64674,7 +64674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -64699,7 +64699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -64715,7 +64715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -64732,7 +64732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -64748,7 +64748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -64765,7 +64765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -64781,7 +64781,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -64802,7 +64802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -64896,7 +64896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -64980,7 +64980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -65015,7 +65015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -65108,7 +65108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -65146,7 +65146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -65394,7 +65394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -65425,7 +65425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -65516,7 +65516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -65562,7 +65562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -65706,7 +65706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -65721,14 +65721,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -66021,7 +66021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -66047,7 +66047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -66073,7 +66073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -66099,7 +66099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -66125,7 +66125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -66142,7 +66142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -66186,7 +66186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -66274,7 +66274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -66352,7 +66352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -66434,7 +66434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -66531,7 +66531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-users
   namespace: default
 stringData:
@@ -66548,7 +66548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -66674,7 +66674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -66948,7 +66948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -66979,7 +66979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -67070,7 +67070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -67116,7 +67116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -67283,7 +67283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -67298,14 +67298,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 12c1cfb64c0709b836db62961b59ab9efbbf1a286cf648e9368932c1f3c375ad
+        config.redpanda.com/checksum: 7f49a42083522fb80756778113f8adb89ef29a4fe3fdd596555f9962918a72e2
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -67613,7 +67613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -67639,7 +67639,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -67665,7 +67665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -67703,7 +67703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -67741,7 +67741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -67757,7 +67757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -67774,7 +67774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -67790,7 +67790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -67834,7 +67834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -67930,7 +67930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -68014,7 +68014,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -68096,7 +68096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -68189,7 +68189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -68227,7 +68227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -68475,7 +68475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -68506,7 +68506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -68597,7 +68597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -68643,7 +68643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -68803,7 +68803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -68818,14 +68818,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -69118,7 +69118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -69144,7 +69144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -69170,7 +69170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -69208,7 +69208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -69246,7 +69246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -69262,7 +69262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -69279,7 +69279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -69295,7 +69295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -69339,7 +69339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -69429,7 +69429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -69507,7 +69507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -69542,7 +69542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -69635,7 +69635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -69673,7 +69673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -69921,7 +69921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -69952,7 +69952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -70043,7 +70043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -70089,7 +70089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -70238,7 +70238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -70253,14 +70253,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -70553,7 +70553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -70579,7 +70579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -70605,7 +70605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -70643,7 +70643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -70681,7 +70681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -70697,7 +70697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -70714,7 +70714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -70730,7 +70730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -70774,7 +70774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -70867,7 +70867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -70945,7 +70945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -70980,7 +70980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -71073,7 +71073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -71111,7 +71111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -71370,7 +71370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -71401,7 +71401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -71492,7 +71492,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -71538,7 +71538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -71696,7 +71696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -71711,14 +71711,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9773405f0013d52d3dac48941938e7db311eaa9a192d940b05a5be9ecc66574d
+        config.redpanda.com/checksum: 2a3df4f1e8c7c89408d7bab1553fbe48c7de69b162b3b24a07f2078ad2391159
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -72032,7 +72032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -72058,7 +72058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -72084,7 +72084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -72122,7 +72122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -72160,7 +72160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -72176,7 +72176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -72193,7 +72193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -72209,7 +72209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -72253,7 +72253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -72364,7 +72364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -72442,7 +72442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -72477,7 +72477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -72570,7 +72570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -72608,7 +72608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -72856,7 +72856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -72887,7 +72887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -72978,7 +72978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -73024,7 +73024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -73168,7 +73168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -73183,14 +73183,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -73484,7 +73484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -73510,7 +73510,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -73536,7 +73536,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -73574,7 +73574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -73612,7 +73612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -73628,7 +73628,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -73645,7 +73645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -73661,7 +73661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -73705,7 +73705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -73794,7 +73794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -73873,7 +73873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -73908,7 +73908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -74001,7 +74001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -74039,7 +74039,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -74287,7 +74287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -74318,7 +74318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -74409,7 +74409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -74455,7 +74455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -74599,7 +74599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -74614,14 +74614,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -74915,7 +74915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -74941,7 +74941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -74967,7 +74967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -75005,7 +75005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -75043,7 +75043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -75059,7 +75059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -75076,7 +75076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -75092,7 +75092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -75136,7 +75136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -75225,7 +75225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -75304,7 +75304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -75339,7 +75339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -75432,7 +75432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -75470,7 +75470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -75718,7 +75718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -75749,7 +75749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -75840,7 +75840,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -75886,7 +75886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -76030,7 +76030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -76045,14 +76045,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -76345,7 +76345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -76371,7 +76371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -76397,7 +76397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -76435,7 +76435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -76473,7 +76473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -76489,7 +76489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -76506,7 +76506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -76522,7 +76522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -76566,7 +76566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -76654,7 +76654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -76732,7 +76732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -76767,7 +76767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -76864,7 +76864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-users
   namespace: default
 stringData:
@@ -76884,7 +76884,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -77010,7 +77010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -77272,7 +77272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -77303,7 +77303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -77394,7 +77394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -77440,7 +77440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -77591,7 +77591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -77606,14 +77606,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 95ae27b56b090b6197c9daca8bebe85aeba8cce0e5cb2d4ee00d09a1e2ddb901
+        config.redpanda.com/checksum: 2579099012a003e68e38ed383c13e093279ef5d7fb1c17f8bced429591ef644d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -77921,7 +77921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -77947,7 +77947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -77973,7 +77973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -78011,7 +78011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -78049,7 +78049,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -78065,7 +78065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -78082,7 +78082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -78098,7 +78098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -78142,7 +78142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -78236,7 +78236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -78344,7 +78344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -78379,7 +78379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -78472,7 +78472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -78510,7 +78510,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -78756,7 +78756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -78787,7 +78787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -78878,7 +78878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -78924,7 +78924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -79068,7 +79068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -79083,14 +79083,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 41277586b023d92d69c627621845dbf882612366ce060a9ec7e4f4aef91398be
+        config.redpanda.com/checksum: c3bdad6e146b00384c28f194451175cc375294491c88fd1d3e7400e0a074ddc0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -79383,7 +79383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -79409,7 +79409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -79435,7 +79435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -79473,7 +79473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -79511,7 +79511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -79527,7 +79527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -79544,7 +79544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -79560,7 +79560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -79604,7 +79604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -79692,7 +79692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -79763,7 +79763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -79845,7 +79845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -79938,7 +79938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -79976,7 +79976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -80222,7 +80222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -80253,7 +80253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -80344,7 +80344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -80390,7 +80390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -80550,7 +80550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -80565,14 +80565,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 8600a35765278df4fca07e3a6b698e64e988fbed3178d6c51c1b8c84f446649c
+        config.redpanda.com/checksum: 23507efd6d0b6b7fbb31dbf9d357282f7acbf4497243d48d669a665d122e1c64
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -80865,7 +80865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -80891,7 +80891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -80917,7 +80917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -80955,7 +80955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -80993,7 +80993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -81009,7 +81009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -81026,7 +81026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -81042,7 +81042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -81086,7 +81086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -81176,7 +81176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -81247,7 +81247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -81282,7 +81282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -81375,7 +81375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -81413,7 +81413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -81665,7 +81665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -81696,7 +81696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -81787,7 +81787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -81833,7 +81833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -81977,7 +81977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -81992,14 +81992,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 379b6b222b203f099603f249796e8449071daa43517dfa805c9296c82ed504d6
+        config.redpanda.com/checksum: a08ab6e3001b0b8ce2a16e0775d5b0f6d09a3d8908c7e017f313c57a5ae42b23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -82292,7 +82292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -82318,7 +82318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -82344,7 +82344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -82382,7 +82382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -82420,7 +82420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -82436,7 +82436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -82453,7 +82453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -82469,7 +82469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -82513,7 +82513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -82601,7 +82601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -82684,7 +82684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -82719,7 +82719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -82812,7 +82812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -82850,7 +82850,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -83096,7 +83096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -83127,7 +83127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -83218,7 +83218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -83264,7 +83264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -83408,7 +83408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -83423,14 +83423,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 41277586b023d92d69c627621845dbf882612366ce060a9ec7e4f4aef91398be
+        config.redpanda.com/checksum: c3bdad6e146b00384c28f194451175cc375294491c88fd1d3e7400e0a074ddc0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -83723,7 +83723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -83749,7 +83749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -83775,7 +83775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -83813,7 +83813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -83851,7 +83851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -83867,7 +83867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -83884,7 +83884,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -83900,7 +83900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -83944,7 +83944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -84032,7 +84032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -84103,7 +84103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -84185,7 +84185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -84278,7 +84278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -84316,7 +84316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -84562,7 +84562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -84593,7 +84593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -84684,7 +84684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -84730,7 +84730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -84890,7 +84890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -84905,14 +84905,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 8600a35765278df4fca07e3a6b698e64e988fbed3178d6c51c1b8c84f446649c
+        config.redpanda.com/checksum: 23507efd6d0b6b7fbb31dbf9d357282f7acbf4497243d48d669a665d122e1c64
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -85205,7 +85205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -85231,7 +85231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -85257,7 +85257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -85295,7 +85295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -85333,7 +85333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -85349,7 +85349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -85366,7 +85366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -85382,7 +85382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -85426,7 +85426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -85516,7 +85516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -85587,7 +85587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -85622,7 +85622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -85715,7 +85715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -85753,7 +85753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -86005,7 +86005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -86036,7 +86036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -86127,7 +86127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -86173,7 +86173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -86317,7 +86317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -86332,14 +86332,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 379b6b222b203f099603f249796e8449071daa43517dfa805c9296c82ed504d6
+        config.redpanda.com/checksum: a08ab6e3001b0b8ce2a16e0775d5b0f6d09a3d8908c7e017f313c57a5ae42b23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -86632,7 +86632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -86658,7 +86658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -86684,7 +86684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -86722,7 +86722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -86760,7 +86760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -86776,7 +86776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -86793,7 +86793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -86809,7 +86809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -86853,7 +86853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -86941,7 +86941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -87012,7 +87012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -87047,7 +87047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -87140,7 +87140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -87178,7 +87178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -87424,7 +87424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -87455,7 +87455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -87546,7 +87546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -87592,7 +87592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -87736,7 +87736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -87751,14 +87751,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 41277586b023d92d69c627621845dbf882612366ce060a9ec7e4f4aef91398be
+        config.redpanda.com/checksum: c3bdad6e146b00384c28f194451175cc375294491c88fd1d3e7400e0a074ddc0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -88051,7 +88051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -88077,7 +88077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -88103,7 +88103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -88141,7 +88141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -88179,7 +88179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -88195,7 +88195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -88212,7 +88212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -88228,7 +88228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -88272,7 +88272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -88360,7 +88360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -88431,7 +88431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -88513,7 +88513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -88606,7 +88606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -88644,7 +88644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -88890,7 +88890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -88921,7 +88921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -89012,7 +89012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -89058,7 +89058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -89218,7 +89218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -89233,14 +89233,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 8600a35765278df4fca07e3a6b698e64e988fbed3178d6c51c1b8c84f446649c
+        config.redpanda.com/checksum: 23507efd6d0b6b7fbb31dbf9d357282f7acbf4497243d48d669a665d122e1c64
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -89533,7 +89533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -89559,7 +89559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -89585,7 +89585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -89623,7 +89623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -89661,7 +89661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -89677,7 +89677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -89694,7 +89694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -89710,7 +89710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -89754,7 +89754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -89844,7 +89844,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -89915,7 +89915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -89950,7 +89950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -90043,7 +90043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -90081,7 +90081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -90333,7 +90333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -90364,7 +90364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -90455,7 +90455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -90501,7 +90501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -90645,7 +90645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -90660,14 +90660,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 379b6b222b203f099603f249796e8449071daa43517dfa805c9296c82ed504d6
+        config.redpanda.com/checksum: a08ab6e3001b0b8ce2a16e0775d5b0f6d09a3d8908c7e017f313c57a5ae42b23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -90960,7 +90960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -90986,7 +90986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -91012,7 +91012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -91050,7 +91050,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -91088,7 +91088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -91104,7 +91104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -91121,7 +91121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -91137,7 +91137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -91181,7 +91181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -91269,7 +91269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -91340,7 +91340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -91375,7 +91375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -91468,7 +91468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -91506,7 +91506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -91752,7 +91752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -91783,7 +91783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -91874,7 +91874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -91920,7 +91920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -92064,7 +92064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -92079,14 +92079,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 41277586b023d92d69c627621845dbf882612366ce060a9ec7e4f4aef91398be
+        config.redpanda.com/checksum: c3bdad6e146b00384c28f194451175cc375294491c88fd1d3e7400e0a074ddc0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -92379,7 +92379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -92405,7 +92405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -92431,7 +92431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -92469,7 +92469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -92507,7 +92507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -92523,7 +92523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -92540,7 +92540,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -92556,7 +92556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -92600,7 +92600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -92688,7 +92688,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -92766,7 +92766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -92848,7 +92848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -92941,7 +92941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -92979,7 +92979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -93225,7 +93225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -93256,7 +93256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -93347,7 +93347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -93393,7 +93393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -93553,7 +93553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -93568,14 +93568,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 8600a35765278df4fca07e3a6b698e64e988fbed3178d6c51c1b8c84f446649c
+        config.redpanda.com/checksum: 23507efd6d0b6b7fbb31dbf9d357282f7acbf4497243d48d669a665d122e1c64
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -93868,7 +93868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -93894,7 +93894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -93920,7 +93920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -93958,7 +93958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -93996,7 +93996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -94012,7 +94012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -94029,7 +94029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -94045,7 +94045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -94089,7 +94089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -94179,7 +94179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -94257,7 +94257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -94292,7 +94292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -94385,7 +94385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -94423,7 +94423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -94675,7 +94675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -94706,7 +94706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -94797,7 +94797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -94843,7 +94843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -94987,7 +94987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -95002,14 +95002,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 379b6b222b203f099603f249796e8449071daa43517dfa805c9296c82ed504d6
+        config.redpanda.com/checksum: a08ab6e3001b0b8ce2a16e0775d5b0f6d09a3d8908c7e017f313c57a5ae42b23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -95302,7 +95302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -95328,7 +95328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -95354,7 +95354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -95392,7 +95392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -95430,7 +95430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -95446,7 +95446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -95463,7 +95463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -95479,7 +95479,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -95523,7 +95523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -95611,7 +95611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -95689,7 +95689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -95724,7 +95724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -95817,7 +95817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -95855,7 +95855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -96103,7 +96103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -96134,7 +96134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -96225,7 +96225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -96271,7 +96271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -96415,7 +96415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -96430,14 +96430,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ff71b63d2b0f5985dc9aa48c13eb9217b9b847b423f12be5bfb69d48c9e30735
+        config.redpanda.com/checksum: 42aba39117a1841d529bfb9c30d60d1501ddaa8d7a1619495642c6b6fa357743
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -96730,7 +96730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -96756,7 +96756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -96782,7 +96782,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -96820,7 +96820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -96858,7 +96858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -96874,7 +96874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -96891,7 +96891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -96907,7 +96907,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -96951,7 +96951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -97039,7 +97039,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -97117,7 +97117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -97199,7 +97199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -97292,7 +97292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -97330,7 +97330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -97578,7 +97578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -97609,7 +97609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -97700,7 +97700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -97746,7 +97746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -97906,7 +97906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -97921,14 +97921,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -98221,7 +98221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -98247,7 +98247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -98273,7 +98273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -98311,7 +98311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -98349,7 +98349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -98365,7 +98365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -98382,7 +98382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -98398,7 +98398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -98442,7 +98442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -98532,7 +98532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -98610,7 +98610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -98645,7 +98645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -98738,7 +98738,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -98776,7 +98776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -99030,7 +99030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -99061,7 +99061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -99152,7 +99152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -99198,7 +99198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -99342,7 +99342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -99357,14 +99357,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 3915ccad139b95370907ae0565018041aa7ed93a7e8909be28f433abab52fb6a
+        config.redpanda.com/checksum: c626646bc1c059385811e7ac429800a2dab657c95c75880b3ec844f2e7ce1183
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -99657,7 +99657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -99683,7 +99683,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -99709,7 +99709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -99747,7 +99747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -99785,7 +99785,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -99801,7 +99801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -99818,7 +99818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -99834,7 +99834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -99878,7 +99878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -99966,7 +99966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -100044,7 +100044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -100079,7 +100079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -100172,7 +100172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -100210,7 +100210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -100458,7 +100458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -100489,7 +100489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -100580,7 +100580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -100626,7 +100626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -100770,7 +100770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -100785,14 +100785,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ff71b63d2b0f5985dc9aa48c13eb9217b9b847b423f12be5bfb69d48c9e30735
+        config.redpanda.com/checksum: 42aba39117a1841d529bfb9c30d60d1501ddaa8d7a1619495642c6b6fa357743
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -101085,7 +101085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -101111,7 +101111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -101137,7 +101137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -101175,7 +101175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -101213,7 +101213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -101229,7 +101229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -101246,7 +101246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -101262,7 +101262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -101306,7 +101306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -101394,7 +101394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -101472,7 +101472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -101554,7 +101554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -101647,7 +101647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -101685,7 +101685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -101933,7 +101933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -101964,7 +101964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -102055,7 +102055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -102101,7 +102101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -102261,7 +102261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -102276,14 +102276,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -102576,7 +102576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -102602,7 +102602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -102628,7 +102628,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -102666,7 +102666,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -102704,7 +102704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -102720,7 +102720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -102737,7 +102737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -102753,7 +102753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -102797,7 +102797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -102887,7 +102887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -102965,7 +102965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -103000,7 +103000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -103093,7 +103093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -103131,7 +103131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -103385,7 +103385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -103416,7 +103416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -103507,7 +103507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -103553,7 +103553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -103697,7 +103697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -103712,14 +103712,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 3915ccad139b95370907ae0565018041aa7ed93a7e8909be28f433abab52fb6a
+        config.redpanda.com/checksum: c626646bc1c059385811e7ac429800a2dab657c95c75880b3ec844f2e7ce1183
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -104012,7 +104012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -104038,7 +104038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -104064,7 +104064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -104102,7 +104102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -104140,7 +104140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -104156,7 +104156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -104173,7 +104173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -104189,7 +104189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -104233,7 +104233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -104321,7 +104321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -104399,7 +104399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -104434,7 +104434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -104527,7 +104527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -104565,7 +104565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -104813,7 +104813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -104844,7 +104844,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -104935,7 +104935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -104981,7 +104981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -105125,7 +105125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -105140,14 +105140,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -105467,7 +105467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -105555,7 +105555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -105633,7 +105633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -105668,7 +105668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -105761,7 +105761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -105799,7 +105799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -106046,7 +106046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -106076,7 +106076,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -106167,7 +106167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -106213,7 +106213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -106339,7 +106339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -106354,14 +106354,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 5c2a8e051f87d8f880534d9479823632719f49bc41bc61ae18a06a45ec0f4db5
+        config.redpanda.com/checksum: 53b9e568a243c90d235051c54c5c30d1da84d174b8c43e674579fc5e1cc402b4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -106681,7 +106681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -106769,7 +106769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -106847,7 +106847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -106882,7 +106882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -106975,7 +106975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -107013,7 +107013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -107323,7 +107323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -107354,7 +107354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -107445,7 +107445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -107491,7 +107491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -107655,7 +107655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -107670,14 +107670,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: bac9d28eef6e1ee03492442dd8fbd12b95d5b6a7993866bf1bec6a7699e0f139
+        config.redpanda.com/checksum: 3e2586d087a9140b8b8f22ed8ff23ad42af3a33ae1b2f4a0bf472b9727a7c23d
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -108015,7 +108015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -108041,7 +108041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -108067,7 +108067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -108105,7 +108105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -108143,7 +108143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -108159,7 +108159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -108176,7 +108176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -108192,7 +108192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -108236,7 +108236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -108324,7 +108324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -108402,7 +108402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -108437,7 +108437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -108530,7 +108530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -108568,7 +108568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -108819,7 +108819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -108852,7 +108852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -108943,7 +108943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -108989,7 +108989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -109133,7 +109133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -109148,14 +109148,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 3eb4f834c1c785ade8f148bc82980bb9d0faf92bf64ea60f1bf080d348e13306
+        config.redpanda.com/checksum: ee28a30231d6d4cbaab83b8c8b8da05c4833148d1ac581152ed0d714599bd95e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -109460,7 +109460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -109486,7 +109486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -109512,7 +109512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -109538,7 +109538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -109576,7 +109576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -109614,7 +109614,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -109652,7 +109652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -109677,7 +109677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -109693,7 +109693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -109710,7 +109710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -109726,7 +109726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -109743,7 +109743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -109759,7 +109759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -109803,7 +109803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -109897,7 +109897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -109981,7 +109981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -110016,7 +110016,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -110109,7 +110109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -110147,7 +110147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -110395,7 +110395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -110426,7 +110426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -110517,7 +110517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -110563,7 +110563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -110707,7 +110707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -110722,14 +110722,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0d02899e253d3d7d21fdc232c8c0f57ccfe7c9d49d8a8bd487f6ff93f4d8e373
+        config.redpanda.com/checksum: f4848bd72897c9d7f5add61fa8c85cf4a1ef802ed92e801961f60477ae39be9c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -111022,7 +111022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -111048,7 +111048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -111074,7 +111074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -111112,7 +111112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -111150,7 +111150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -111166,7 +111166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -111183,7 +111183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -111199,7 +111199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -111243,7 +111243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -111331,7 +111331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -111409,7 +111409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -111444,7 +111444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -111537,7 +111537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -111575,7 +111575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -111821,7 +111821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -111852,7 +111852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -111943,7 +111943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -111989,7 +111989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -112133,7 +112133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -112148,14 +112148,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 41277586b023d92d69c627621845dbf882612366ce060a9ec7e4f4aef91398be
+        config.redpanda.com/checksum: c3bdad6e146b00384c28f194451175cc375294491c88fd1d3e7400e0a074ddc0
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -112448,7 +112448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -112474,7 +112474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -112500,7 +112500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -112538,7 +112538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -112576,7 +112576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -112592,7 +112592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -112609,7 +112609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -112625,7 +112625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -112669,7 +112669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -112757,7 +112757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -112835,7 +112835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -112917,7 +112917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -113010,7 +113010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -113048,7 +113048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -113294,7 +113294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -113325,7 +113325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -113416,7 +113416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -113462,7 +113462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -113622,7 +113622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -113637,14 +113637,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 8600a35765278df4fca07e3a6b698e64e988fbed3178d6c51c1b8c84f446649c
+        config.redpanda.com/checksum: 23507efd6d0b6b7fbb31dbf9d357282f7acbf4497243d48d669a665d122e1c64
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -113937,7 +113937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -113963,7 +113963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -113989,7 +113989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -114027,7 +114027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -114065,7 +114065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -114081,7 +114081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -114098,7 +114098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -114114,7 +114114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -114158,7 +114158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -114248,7 +114248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -114326,7 +114326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -114361,7 +114361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -114454,7 +114454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -114492,7 +114492,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -114744,7 +114744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -114775,7 +114775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -114866,7 +114866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -114912,7 +114912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -115056,7 +115056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -115071,14 +115071,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 379b6b222b203f099603f249796e8449071daa43517dfa805c9296c82ed504d6
+        config.redpanda.com/checksum: a08ab6e3001b0b8ce2a16e0775d5b0f6d09a3d8908c7e017f313c57a5ae42b23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -115371,7 +115371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -115397,7 +115397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -115423,7 +115423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -115461,7 +115461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -115499,7 +115499,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -115515,7 +115515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -115532,7 +115532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -115548,7 +115548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -115592,7 +115592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -115680,7 +115680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -115758,7 +115758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -115793,7 +115793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -115886,7 +115886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -115924,7 +115924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -116172,7 +116172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -116203,7 +116203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -116294,7 +116294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -116340,7 +116340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -116484,7 +116484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -116499,14 +116499,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: ff71b63d2b0f5985dc9aa48c13eb9217b9b847b423f12be5bfb69d48c9e30735
+        config.redpanda.com/checksum: 42aba39117a1841d529bfb9c30d60d1501ddaa8d7a1619495642c6b6fa357743
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -116799,7 +116799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -116825,7 +116825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -116851,7 +116851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -116889,7 +116889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -116927,7 +116927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -116943,7 +116943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -116960,7 +116960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -116976,7 +116976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -117020,7 +117020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -117108,7 +117108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -117186,7 +117186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -117268,7 +117268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -117361,7 +117361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -117399,7 +117399,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -117647,7 +117647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -117678,7 +117678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -117769,7 +117769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -117815,7 +117815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -117975,7 +117975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -117990,14 +117990,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -118290,7 +118290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -118316,7 +118316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -118342,7 +118342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -118380,7 +118380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -118418,7 +118418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -118434,7 +118434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -118451,7 +118451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -118467,7 +118467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -118511,7 +118511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -118601,7 +118601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -118679,7 +118679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -118714,7 +118714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -118807,7 +118807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -118845,7 +118845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -119099,7 +119099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -119130,7 +119130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -119221,7 +119221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -119267,7 +119267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -119411,7 +119411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -119426,14 +119426,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 3915ccad139b95370907ae0565018041aa7ed93a7e8909be28f433abab52fb6a
+        config.redpanda.com/checksum: c626646bc1c059385811e7ac429800a2dab657c95c75880b3ec844f2e7ce1183
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -119726,7 +119726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -119752,7 +119752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -119778,7 +119778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -119816,7 +119816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -119854,7 +119854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -119870,7 +119870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -119887,7 +119887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -119903,7 +119903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -119947,7 +119947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -120035,7 +120035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -120113,7 +120113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -120148,7 +120148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -120241,7 +120241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -120279,7 +120279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -120527,7 +120527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 ---
@@ -120558,7 +120558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-rpk
   namespace: default
 ---
@@ -120649,7 +120649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -120695,7 +120695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external
   namespace: default
 spec:
@@ -120839,7 +120839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda
   namespace: default
 spec:
@@ -120854,14 +120854,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 4e59482b2f67d095b3d32ed889acebc328102b915843b11c25fd366a5699bd5b
+        config.redpanda.com/checksum: fe071c0b7a5641751684a84cb1f8db1330f1bb0eb6a954a260860532a21fa42c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.0
+        helm.sh/chart: redpanda-5.9.1
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -121154,7 +121154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -121180,7 +121180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -121206,7 +121206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -121244,7 +121244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -121282,7 +121282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -121298,7 +121298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -121315,7 +121315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -121331,7 +121331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -121375,7 +121375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-configuration
   namespace: default
 spec:
@@ -121463,7 +121463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.0
+    helm.sh/chart: redpanda-5.9.1
   name: redpanda-post-upgrade
   namespace: default
 spec:


### PR DESCRIPTION
This commit releases the aforementioned versions of the redpanda and console charts.

The console chart was previously partially released. The Chart.yaml's version was not bumped which resulted in no release being created.