### PR TITLE
OIDC console example

### DIFF
--- a/charts/console/testdata/template-cases.golden.txtar
+++ b/charts/console/testdata/template-cases.golden.txtar
@@ -22523,6 +22523,19 @@ data:
     # from .Values.console.config
     login:
       enabled: true
+      oidc:
+        clientId: XYZ
+        displayName: my-corp-provider
+        domain: my-test-domain.com
+        enabled: true
+        issuerTls:
+          caFilepath: /oidc-tls/ca.crt
+          certFilepath: /oidc-tls/tls.crt
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: /oidc-tls/tls.key
+        issuerUrl: my-oidc-issuer.com
+        userIdentifyingClaimKey: corpo-name
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -22583,7 +22596,7 @@ spec:
   template:
     metadata:
       annotations:
-        checksum/config: 1d8cc88294f986688534e08a08a4281dadd270083b8907ba1a5dc7abb36e9102
+        checksum/config: 8b5fca5c113b1cf26ce987d736fc6a3775b3d8224f82066986c688a257a2f00d
       creationTimestamp: null
       labels:
         app.kubernetes.io/instance: console
@@ -22601,7 +22614,9 @@ spec:
             secretKeyRef:
               key: login-jwt-secret
               name: console
-        envFrom: []
+        envFrom:
+        - secretRef:
+            name: my-client-secret-oidc
         image: docker.redpanda.com/redpandadata/console:v2.7.0
         imagePullPolicy: IfNotPresent
         livenessProbe:
@@ -22637,6 +22652,9 @@ spec:
         - mountPath: /etc/console/secrets
           name: secrets
           readOnly: true
+        - mountPath: /oidc-tls
+          name: oidc-issuer-tls
+          readOnly: true
       imagePullSecrets: []
       initContainers: []
       nodeSelector: {}
@@ -22654,6 +22672,9 @@ spec:
       - name: secrets
         secret:
           secretName: console
+      - name: oidc-issuer-tls
+        secret:
+          secretName: corporate-issuer-tls
 ---
 # Source: console/templates/tests/test-connection.yaml
 apiVersion: v1

--- a/charts/console/testdata/template-cases.golden.txtar
+++ b/charts/console/testdata/template-cases.golden.txtar
@@ -22460,6 +22460,223 @@ spec:
       args: ['console:8080']
   restartPolicy: Never
   priorityClassName:
+-- testdata/console-with-oidc-conf.yaml.golden --
+---
+# Source: console/templates/serviceaccount.yaml
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: console
+  namespace: default
+---
+# Source: console/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: console
+stringData:
+  enterprise-license: ""
+  kafka-protobuf-git-basicauth-password: ""
+  kafka-sasl-aws-msk-iam-secret-key: ""
+  kafka-sasl-password: ""
+  kafka-schema-registry-password: ""
+  kafka-schemaregistry-tls-ca: ""
+  kafka-schemaregistry-tls-cert: ""
+  kafka-schemaregistry-tls-key: ""
+  kafka-tls-ca: ""
+  kafka-tls-cert: ""
+  kafka-tls-key: ""
+  login-github-oauth-client-secret: ""
+  login-github-personal-access-token: ""
+  login-google-groups-service-account.json: ""
+  login-google-oauth-client-secret: ""
+  login-jwt-secret: SECRETKEY
+  login-oidc-client-secret: ""
+  login-okta-client-secret: ""
+  login-okta-directory-api-token: ""
+  redpanda-admin-api-password: ""
+  redpanda-admin-api-tls-ca: ""
+  redpanda-admin-api-tls-cert: ""
+  redpanda-admin-api-tls-key: ""
+type: Opaque
+---
+# Source: console/templates/configmap.yaml
+apiVersion: v1
+data:
+  config.yaml: |
+    # from .Values.console.config
+    login:
+      enabled: true
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: console
+---
+# Source: console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: console
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
+  selector:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/name: console
+  type: ClusterIP
+---
+# Source: console/templates/deployment.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: console
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: console
+      app.kubernetes.io/name: console
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        checksum/config: 1d8cc88294f986688534e08a08a4281dadd270083b8907ba1a5dc7abb36e9102
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: console
+        app.kubernetes.io/name: console
+    spec:
+      affinity: {}
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --config.filepath=/etc/console/configs/config.yaml
+        command: null
+        env:
+        - name: LOGIN_JWTSECRET
+          valueFrom:
+            secretKeyRef:
+              key: login-jwt-secret
+              name: console
+        envFrom: []
+        image: docker.redpanda.com/redpandadata/console:v2.7.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /admin/health
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: console
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /admin/health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/console/configs
+          name: configs
+          readOnly: true
+        - mountPath: /etc/console/secrets
+          name: secrets
+          readOnly: true
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      serviceAccountName: console
+      tolerations: []
+      topologySpreadConstraints: []
+      volumes:
+      - configMap:
+          name: console
+        name: configs
+      - name: secrets
+        secret:
+          secretName: console
+---
+# Source: console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "console-test-connection"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: console
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['console:8080']
+  restartPolicy: Never
+  priorityClassName:
 -- testdata/console-with-role-bindings.yaml.golden --
 ---
 # Source: console/templates/serviceaccount.yaml

--- a/charts/console/testdata/template-cases.txtar
+++ b/charts/console/testdata/template-cases.txtar
@@ -137,7 +137,34 @@ initContainers:
 
 -- console-with-oidc-conf --
 
+extraEnvFrom:
+  - secretRef:
+      name: my-client-secret-oidc
+
+extraVolumes:
+  - name: oidc-issuer-tls
+    secret:
+      secretName: corporate-issuer-tls
+
+extraVolumeMounts:
+  - name: oidc-issuer-tls
+    mountPath: /oidc-tls
+    readOnly: true
+
 console:
   config:
     login:
       enabled: true
+      oidc:
+        enabled: true
+        clientId: XYZ
+        domain: my-test-domain.com
+        issuerUrl: my-oidc-issuer.com
+        displayName: my-corp-provider
+        userIdentifyingClaimKey: corpo-name
+        issuerTls:
+          enabled: true
+          caFilepath: /oidc-tls/ca.crt
+          certFilepath: /oidc-tls/tls.crt
+          keyFilepath: /oidc-tls/tls.key
+          insecureSkipTlsVerify: false

--- a/charts/console/testdata/template-cases.txtar
+++ b/charts/console/testdata/template-cases.txtar
@@ -134,3 +134,10 @@ initContainers:
        - |
          set -xe
          echo "Hello {{ add 1 2 }}!"
+
+-- console-with-oidc-conf --
+
+console:
+  config:
+    login:
+      enabled: true


### PR DESCRIPTION
Example oidc configuration test case

The `my-client-secret-oidc` secret could be created using the following
kubectl command:
```
kubectl create secret generic my-client-secret-oidc --from-literal=LOGIN_OIDC_CLIENTSECRET=XYZ_REDACTED_SECRET
```

The key of that secret is crucial to correctly configure Console as it
correspond to the path within enterprise Console configuration schema.

Reference:
https://docs.redpanda.com/beta/reference/console/config/#environment-variables