### PR TITLE
operator: bump app version and release

### DIFF
--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,11 +6,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.27
+version: 0.4.28
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging
-appVersion: v2.1.29-24.2.2
+appVersion: v2.2.0-24.2.2
 
 sources:
   - https://github.com/redpanda-data/helm-charts

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.27](https://img.shields.io/badge/Version-0.4.27-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.1.29-24.2.2](https://img.shields.io/badge/AppVersion-v2.1.29--24.2.2-informational?style=flat-square)
+![Version: 0.4.28](https://img.shields.io/badge/Version-0.4.28-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0-24.2.2](https://img.shields.io/badge/AppVersion-v2.2.0--24.2.2-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 


### PR DESCRIPTION
This commit updates the operator chart's `appVersion` to the fastest operator version `v2.2.0-24.2.2` and releases it.