### PR TITLE
Support trailing empty labels in FQDN parsing routine

### DIFF
--- a/pkg/kube/dialer.go
+++ b/pkg/kube/dialer.go
@@ -184,6 +184,10 @@ func (p *PodDialer) parseDNS(fqdn string) (types.NamespacedName, int, error) {
 
 	fqdn = addressPort[0]
 
+	// Trim any empty labels as our Helm chart-based
+	// URLS use FQDNs ending with an empty label
+	fqdn = strings.TrimSuffix(fqdn, ".")
+
 	isServiceDNS := true
 
 	if strings.Count(fqdn, ".") < 2 {

--- a/pkg/kube/dialer_test.go
+++ b/pkg/kube/dialer_test.go
@@ -150,6 +150,8 @@ func TestDialer(t *testing.T) {
 		// https pod-based DNS
 		"https://name.default",
 		"https://name",
+		// trailing dots
+		"http://name.service.default.svc.cluster.local.",
 	} {
 		t.Run(host, func(t *testing.T) {
 			_, err = httpClient.Get(host)


### PR DESCRIPTION
Previously addressing feedback in my PR to introduce a Kafka/Admin API client constructor into this repo, I [refactored](https://github.com/redpanda-data/helm-charts/pull/1486/commits/91fa8c1f501e8f45dc762e3ccc3df2f148c6bb28) the URL construction code to leverage the same internal helper that constructs URLs with the InternalDomain helper.

Doing this exposed two things:

1. We use an "empty label" trailing dot for our internal domains:

https://github.com/redpanda-data/helm-charts/blob/aca43d8bd857e9d41e68269765fa84f68774203e/charts/redpanda/helpers.go#L136

2. We weren't handling that in the FQDN parsing code that I had added for our dialer.

As a result, when I tried to tie these two pieces of code together with the introduction of a client factory in our operator repo, anything using a Redpanda cluster reference to initialize a client failed with an "invalid FQDN" error. This fixes that and supports the perfectly valid use-case where we have an empty label terminating a fully qualified domain name.