### PR TITLE
redpanda: respect `default_topic_replications` if explicitly set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@
 #### Fixed
 #### Removed
 
+### [5.9.3](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.3) - 2024-09-11
+#### Added
+* Add basic bootstrap user support (#1513)
+#### Changed
+#### Fixed
+* When specified, `truststore_file` is no longer propagated to client configurations.
+* If provided, `config.cluster.default_topic_replications` is now respected regardless of the value of `statefulset.replicas`.
+#### Removed
+
 ### [5.9.1](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.1) - 2024-8-19
 #### Added
 #### Changed

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.9.2
+version: 5.9.3
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.2](https://img.shields.io/badge/Version-5.9.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.3](https://img.shields.io/badge/AppVersion-v24.2.3-informational?style=flat-square)
+![Version: 5.9.3](https://img.shields.io/badge/Version-5.9.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.3](https://img.shields.io/badge/AppVersion-v24.2.3-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
@@ -172,7 +172,7 @@ This section contains various settings supported by Redpanda that may not work c
 **Default:**
 
 ```
-{"cluster":{"default_topic_replications":3},"node":{"crash_loop_limit":5},"pandaproxy_client":{},"rpk":{},"schema_registry_client":{},"tunable":{"compacted_log_segment_size":67108864,"group_topic_partitions":16,"kafka_batch_max_bytes":1048576,"kafka_connection_rate_limit":1000,"log_segment_size":134217728,"log_segment_size_max":268435456,"log_segment_size_min":16777216,"max_compacted_log_segment_size":536870912,"topic_partitions_per_shard":1000}}
+{"cluster":{},"node":{"crash_loop_limit":5},"pandaproxy_client":{},"rpk":{},"schema_registry_client":{},"tunable":{"compacted_log_segment_size":67108864,"group_topic_partitions":16,"kafka_batch_max_bytes":1048576,"kafka_connection_rate_limit":1000,"log_segment_size":134217728,"log_segment_size_max":268435456,"log_segment_size_min":16777216,"max_compacted_log_segment_size":536870912,"topic_partitions_per_shard":1000}}
 ```
 
 ### [config.node](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=config.node)

--- a/charts/redpanda/ci/05-one-node-cluster-tls-sasl-values.yaml
+++ b/charts/redpanda/ci/05-one-node-cluster-tls-sasl-values.yaml
@@ -30,7 +30,6 @@ auth:
 
 config:
   cluster:
-    default_topic_replications: 3
     kafka_nodelete_topics: ['audit', 'consumer_offsets', '_schemas', 'my_sample_topic']
 
 storage:

--- a/charts/redpanda/configmap.tpl.go
+++ b/charts/redpanda/configmap.tpl.go
@@ -61,7 +61,7 @@ func BootstrapFile(dot *helmette.Dot) string {
 	bootstrap = helmette.Merge(bootstrap, values.AuditLogging.Translate(dot, values.Auth.IsSASLEnabled()))
 	bootstrap = helmette.Merge(bootstrap, values.Logging.Translate())
 	bootstrap = helmette.Merge(bootstrap, values.Config.Tunable.Translate())
-	bootstrap = helmette.Merge(bootstrap, values.Config.Cluster.Translate(values.Statefulset.Replicas, false))
+	bootstrap = helmette.Merge(bootstrap, values.Config.Cluster.Translate())
 	bootstrap = helmette.Merge(bootstrap, values.Auth.Translate(values.Auth.IsSASLEnabled()))
 
 	return helmette.ToYaml(bootstrap)
@@ -84,7 +84,7 @@ func RedpandaConfigFile(dot *helmette.Dot, includeSeedServer bool) string {
 	redpanda = helmette.Merge(redpanda, values.AuditLogging.Translate(dot, values.Auth.IsSASLEnabled()))
 	redpanda = helmette.Merge(redpanda, values.Logging.Translate())
 	redpanda = helmette.Merge(redpanda, values.Config.Tunable.Translate())
-	redpanda = helmette.Merge(redpanda, values.Config.Cluster.Translate(values.Statefulset.Replicas, true))
+	redpanda = helmette.Merge(redpanda, values.Config.Cluster.Translate())
 	redpanda = helmette.Merge(redpanda, values.Auth.Translate(values.Auth.IsSASLEnabled()))
 	redpanda = helmette.Merge(redpanda, values.Config.Node.Translate())
 

--- a/charts/redpanda/templates/_configmap.go.tpl
+++ b/charts/redpanda/templates/_configmap.go.tpl
@@ -31,7 +31,7 @@
 {{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.AuditLogging.Translate" (dict "a" (list $values.auditLogging $dot (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.Logging.Translate" (dict "a" (list $values.logging) ))) "r")) -}}
 {{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.TunableConfig.Translate" (dict "a" (list $values.config.tunable) ))) "r")) -}}
-{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.ClusterConfig.Translate" (dict "a" (list $values.config.cluster ($values.statefulset.replicas | int) false) ))) "r")) -}}
+{{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.ClusterConfig.Translate" (dict "a" (list $values.config.cluster) ))) "r")) -}}
 {{- $bootstrap = (merge (dict ) $bootstrap (get (fromJson (include "redpanda.Auth.Translate" (dict "a" (list $values.auth (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (toYaml $bootstrap)) | toJson -}}
@@ -52,7 +52,7 @@
 {{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.AuditLogging.Translate" (dict "a" (list $values.auditLogging $dot (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.Logging.Translate" (dict "a" (list $values.logging) ))) "r")) -}}
 {{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.TunableConfig.Translate" (dict "a" (list $values.config.tunable) ))) "r")) -}}
-{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.ClusterConfig.Translate" (dict "a" (list $values.config.cluster ($values.statefulset.replicas | int) true) ))) "r")) -}}
+{{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.ClusterConfig.Translate" (dict "a" (list $values.config.cluster) ))) "r")) -}}
 {{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.Auth.Translate" (dict "a" (list $values.auth (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $redpanda = (merge (dict ) $redpanda (get (fromJson (include "redpanda.NodeConfig.Translate" (dict "a" (list $values.config.node) ))) "r")) -}}
 {{- $_ := (get (fromJson (include "redpanda.configureListeners" (dict "a" (list $redpanda $dot) ))) "r") -}}

--- a/charts/redpanda/templates/_values.go.tpl
+++ b/charts/redpanda/templates/_values.go.tpl
@@ -1246,35 +1246,15 @@
 
 {{- define "redpanda.ClusterConfig.Translate" -}}
 {{- $c := (index .a 0) -}}
-{{- $replicas := (index .a 1) -}}
-{{- $skipDefaultTopic := (index .a 2) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $result := (dict ) -}}
 {{- range $k, $v := $c -}}
-{{- if (and (eq $k "default_topic_replications") (not $skipDefaultTopic)) -}}
-{{- $r := ($replicas | int) -}}
-{{- $input := ($r | int) -}}
-{{- $tmp_tuple_15 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $v) ))) "r")) ))) "r") -}}
+{{- $tmp_tuple_15 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
 {{- $ok_17 := $tmp_tuple_15.T2 -}}
-{{- $num_16 := ($tmp_tuple_15.T1 | int) -}}
+{{- $b_16 := $tmp_tuple_15.T1 -}}
 {{- if $ok_17 -}}
-{{- $input = $num_16 -}}
-{{- end -}}
-{{- $tmp_tuple_16 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asnumeric" (dict "a" (list $v) ))) "r")) ))) "r") -}}
-{{- $ok_19 := $tmp_tuple_16.T2 -}}
-{{- $f_18 := ($tmp_tuple_16.T1 | float64) -}}
-{{- if $ok_19 -}}
-{{- $input = ($f_18 | int) -}}
-{{- end -}}
-{{- $_ := (set $result $k (min ($input | int64) (((sub ((add $r (((mod $r (2 | int)) | int))) | int) (1 | int)) | int) | int64))) -}}
-{{- continue -}}
-{{- end -}}
-{{- $tmp_tuple_17 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $v false) ))) "r")) ))) "r") -}}
-{{- $ok_21 := $tmp_tuple_17.T2 -}}
-{{- $b_20 := $tmp_tuple_17.T1 -}}
-{{- if $ok_21 -}}
-{{- $_ := (set $result $k $b_20) -}}
+{{- $_ := (set $result $k $b_16) -}}
 {{- continue -}}
 {{- end -}}
 {{- if (not (empty $v)) -}}

--- a/charts/redpanda/templates/post_upgrade_job.yaml
+++ b/charts/redpanda/templates/post_upgrade_job.yaml
@@ -29,11 +29,6 @@
 {{- $tmp_tuple_1 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.asintegral" (dict "a" (list $value) ))) "r")) ))) "r") -}}
 {{- $isInt64 := $tmp_tuple_1.T2 -}}
 {{- $asInt64 := ($tmp_tuple_1.T1 | int64) -}}
-{{- if (and (eq $key "default_topic_replications") $isInt64) -}}
-{{- $r := (($values.statefulset.replicas | int) | int64) -}}
-{{- $r = ((sub (((add $r (((mod $r (2 | int64)) | int64))) | int64)) (1 | int64)) | int64) -}}
-{{- $asInt64 = (min $asInt64 ($r | int64)) -}}
-{{- end -}}
 {{- $tmp_tuple_2 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.typetest" (dict "a" (list "bool" $value false) ))) "r")) ))) "r") -}}
 {{- $ok_2 := $tmp_tuple_2.T2 -}}
 {{- $asBool_1 := $tmp_tuple_2.T1 -}}
@@ -62,9 +57,14 @@
 {{- if $_is_returning -}}
 {{- break -}}
 {{- end -}}
-{{- $tmp_tuple_5 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.config.cluster "storage_min_free_bytes" (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $tmp_tuple_5 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.config.cluster "default_topic_replications" (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $ok_7 := $tmp_tuple_5.T2 -}}
-{{- if (not $ok_7) -}}
+{{- if (and (not $ok_7) (ge ($values.statefulset.replicas | int) (3 | int))) -}}
+{{- $script = (concat (default (list ) $script) (list "rpk cluster config set default_topic_replications 3")) -}}
+{{- end -}}
+{{- $tmp_tuple_6 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $values.config.cluster "storage_min_free_bytes" (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_8 := $tmp_tuple_6.T2 -}}
+{{- if (not $ok_8) -}}
 {{- $script = (concat (default (list ) $script) (list (printf "rpk cluster config set storage_min_free_bytes %d" ((get (fromJson (include "redpanda.Storage.StorageMinFreeBytes" (dict "a" (list $values.storage) ))) "r") | int64)))) -}}
 {{- end -}}
 {{- if (get (fromJson (include "redpanda.RedpandaAtLeast_23_2_1" (dict "a" (list $dot) ))) "r") -}}

--- a/charts/redpanda/templates/tests/test-auditLogging.yaml
+++ b/charts/redpanda/templates/tests/test-auditLogging.yaml
@@ -51,7 +51,7 @@ spec:
           old_setting=${-//[^x]/}
           audit_topic_name="_redpanda.audit_log"
           expected_partitions={{ .Values.auditLogging.partitions }}
-          
+
           # sasl configurations
           set +x
           IFS=":" read -r {{ include "rpk-sasl-environment-variables" . }} < <(grep "" $(find /etc/secrets/users/* -print))
@@ -62,12 +62,7 @@ spec:
           {{- end }}
           export {{ include "rpk-sasl-environment-variables" . }}
           if [[ -n "$old_setting" ]]; then set -x; fi
-        
-          {{- $i := .Values.statefulset.replicas }}
-          {{- $default_topic_replicas := sub (add $i (mod $i 2)) 1 }}
-          # wait for post-upgrade job to update the default_topic_replications value
-          timeout 600 bash -c "until [[ $(rpk cluster config get default_topic_replications) = {{ $default_topic_replicas }} ]]; do sleep 1; done"
-          
+
           # now run the to determine if we have the right results
           # should describe topic without error
           rpk topic describe ${audit_topic_name}

--- a/charts/redpanda/templates/tests/test-kafka-nodelete.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-nodelete.yaml
@@ -68,11 +68,7 @@ spec:
           export {{ include "rpk-sasl-environment-variables" . }}
           if [[ -n "$old_setting" ]]; then set -x; fi
 {{- end }}
-          {{- $i := .Values.statefulset.replicas }}
-          {{- $default_topic_replicas := sub (add $i (mod $i 2)) 1 }}
-          # wait for post-upgrade job to update the default_topic_replications value
-          timeout 120 bash -c "until [[ $(rpk cluster config get default_topic_replications) = {{ $default_topic_replicas }} ]]; do sleep 1; done"
-  
+
           exists=$(rpk topic list | grep my_sample_topic | awk '{print $1}')
           if [[ "$exists" != "my_sample_topic" ]]; then
             until rpk topic create my_sample_topic {{ $cloudStorageFlags }}
@@ -85,7 +81,7 @@ spec:
           {{- end }}
           sleep 2
           rpk topic consume my_sample_topic -n 1 | grep "Pandas are awesome!"
-         
+
           # now check if we can delete the topic (we should not)
           rpk topic delete my_sample_topic
 

--- a/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
+++ b/charts/redpanda/templates/tests/test-kafka-produce-consume.yaml
@@ -67,10 +67,6 @@ spec:
           export {{ include "rpk-sasl-environment-variables" . }}
           if [[ -n "$old_setting" ]]; then set -x; fi
 {{- end }}
-          {{- $i := .Values.statefulset.replicas }}
-          {{- $default_topic_replicas := sub (add $i (mod $i 2)) 1 }}
-          # wait for post-upgrade job to update the default_topic_replications value
-          timeout 600 bash -c "until [[ $(rpk cluster config get default_topic_replications) = {{ $default_topic_replicas }} ]]; do sleep 1; done"
           until rpk topic create produce.consume.test.$POD_NAME {{ $cloudStorageFlags }}
             do sleep 2
           done

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -235,7 +235,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -307,7 +306,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -423,7 +421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -454,7 +452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -547,7 +545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -593,7 +591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -749,7 +747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -764,14 +762,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -1064,7 +1062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -1090,7 +1088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -1116,7 +1114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1154,7 +1152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1192,7 +1190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -1208,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -1225,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -1241,7 +1239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -1285,7 +1283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1375,7 +1373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -1453,7 +1451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1492,7 +1490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -1587,7 +1585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -1626,7 +1624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -1671,7 +1669,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 1
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -1712,7 +1709,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -1779,7 +1775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1805,7 +1801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -1895,7 +1891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -1942,7 +1938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -2074,7 +2070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -2090,14 +2086,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 6792799eef652353937d228551ca9658a41e4aa4209ed9c302fe12782bc0fd53
+        config.redpanda.com/checksum: 945ed23acf87df616ff55bb2d7dbd02704929135f5389fc85e9cf175bd52e9b1
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
     spec:
@@ -2394,7 +2390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -2474,7 +2470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     testlabel: exercise_common_labels_template
   name: redpanda-post-upgrade
   namespace: default
@@ -2497,7 +2493,6 @@ spec:
         - |
           set -e
 
-          rpk cluster config set default_topic_replications 1
           rpk cluster config set retention_local_target_ms_default 21600000
           rpk cluster config set storage_min_free_bytes 161061273
           if [ -d "/etc/secrets/users/" ]; then
@@ -2543,7 +2538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -2581,7 +2576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -2675,7 +2670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -2713,7 +2708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -2757,7 +2752,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 1
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -2825,7 +2819,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -2927,7 +2920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -2954,7 +2947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -3043,7 +3036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -3089,7 +3082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -3245,7 +3238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -3260,14 +3253,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d39d8820c236987d07f35148aa238a6942a84894e3ed3b05ac895bb1bffa2b19
+        config.redpanda.com/checksum: 20cc89dc47888fe7d20d08fc8113cb590e2d9e2762cbaf08aa0da5cc4f800500
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -3560,7 +3553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -3586,7 +3579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -3612,7 +3605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -3650,7 +3643,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -3688,7 +3681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -3704,7 +3697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -3721,7 +3714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -3737,7 +3730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -3781,7 +3774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -3871,7 +3864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -3892,7 +3885,6 @@ spec:
         - |
           set -e
 
-          rpk cluster config set default_topic_replications 1
           rpk cluster config set storage_min_free_bytes 161061273
           if [ -d "/etc/secrets/users/" ]; then
               IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
@@ -3949,7 +3941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -3987,7 +3979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -4085,7 +4077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-users
   namespace: default
 stringData:
@@ -4102,7 +4094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -4239,7 +4231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -4287,7 +4279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -4300,7 +4292,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 1
     enable_rack_awareness: false
     enable_sasl: true
     group_topic_partitions: 16
@@ -4345,7 +4336,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
       group_topic_partitions: 16
@@ -4418,7 +4408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -4443,7 +4433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -4532,7 +4522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -4578,7 +4568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -4724,7 +4714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -4739,14 +4729,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 8c22851012a440f124b61ede7f178b2dc6c0803748c20a27b5176fb547ff060b
+        config.redpanda.com/checksum: e6ab46f0225db04425dabcc6f8323b0ae49e6736a7caf23ed6127d40bf98c140
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -5085,7 +5075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -5178,7 +5168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -5199,7 +5189,6 @@ spec:
         - |
           set -e
 
-          rpk cluster config set default_topic_replications 1
           rpk cluster config set storage_min_free_bytes 161061273
           if [ -d "/etc/secrets/users/" ]; then
               IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
@@ -5259,7 +5248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -5297,7 +5286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -5395,7 +5384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-users
   namespace: default
 stringData:
@@ -5412,7 +5401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -5549,7 +5538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -5597,7 +5586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -5610,7 +5599,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 1
     enable_rack_awareness: false
     enable_sasl: true
     group_topic_partitions: 16
@@ -5688,7 +5676,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
       group_topic_partitions: 16
@@ -5802,7 +5789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -5829,7 +5816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -5918,7 +5905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -5964,7 +5951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -6135,7 +6122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -6150,14 +6137,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7bef64de129befe1ac0167a9a9327e92b06d97013ebe7bd3e09bba6c552cd8d6
+        config.redpanda.com/checksum: 403fffd1d61494058d7473a752eb95f3c8388a7ceb510896a0ef947bb72e3b76
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -6494,7 +6481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -6520,7 +6507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -6546,7 +6533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -6584,7 +6571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -6622,7 +6609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -6638,7 +6625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -6655,7 +6642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -6671,7 +6658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -6715,7 +6702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -6820,7 +6807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -6841,7 +6828,6 @@ spec:
         - |
           set -e
 
-          rpk cluster config set default_topic_replications 1
           rpk cluster config set kafka_nodelete_topics "[ audit,consumer_offsets,_schemas,my_sample_topic ]"
           rpk cluster config set storage_min_free_bytes 161061273
           if [ -d "/etc/secrets/users/" ]; then
@@ -6914,7 +6900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -6953,7 +6939,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -6967,7 +6953,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -7060,7 +7046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -7098,7 +7084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -7160,7 +7146,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -7232,7 +7217,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -7348,7 +7332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -7379,7 +7363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -7447,7 +7431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
 rules:
 - apiGroups:
@@ -7469,7 +7453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -7501,7 +7485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7523,7 +7507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7570,7 +7554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -7616,7 +7600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -7772,7 +7756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -7787,14 +7771,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9afc46d83a991f0a9d3097edcab58ecfc95be979941f151e902f8bc205b55419
+        config.redpanda.com/checksum: 5f66fd654e4814d30a05a6c37a88b3740691f219f80e279dc760f86f1337fe7e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -8087,7 +8071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -8113,7 +8097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -8139,7 +8123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -8177,7 +8161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -8215,7 +8199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -8231,7 +8215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -8248,7 +8232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -8264,7 +8248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -8308,7 +8292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -8398,7 +8382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -8476,7 +8460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -8514,7 +8498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -8607,7 +8591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -8645,7 +8629,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -8753,7 +8737,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -8827,7 +8810,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -8950,7 +8932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -8980,7 +8962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -9073,7 +9055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -9119,7 +9101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -9287,7 +9269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -9302,14 +9284,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 652d5f75719863f650be8d7f4f04dbf5a5f7c14764dfd204fff07884e81c5332
+        config.redpanda.com/checksum: 98953a6cf5e49d36cbca06a2997aae1f79d36670a9be79784d30c6c479b02d38
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -9626,7 +9608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-cert2-root-certificate
   namespace: default
 spec:
@@ -9652,7 +9634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -9678,7 +9660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -9704,7 +9686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -9742,7 +9724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -9780,7 +9762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -9818,7 +9800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-cert2-selfsigned-issuer
   namespace: default
 spec:
@@ -9834,7 +9816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-cert2-root-issuer
   namespace: default
 spec:
@@ -9851,7 +9833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -9867,7 +9849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -9884,7 +9866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -9900,7 +9882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -9944,7 +9926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -10040,7 +10022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -10124,7 +10106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -10162,7 +10144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -10255,7 +10237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -10293,7 +10275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -10349,7 +10331,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -10421,7 +10402,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -10537,7 +10517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -10568,7 +10548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -10661,7 +10641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -10707,7 +10687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -10863,7 +10843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -10878,14 +10858,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -11177,7 +11157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -11203,7 +11183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -11229,7 +11209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -11267,7 +11247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -11305,7 +11285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -11321,7 +11301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -11338,7 +11318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -11354,7 +11334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -11398,7 +11378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -11488,7 +11468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -11566,7 +11546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -11604,7 +11584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -11697,7 +11677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -11735,7 +11715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -11795,7 +11775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -11846,7 +11826,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -11918,7 +11897,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -12034,7 +12012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -12065,7 +12043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -12158,7 +12136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -12204,7 +12182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -12360,7 +12338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -12375,14 +12353,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -12759,7 +12737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -12785,7 +12763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -12811,7 +12789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -12849,7 +12827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -12887,7 +12865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -12903,7 +12881,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -12920,7 +12898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -12936,7 +12914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -12980,7 +12958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -13070,7 +13048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -13148,7 +13126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -13186,7 +13164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -13279,7 +13257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -13317,7 +13295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -13373,7 +13351,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -13445,7 +13422,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -13561,7 +13537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -13592,7 +13568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -13685,7 +13661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -13731,7 +13707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -13887,7 +13863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -13902,14 +13878,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 1a4bdaca30992579197912d657e7b21873e37b00db8a096b31a64a753abe0190
+        config.redpanda.com/checksum: d6b360312cc30b7737b303cd596213b851e030ed6b2b12c14f67ff6921481ef4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -14202,7 +14178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -14228,7 +14204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -14254,7 +14230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -14294,7 +14270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -14334,7 +14310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -14350,7 +14326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -14367,7 +14343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -14383,7 +14359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -14427,7 +14403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -14517,7 +14493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -14595,7 +14571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -14633,7 +14609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -14730,7 +14706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: some-users
   namespace: default
 stringData:
@@ -14751,7 +14727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -14888,7 +14864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -14948,7 +14924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -14961,7 +14937,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: true
     group_topic_partitions: 16
@@ -15041,7 +15016,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
       group_topic_partitions: 16
@@ -15167,7 +15141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -15198,7 +15172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -15291,7 +15265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -15337,7 +15311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -15508,7 +15482,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -15523,14 +15497,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 2eb0ac0f32288893b4a45bf417f3d032a55368bd2cc727a22711186a553c2e65
+        config.redpanda.com/checksum: 5079e6cef2c4f25862c8947b3800bcf5ed2ab3c64fcf6fde9df3098beab4973b
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -15867,7 +15841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -15893,7 +15867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -15919,7 +15893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -15957,7 +15931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -15995,7 +15969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -16011,7 +15985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -16028,7 +16002,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -16044,7 +16018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -16088,7 +16062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -16193,7 +16167,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -16286,7 +16260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -16324,7 +16298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -16417,7 +16391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -16455,7 +16429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -16511,7 +16485,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -16583,7 +16556,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -16699,7 +16671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -16730,7 +16702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -16823,7 +16795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -16869,7 +16841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -17025,7 +16997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -17040,14 +17012,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 65178c4bede13e89eb75b1f5e9398524672d3e21f2010245b47e7d70d19638ad
+        config.redpanda.com/checksum: f16f6bac1a930d23127641ff0023775fce7bfd5eb0249627fcfcbe167beb4ed9
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -17340,7 +17312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -17366,7 +17338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -17406,7 +17378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -17422,7 +17394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -17466,7 +17438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -17556,7 +17528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -17634,7 +17606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -17672,7 +17644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -17765,7 +17737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -17803,7 +17775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -17859,7 +17831,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -17931,7 +17902,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -18047,7 +18017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -18078,7 +18048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -18171,7 +18141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -18217,7 +18187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -18261,7 +18231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -18305,7 +18275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -18460,7 +18430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -18475,14 +18445,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 65178c4bede13e89eb75b1f5e9398524672d3e21f2010245b47e7d70d19638ad
+        config.redpanda.com/checksum: f16f6bac1a930d23127641ff0023775fce7bfd5eb0249627fcfcbe167beb4ed9
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -18775,7 +18745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -18801,7 +18771,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -18841,7 +18811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -18857,7 +18827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -18901,7 +18871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -18991,7 +18961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -19069,7 +19039,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -19107,7 +19077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -19200,7 +19170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -19238,7 +19208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -19294,7 +19264,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -19338,7 +19307,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -19418,7 +19386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -19447,7 +19415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -19540,7 +19508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -19586,7 +19554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -19717,7 +19685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -19732,14 +19700,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 2c14528e3a649ab9bfcb8c46f12e5e45f32ae9f1e94cd14baef7091be3d0c7d4
+        config.redpanda.com/checksum: 64b185c0b093a2061358b2fa968a6b61a54de61b133a90d7998917e53ac8bf9c
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -20007,7 +19975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -20061,7 +20029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -20139,7 +20107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -20205,7 +20173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -20243,7 +20211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -20336,7 +20304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -20374,7 +20342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -20430,7 +20398,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -20502,7 +20469,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -20618,7 +20584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -20649,7 +20615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -20742,7 +20708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -20788,7 +20754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -20944,7 +20910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -20959,14 +20925,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -21259,7 +21225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -21285,7 +21251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -21311,7 +21277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -21349,7 +21315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -21387,7 +21353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -21403,7 +21369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -21420,7 +21386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -21436,7 +21402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -21453,7 +21419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -21511,7 +21477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -21601,7 +21567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -21679,7 +21645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -21717,7 +21683,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -21810,7 +21776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -21848,7 +21814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -21904,7 +21870,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -21976,7 +21941,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -22092,7 +22056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -22123,7 +22087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -22191,7 +22155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -22225,7 +22189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
 rules:
 - apiGroups:
@@ -22247,7 +22211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -22279,7 +22243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22301,7 +22265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22323,7 +22287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22345,7 +22309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -22398,7 +22362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -22446,7 +22410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -22492,7 +22456,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -22648,7 +22612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -22663,14 +22627,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -22978,7 +22942,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -23004,7 +22968,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -23030,7 +22994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -23068,7 +23032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -23106,7 +23070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -23122,7 +23086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -23139,7 +23103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -23155,7 +23119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -23199,7 +23163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -23289,7 +23253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -23367,7 +23331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -23405,7 +23369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -23498,7 +23462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -23536,7 +23500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -23592,7 +23556,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -23664,7 +23627,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -23780,7 +23742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -23811,7 +23773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -23904,7 +23866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -23950,7 +23912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -24106,7 +24068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -24121,14 +24083,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 82fcb3aa84d441a0fe15fcdb98d75ba13f6e7726c1d1c5b61431599a7d042c25
+        config.redpanda.com/checksum: 45d1e1c71a1b19817a856a724ff9a58dc37541fb3b5468bed6c545c262dc8ebe
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -24424,7 +24386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -24450,7 +24412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -24476,7 +24438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -24514,7 +24476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -24552,7 +24514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -24568,7 +24530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -24585,7 +24547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -24601,7 +24563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -24645,7 +24607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -24735,7 +24697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -24813,7 +24775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -24851,7 +24813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -24944,7 +24906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -24982,7 +24944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -25038,7 +25000,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -25110,7 +25071,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -25226,7 +25186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -25257,7 +25217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -25350,7 +25310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -25396,7 +25356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -25552,7 +25512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -25567,14 +25527,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 6b2b84ca93f48a49e341377c7c2c5746b9a0e118880dba945807e51838944fe2
+        config.redpanda.com/checksum: 56cee391bca9c41c012ad40245b3abc5956d5f0c76e7c773f0f87686da6c4ebd
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -25867,7 +25827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -25893,7 +25853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -25919,7 +25879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -25959,7 +25919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -25999,7 +25959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -26015,7 +25975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -26032,7 +25992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -26048,7 +26008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -26092,7 +26052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -26182,7 +26142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -26260,7 +26220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -26337,7 +26297,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -26430,7 +26390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -26468,7 +26428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -26524,7 +26484,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -26606,7 +26565,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -26722,7 +26680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -26753,7 +26711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -26846,7 +26804,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -26892,7 +26850,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -27064,7 +27022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -27079,14 +27037,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 80545394f94c2fad1777276ef7615cbd83991ae691eac3e51cc3e4ef64c2ba8b
+        config.redpanda.com/checksum: 82a1f161db6f72aeb712234c4e6b51300b908e0242eee9db9a5fe496c2d11268
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -27400,7 +27358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -27426,7 +27384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -27452,7 +27410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -27490,7 +27448,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -27528,7 +27486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -27544,7 +27502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -27561,7 +27519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -27577,7 +27535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -27621,7 +27579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -27733,7 +27691,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -27811,7 +27769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -27888,7 +27846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -27981,7 +27939,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -28019,7 +27977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -28075,7 +28033,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -28158,7 +28115,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -28274,7 +28230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -28305,7 +28261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -28398,7 +28354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -28444,7 +28400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -28616,7 +28572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -28631,14 +28587,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 6590260864f8bf7ee7b45119875b7c615a204bd428ba52941de5c9eb999d345f
+        config.redpanda.com/checksum: b57b83923352096ffee5c544cbe31d82e156f9b3235ffa6b507445a93d2e17bf
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -28952,7 +28908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -28978,7 +28934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -29004,7 +28960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -29042,7 +28998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -29080,7 +29036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -29096,7 +29052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -29113,7 +29069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -29129,7 +29085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -29173,7 +29129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -29287,7 +29243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -29365,7 +29321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -29442,7 +29398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -29535,7 +29491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -29573,7 +29529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -29629,7 +29585,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -29710,7 +29665,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -29826,7 +29780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -29857,7 +29811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -29950,7 +29904,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -29996,7 +29950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -30168,7 +30122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -30183,14 +30137,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e99a066044c3756118c1b486d406bef43e786e2ba4fa7c5a42155fa75f07974e
+        config.redpanda.com/checksum: dd5c2081b2e194363b43aff29f70c8c062afcf746a84f09d2eebd256f73ef60e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -30505,7 +30459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -30531,7 +30485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -30557,7 +30511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -30595,7 +30549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -30633,7 +30587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -30649,7 +30603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -30666,7 +30620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -30682,7 +30636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -30726,7 +30680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -30836,7 +30790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -30914,7 +30868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -30952,7 +30906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -31045,7 +30999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -31083,7 +31037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -31139,7 +31093,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -31220,7 +31173,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -31336,7 +31288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -31367,7 +31319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -31460,7 +31412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -31506,7 +31458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -31662,7 +31614,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -31677,14 +31629,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 1133b090528093544ecf6e86883d8ba54ffa248c2cff8da2b67ec1df88f6212d
+        config.redpanda.com/checksum: af99f82dd182335b370cdd76b7cdd26ad00084684eed04b4ac8cb3f156a784c5
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -31999,7 +31951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -32025,7 +31977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -32051,7 +32003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -32089,7 +32041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -32127,7 +32079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -32143,7 +32095,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -32160,7 +32112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -32176,7 +32128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -32220,7 +32172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -32328,7 +32280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -32406,7 +32358,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -32483,7 +32435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -32576,7 +32528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -32614,7 +32566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -32670,7 +32622,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -32752,7 +32703,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -32868,7 +32818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -32899,7 +32849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -32992,7 +32942,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -33038,7 +32988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -33210,7 +33160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -33225,14 +33175,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 80545394f94c2fad1777276ef7615cbd83991ae691eac3e51cc3e4ef64c2ba8b
+        config.redpanda.com/checksum: 82a1f161db6f72aeb712234c4e6b51300b908e0242eee9db9a5fe496c2d11268
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -33558,7 +33508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -33584,7 +33534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -33610,7 +33560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -33648,7 +33598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -33686,7 +33636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -33702,7 +33652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -33719,7 +33669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -33735,7 +33685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -33779,7 +33729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -33891,7 +33841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -33969,7 +33919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -34046,7 +33996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -34139,7 +34089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -34177,7 +34127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -34233,7 +34183,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -34316,7 +34265,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -34432,7 +34380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -34463,7 +34411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -34556,7 +34504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -34602,7 +34550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -34774,7 +34722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -34789,14 +34737,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 6590260864f8bf7ee7b45119875b7c615a204bd428ba52941de5c9eb999d345f
+        config.redpanda.com/checksum: b57b83923352096ffee5c544cbe31d82e156f9b3235ffa6b507445a93d2e17bf
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -35122,7 +35070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -35148,7 +35096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -35174,7 +35122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -35212,7 +35160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -35250,7 +35198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -35266,7 +35214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -35283,7 +35231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -35299,7 +35247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -35343,7 +35291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -35457,7 +35405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -35535,7 +35483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -35612,7 +35560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -35705,7 +35653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -35743,7 +35691,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -35799,7 +35747,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -35880,7 +35827,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -35996,7 +35942,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -36027,7 +35973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -36120,7 +36066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -36166,7 +36112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -36338,7 +36284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -36353,14 +36299,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e99a066044c3756118c1b486d406bef43e786e2ba4fa7c5a42155fa75f07974e
+        config.redpanda.com/checksum: dd5c2081b2e194363b43aff29f70c8c062afcf746a84f09d2eebd256f73ef60e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -36688,7 +36634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -36714,7 +36660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -36740,7 +36686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -36778,7 +36724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -36816,7 +36762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -36832,7 +36778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -36849,7 +36795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -36865,7 +36811,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -36909,7 +36855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -37019,7 +36965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -37097,7 +37043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -37135,7 +37081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -37228,7 +37174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -37266,7 +37212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -37322,7 +37268,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -37403,7 +37348,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -37519,7 +37463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -37550,7 +37494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -37643,7 +37587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -37689,7 +37633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -37845,7 +37789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -37860,14 +37804,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e99a066044c3756118c1b486d406bef43e786e2ba4fa7c5a42155fa75f07974e
+        config.redpanda.com/checksum: dd5c2081b2e194363b43aff29f70c8c062afcf746a84f09d2eebd256f73ef60e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -38195,7 +38139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -38221,7 +38165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -38247,7 +38191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -38285,7 +38229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -38323,7 +38267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -38339,7 +38283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -38356,7 +38300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -38372,7 +38316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -38416,7 +38360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -38524,7 +38468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -38602,7 +38546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -38679,7 +38623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -38772,7 +38716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -38810,7 +38754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -38866,7 +38810,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -38948,7 +38891,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -39064,7 +39006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -39095,7 +39037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -39188,7 +39130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -39234,7 +39176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -39406,7 +39348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -39421,14 +39363,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 80545394f94c2fad1777276ef7615cbd83991ae691eac3e51cc3e4ef64c2ba8b
+        config.redpanda.com/checksum: 82a1f161db6f72aeb712234c4e6b51300b908e0242eee9db9a5fe496c2d11268
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -39754,7 +39696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -39780,7 +39722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -39806,7 +39748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -39844,7 +39786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -39882,7 +39824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -39898,7 +39840,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -39915,7 +39857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -39931,7 +39873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -39975,7 +39917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -40087,7 +40029,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -40165,7 +40107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -40242,7 +40184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -40335,7 +40277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -40373,7 +40315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -40429,7 +40371,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -40512,7 +40453,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -40628,7 +40568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -40659,7 +40599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -40752,7 +40692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -40798,7 +40738,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -40970,7 +40910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -40985,14 +40925,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 6590260864f8bf7ee7b45119875b7c615a204bd428ba52941de5c9eb999d345f
+        config.redpanda.com/checksum: b57b83923352096ffee5c544cbe31d82e156f9b3235ffa6b507445a93d2e17bf
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -41318,7 +41258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -41344,7 +41284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -41370,7 +41310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -41408,7 +41348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -41446,7 +41386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -41462,7 +41402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -41479,7 +41419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -41495,7 +41435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -41539,7 +41479,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -41653,7 +41593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -41731,7 +41671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -41808,7 +41748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -41901,7 +41841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -41939,7 +41879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -41995,7 +41935,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -42076,7 +42015,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -42192,7 +42130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -42223,7 +42161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -42316,7 +42254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -42362,7 +42300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -42534,7 +42472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -42549,14 +42487,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e99a066044c3756118c1b486d406bef43e786e2ba4fa7c5a42155fa75f07974e
+        config.redpanda.com/checksum: dd5c2081b2e194363b43aff29f70c8c062afcf746a84f09d2eebd256f73ef60e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -42884,7 +42822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -42910,7 +42848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -42936,7 +42874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -42974,7 +42912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -43012,7 +42950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -43028,7 +42966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -43045,7 +42983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -43061,7 +42999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -43105,7 +43043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -43215,7 +43153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -43293,7 +43231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -43331,7 +43269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -43424,7 +43362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -43462,7 +43400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -43518,7 +43456,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -43599,7 +43536,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -43715,7 +43651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -43746,7 +43682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -43839,7 +43775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -43885,7 +43821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -44041,7 +43977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -44056,14 +43992,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e99a066044c3756118c1b486d406bef43e786e2ba4fa7c5a42155fa75f07974e
+        config.redpanda.com/checksum: dd5c2081b2e194363b43aff29f70c8c062afcf746a84f09d2eebd256f73ef60e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -44391,7 +44327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -44417,7 +44353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -44443,7 +44379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -44481,7 +44417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -44519,7 +44455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -44535,7 +44471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -44552,7 +44488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -44568,7 +44504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -44612,7 +44548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -44720,7 +44656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -44798,7 +44734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -44836,7 +44772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -44929,7 +44865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -44967,7 +44903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -45023,7 +44959,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -45095,7 +45030,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -45211,7 +45145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -45242,7 +45176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -45335,7 +45269,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -45381,7 +45315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -45537,7 +45471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -45552,14 +45486,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 911bd4e31549e914ca443c4040bf69209a37d64b8ee6a7a896b4d6880106d1ae
+        config.redpanda.com/checksum: 6c46c26e5cf617d8aa79156b70dda19973b2cfbb6aa9052c34cc70761973bd23
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -45852,7 +45786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -45878,7 +45812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -45904,7 +45838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -45942,7 +45876,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -45980,7 +45914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -45996,7 +45930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -46013,7 +45947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -46029,7 +45963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -46073,7 +46007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -46163,7 +46097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -46241,7 +46175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -46279,7 +46213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -46372,7 +46306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -46410,7 +46344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -46466,7 +46400,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -46538,7 +46471,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -46654,7 +46586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -46685,7 +46617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -46778,7 +46710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -46824,7 +46756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -46980,7 +46912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -46995,7 +46927,7 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
@@ -47003,7 +46935,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -47296,7 +47228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -47322,7 +47254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -47348,7 +47280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -47386,7 +47318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -47424,7 +47356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -47440,7 +47372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -47457,7 +47389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -47473,7 +47405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -47517,7 +47449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -47607,7 +47539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -47685,7 +47617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -47723,7 +47655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -47816,7 +47748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -47854,7 +47786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -47910,7 +47842,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -47982,7 +47913,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -48098,7 +48028,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -48129,7 +48059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -48222,7 +48152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -48268,7 +48198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -48424,7 +48354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -48439,14 +48369,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -48745,7 +48675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -48771,7 +48701,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -48797,7 +48727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -48835,7 +48765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -48873,7 +48803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -48889,7 +48819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -48906,7 +48836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -48922,7 +48852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -48966,7 +48896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -49056,7 +48986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -49134,7 +49064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -49172,7 +49102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -49265,7 +49195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -49303,7 +49233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -49429,7 +49359,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -49493,7 +49422,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -49605,7 +49533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -49637,7 +49565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -49732,7 +49660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -49778,7 +49706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -49945,7 +49873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -49960,14 +49888,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 36fcc869ad8651a2e768592030573ba1948cf4c28636bfe409fb1fd38d3e901f
+        config.redpanda.com/checksum: 5925613c3308457142c65aefdecdd3391db2c366b43b0d514a68b22ece8f632b
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -50268,7 +50196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -50294,7 +50222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -50320,7 +50248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -50358,7 +50286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -50396,7 +50324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -50412,7 +50340,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -50429,7 +50357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -50445,7 +50373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -50489,7 +50417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -50579,7 +50507,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -50657,7 +50585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -50698,7 +50626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -50791,7 +50719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -50829,7 +50757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -50885,7 +50813,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -50957,7 +50884,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -51073,7 +50999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -51104,7 +51030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -51197,7 +51123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -51246,7 +51172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -51405,7 +51331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -51423,14 +51349,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -51732,7 +51658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -51758,7 +51684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -51784,7 +51710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -51822,7 +51748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -51860,7 +51786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -51876,7 +51802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -51893,7 +51819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -51909,7 +51835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -51953,7 +51879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -52043,7 +51969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -52121,7 +52047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -52159,7 +52085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -52252,7 +52178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -52290,7 +52216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -52346,7 +52272,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -52418,7 +52343,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -52534,7 +52458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -52565,7 +52489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -52633,7 +52557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -52667,7 +52591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
 rules:
 - apiGroups:
@@ -52689,7 +52613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -52721,7 +52645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52743,7 +52667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52765,7 +52689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52787,7 +52711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -52840,7 +52764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -52888,7 +52812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -52934,7 +52858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -53090,7 +53014,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -53105,14 +53029,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -53432,7 +53356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -53458,7 +53382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -53484,7 +53408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -53522,7 +53446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -53560,7 +53484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -53576,7 +53500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -53593,7 +53517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -53609,7 +53533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -53653,7 +53577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -53743,7 +53667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -53821,7 +53745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -53859,7 +53783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -53952,7 +53876,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -53990,7 +53914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -54050,7 +53974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -54101,7 +54025,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -54173,7 +54096,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -54289,7 +54211,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -54320,7 +54242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -54388,7 +54310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -54422,7 +54344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -54444,7 +54366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -54497,7 +54419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -54545,7 +54467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -54591,7 +54513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -54747,7 +54669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -54762,14 +54684,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -55103,7 +55025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -55129,7 +55051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -55155,7 +55077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -55193,7 +55115,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -55231,7 +55153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -55247,7 +55169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -55264,7 +55186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -55280,7 +55202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -55324,7 +55246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -55414,7 +55336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -55492,7 +55414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -55530,7 +55452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -55623,7 +55545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -55661,7 +55583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -55717,7 +55639,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -55789,7 +55710,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -55905,7 +55825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -55936,7 +55856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -56078,7 +55998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -56124,7 +56044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -56436,7 +56356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -56451,14 +56371,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -56751,7 +56671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -56777,7 +56697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -56803,7 +56723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -56841,7 +56761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -56879,7 +56799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -56895,7 +56815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -56912,7 +56832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -56928,7 +56848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -56972,7 +56892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -57062,7 +56982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -57140,7 +57060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -57178,7 +57098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -57271,7 +57191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -57309,7 +57229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -57365,7 +57285,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -57437,7 +57356,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -57553,7 +57471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -57584,7 +57502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -57677,7 +57595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -57723,7 +57641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -57879,7 +57797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -57894,14 +57812,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: e5c9830ea2e913e0f25a2ab7fd9c0e05eab27eadb422db1c4c016326a7b56830
+        config.redpanda.com/checksum: afd3faf06d3b137b2a89c9a61d2084dcece97779ac42626318edaa069b49e3ec
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -58194,7 +58112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -58220,7 +58138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -58246,7 +58164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -58286,7 +58204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -58326,7 +58244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -58342,7 +58260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -58359,7 +58277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -58375,7 +58293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -58419,7 +58337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -58509,7 +58427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -58587,7 +58505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -58626,7 +58544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -58719,7 +58637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -58757,7 +58675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -58813,7 +58731,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -58885,7 +58802,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -59001,7 +58917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -59032,7 +58948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -59126,7 +59042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -59173,7 +59089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: change-name-external
   namespace: default
 spec:
@@ -59330,7 +59246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -59346,14 +59262,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: bc0954a86224c7d89811320d54a537bc5823c5f2fa7a486dabcb9e2e40ca6128
+        config.redpanda.com/checksum: e241b03a42f9513720de728d6eb25a75d4fc8355a2af74d75666700b0f3c56e4
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
         test: test
     spec:
@@ -59649,7 +59565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -59675,7 +59591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -59701,7 +59617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -59739,7 +59655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -59777,7 +59693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -59793,7 +59709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -59810,7 +59726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -59826,7 +59742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -59843,7 +59759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -59901,7 +59817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -59991,7 +59907,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -60069,7 +59985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -60107,7 +60023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -60200,7 +60116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -60238,7 +60154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -60294,7 +60210,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -60366,7 +60281,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -60482,7 +60396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -60513,7 +60427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -60606,7 +60520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -60652,7 +60566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -60808,7 +60722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -60823,14 +60737,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -61138,7 +61052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -61164,7 +61078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -61190,7 +61104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -61228,7 +61142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -61266,7 +61180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -61282,7 +61196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -61299,7 +61213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -61315,7 +61229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -61359,7 +61273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -61468,7 +61382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -61561,7 +61475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -61599,7 +61513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -61692,7 +61606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -61730,7 +61644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -61786,7 +61700,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -61858,7 +61771,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -61974,7 +61886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -62005,7 +61917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -62098,7 +62010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -62144,7 +62056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -62300,7 +62212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -62315,14 +62227,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -62630,7 +62542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -62656,7 +62568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -62682,7 +62594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -62720,7 +62632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -62758,7 +62670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -62774,7 +62686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -62791,7 +62703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -62807,7 +62719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -62851,7 +62763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -62962,7 +62874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -63055,7 +62967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -63093,7 +63005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -63186,7 +63098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -63224,7 +63136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -63280,7 +63192,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -63352,7 +63263,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -63468,7 +63378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -63499,7 +63409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -63592,7 +63502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -63638,7 +63548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -63794,7 +63704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -63809,14 +63719,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -64111,7 +64021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -64137,7 +64047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -64163,7 +64073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -64201,7 +64111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -64239,7 +64149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -64255,7 +64165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -64272,7 +64182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -64288,7 +64198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -64332,7 +64242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -64424,7 +64334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -64504,7 +64414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -64526,7 +64436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -64619,7 +64529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -64657,7 +64567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -64712,7 +64622,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -64762,7 +64671,6 @@ data:
       admin_api_tls: null
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -64882,7 +64790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -64914,7 +64822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -64929,7 +64837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -64975,7 +64883,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -65019,7 +64927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -65034,14 +64942,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0cc041a88a160f7f88e96c2aa46bce69fb0512b190cffbfcef766687f866b5a6
+        config.redpanda.com/checksum: e6dc5ca05c3c4bc874798883bb675fb354cfce130f4cf7dd356fae471e304eca
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -65343,7 +65251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -65369,7 +65277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -65395,7 +65303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -65421,7 +65329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -65459,7 +65367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -65497,7 +65405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -65535,7 +65443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -65560,7 +65468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -65576,7 +65484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -65593,7 +65501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -65609,7 +65517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -65626,7 +65534,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -65642,7 +65550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -65663,7 +65571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -65759,7 +65667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -65843,7 +65751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -65881,7 +65789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -65974,7 +65882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -66012,7 +65920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -66068,7 +65976,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -66140,7 +66047,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -66256,7 +66162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -66287,7 +66193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -66380,7 +66286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -66426,7 +66332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -66582,7 +66488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -66597,14 +66503,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -66897,7 +66803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -66923,7 +66829,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -66949,7 +66855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -66975,7 +66881,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -67001,7 +66907,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -67018,7 +66924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -67062,7 +66968,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -67152,7 +67058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -67230,7 +67136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -67307,7 +67213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -67404,7 +67310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-users
   namespace: default
 stringData:
@@ -67421,7 +67327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -67558,7 +67464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -67618,7 +67524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -67632,7 +67538,6 @@ data:
     audit_enabled: true
     cluster_id: cluster-id-test
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: true
     group_topic_partitions: 16
@@ -67722,7 +67627,6 @@ data:
       cluster_id: cluster-id-test
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
       group_topic_partitions: 16
@@ -67845,7 +67749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -67876,7 +67780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -67969,7 +67873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -68015,7 +67919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -68202,7 +68106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -68217,14 +68121,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: fff365619768271563c325561c033970df7697d098cfbd52a37559ee96fbdc6e
+        config.redpanda.com/checksum: 81f9b189b1f76d1132e539c74b524b9483f10194b5da97e9f873ca55913b047a
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -68561,7 +68465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -68587,7 +68491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -68613,7 +68517,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -68651,7 +68555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -68689,7 +68593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -68705,7 +68609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -68722,7 +68626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -68738,7 +68642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -68782,7 +68686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -68889,7 +68793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -68982,7 +68886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -69059,7 +68963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -69152,7 +69056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -69190,7 +69094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -69246,7 +69150,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -69318,7 +69221,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -69434,7 +69336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -69465,7 +69367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -69558,7 +69460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -69604,7 +69506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -69776,7 +69678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -69791,14 +69693,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -70091,7 +69993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -70117,7 +70019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -70143,7 +70045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -70181,7 +70083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -70219,7 +70121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -70235,7 +70137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -70252,7 +70154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -70268,7 +70170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -70312,7 +70214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -70404,7 +70306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -70482,7 +70384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -70520,7 +70422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -70613,7 +70515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -70651,7 +70553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -70707,7 +70609,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -70779,7 +70680,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -70895,7 +70795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -70926,7 +70826,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -71019,7 +70919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -71065,7 +70965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -71226,7 +71126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -71241,14 +71141,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -71541,7 +71441,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -71567,7 +71467,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -71593,7 +71493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -71631,7 +71531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -71669,7 +71569,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -71685,7 +71585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -71702,7 +71602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -71718,7 +71618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -71762,7 +71662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -71857,7 +71757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -71935,7 +71835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -71973,7 +71873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -72066,7 +71966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -72104,7 +72004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -72160,7 +72060,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_idempotence: false
     enable_rack_awareness: false
     enable_sasl: false
@@ -72242,7 +72141,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_idempotence: false
       enable_sasl: false
@@ -72359,7 +72257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -72390,7 +72288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -72483,7 +72381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -72529,7 +72427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -72699,7 +72597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -72714,14 +72612,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 1b83a422bcfe5d920ab0bcc0060a6a0395a159078cd51752dc04832ea51c5546
+        config.redpanda.com/checksum: ec7ba898c4b6fce8ab8d1139e7b1ace50b0b4482050cff12c1c7c339f2c5b544
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -73035,7 +72933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -73061,7 +72959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -73087,7 +72985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -73125,7 +73023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -73163,7 +73061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -73179,7 +73077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -73196,7 +73094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -73212,7 +73110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -73256,7 +73154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -73369,7 +73267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -73447,7 +73345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -73485,7 +73383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -73578,7 +73476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -73616,7 +73514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -73672,7 +73570,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -73744,7 +73641,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -73860,7 +73756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -73891,7 +73787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -73984,7 +73880,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -74030,7 +73926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -74186,7 +74082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -74201,14 +74097,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -74502,7 +74398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -74528,7 +74424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -74554,7 +74450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -74592,7 +74488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -74630,7 +74526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -74646,7 +74542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -74663,7 +74559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -74679,7 +74575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -74723,7 +74619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -74814,7 +74710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -74893,7 +74789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -74931,7 +74827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -75024,7 +74920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -75062,7 +74958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -75118,7 +75014,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -75190,7 +75085,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -75306,7 +75200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -75337,7 +75231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -75430,7 +75324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -75476,7 +75370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -75632,7 +75526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -75647,14 +75541,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -75948,7 +75842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -75974,7 +75868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -76000,7 +75894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -76038,7 +75932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -76076,7 +75970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -76092,7 +75986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -76109,7 +76003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -76125,7 +76019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -76169,7 +76063,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -76260,7 +76154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -76339,7 +76233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -76377,7 +76271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -76470,7 +76364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -76508,7 +76402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -76564,7 +76458,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -76636,7 +76529,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -76752,7 +76644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -76783,7 +76675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -76876,7 +76768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -76922,7 +76814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -77078,7 +76970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -77093,14 +76985,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -77393,7 +77285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -77419,7 +77311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -77445,7 +77337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -77483,7 +77375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -77521,7 +77413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -77537,7 +77429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -77554,7 +77446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -77570,7 +77462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -77614,7 +77506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -77704,7 +77596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -77782,7 +77674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -77820,7 +77712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -77917,7 +77809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-users
   namespace: default
 stringData:
@@ -77937,7 +77829,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -78074,7 +77966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -78134,7 +78026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -78147,7 +78039,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: true
     group_topic_partitions: 16
@@ -78226,7 +78117,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: true
       group_topic_partitions: 16
@@ -78351,7 +78241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -78382,7 +78272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -78475,7 +78365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -78521,7 +78411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -78692,7 +78582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -78707,14 +78597,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7173f4668d0175bf6f876a395a86847a4e0bd9f3305aca68bc046c86191d7185
+        config.redpanda.com/checksum: cc69b12803194dfb54c42ac6395910844f43b19d56ded7eb1297165f6d3b5dd3
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -79051,7 +78941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -79077,7 +78967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -79103,7 +78993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -79141,7 +79031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -79179,7 +79069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -79195,7 +79085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -79212,7 +79102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -79228,7 +79118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -79272,7 +79162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -79377,7 +79267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -79494,7 +79384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -79532,7 +79422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -79625,7 +79515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -79663,7 +79553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -79718,7 +79608,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -79789,7 +79678,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -79905,7 +79793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -79936,7 +79824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -80029,7 +79917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -80075,7 +79963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -80231,7 +80119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -80246,14 +80134,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: b4f5c87f7e221601ae6b84bb4e53fbb079989210981abe77fae69c94362abc09
+        config.redpanda.com/checksum: bd8064f0811f4477006c367b86a3ca709cbf758fe418153c4de99edd89783b40
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -80546,7 +80434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -80572,7 +80460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -80598,7 +80486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -80636,7 +80524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -80674,7 +80562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -80690,7 +80578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -80707,7 +80595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -80723,7 +80611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -80767,7 +80655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -80857,7 +80745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -80928,7 +80816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -81005,7 +80893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -81098,7 +80986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -81136,7 +81024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -81191,7 +81079,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -81262,7 +81149,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -81378,7 +81264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -81409,7 +81295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -81502,7 +81388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -81548,7 +81434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -81720,7 +81606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -81735,14 +81621,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: f32c3d39d665fd2d0fb7accd77510b88b3ec475a9101b8ae6c1dbe3f5922bfc6
+        config.redpanda.com/checksum: 6d57eeb3fc8cce37385d9a65aced22e7c3bd8b230fae1d372706f2d97fd4f258
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -82035,7 +81921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -82061,7 +81947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -82087,7 +81973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -82125,7 +82011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -82163,7 +82049,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -82179,7 +82065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -82196,7 +82082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -82212,7 +82098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -82256,7 +82142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -82348,7 +82234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -82419,7 +82305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -82457,7 +82343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -82550,7 +82436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -82588,7 +82474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -82649,7 +82535,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -82720,7 +82605,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -82836,7 +82720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -82867,7 +82751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -82960,7 +82844,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -83006,7 +82890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -83162,7 +83046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -83177,14 +83061,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0482e004a7b519b4994958383c26892aa19930c2ffb74d06d10c8d3b26139135
+        config.redpanda.com/checksum: 0316b707c2806c2584c4bac9867a095106e0332778214a2d148a2de3d6126b19
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -83477,7 +83361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -83503,7 +83387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -83529,7 +83413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -83567,7 +83451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -83605,7 +83489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -83621,7 +83505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -83638,7 +83522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -83654,7 +83538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -83698,7 +83582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -83788,7 +83672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -83871,7 +83755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -83909,7 +83793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -84002,7 +83886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -84040,7 +83924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -84095,7 +83979,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -84166,7 +84049,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -84282,7 +84164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -84313,7 +84195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -84406,7 +84288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -84452,7 +84334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -84608,7 +84490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -84623,14 +84505,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: b4f5c87f7e221601ae6b84bb4e53fbb079989210981abe77fae69c94362abc09
+        config.redpanda.com/checksum: bd8064f0811f4477006c367b86a3ca709cbf758fe418153c4de99edd89783b40
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -84923,7 +84805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -84949,7 +84831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -84975,7 +84857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -85013,7 +84895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -85051,7 +84933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -85067,7 +84949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -85084,7 +84966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -85100,7 +84982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -85144,7 +85026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -85234,7 +85116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -85305,7 +85187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -85382,7 +85264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -85475,7 +85357,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -85513,7 +85395,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -85568,7 +85450,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -85639,7 +85520,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -85755,7 +85635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -85786,7 +85666,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -85879,7 +85759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -85925,7 +85805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -86097,7 +85977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -86112,14 +85992,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: f32c3d39d665fd2d0fb7accd77510b88b3ec475a9101b8ae6c1dbe3f5922bfc6
+        config.redpanda.com/checksum: 6d57eeb3fc8cce37385d9a65aced22e7c3bd8b230fae1d372706f2d97fd4f258
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -86412,7 +86292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -86438,7 +86318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -86464,7 +86344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -86502,7 +86382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -86540,7 +86420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -86556,7 +86436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -86573,7 +86453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -86589,7 +86469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -86633,7 +86513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -86725,7 +86605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -86796,7 +86676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -86834,7 +86714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -86927,7 +86807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -86965,7 +86845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -87026,7 +86906,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -87097,7 +86976,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -87213,7 +87091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -87244,7 +87122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -87337,7 +87215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -87383,7 +87261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -87539,7 +87417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -87554,14 +87432,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0482e004a7b519b4994958383c26892aa19930c2ffb74d06d10c8d3b26139135
+        config.redpanda.com/checksum: 0316b707c2806c2584c4bac9867a095106e0332778214a2d148a2de3d6126b19
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -87854,7 +87732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -87880,7 +87758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -87906,7 +87784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -87944,7 +87822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -87982,7 +87860,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -87998,7 +87876,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -88015,7 +87893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -88031,7 +87909,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -88075,7 +87953,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -88165,7 +88043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -88236,7 +88114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -88274,7 +88152,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -88367,7 +88245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -88405,7 +88283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -88460,7 +88338,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -88531,7 +88408,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -88647,7 +88523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -88678,7 +88554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -88771,7 +88647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -88817,7 +88693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -88973,7 +88849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -88988,14 +88864,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: b4f5c87f7e221601ae6b84bb4e53fbb079989210981abe77fae69c94362abc09
+        config.redpanda.com/checksum: bd8064f0811f4477006c367b86a3ca709cbf758fe418153c4de99edd89783b40
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -89288,7 +89164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -89314,7 +89190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -89340,7 +89216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -89378,7 +89254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -89416,7 +89292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -89432,7 +89308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -89449,7 +89325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -89465,7 +89341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -89509,7 +89385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -89599,7 +89475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -89670,7 +89546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -89747,7 +89623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -89840,7 +89716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -89878,7 +89754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -89933,7 +89809,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -90004,7 +89879,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -90120,7 +89994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -90151,7 +90025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -90244,7 +90118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -90290,7 +90164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -90462,7 +90336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -90477,14 +90351,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: f32c3d39d665fd2d0fb7accd77510b88b3ec475a9101b8ae6c1dbe3f5922bfc6
+        config.redpanda.com/checksum: 6d57eeb3fc8cce37385d9a65aced22e7c3bd8b230fae1d372706f2d97fd4f258
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -90777,7 +90651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -90803,7 +90677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -90829,7 +90703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -90867,7 +90741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -90905,7 +90779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -90921,7 +90795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -90938,7 +90812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -90954,7 +90828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -90998,7 +90872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -91090,7 +90964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -91161,7 +91035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -91199,7 +91073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -91292,7 +91166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -91330,7 +91204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -91391,7 +91265,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -91462,7 +91335,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -91578,7 +91450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -91609,7 +91481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -91702,7 +91574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -91748,7 +91620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -91904,7 +91776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -91919,14 +91791,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0482e004a7b519b4994958383c26892aa19930c2ffb74d06d10c8d3b26139135
+        config.redpanda.com/checksum: 0316b707c2806c2584c4bac9867a095106e0332778214a2d148a2de3d6126b19
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -92219,7 +92091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -92245,7 +92117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -92271,7 +92143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -92309,7 +92181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -92347,7 +92219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -92363,7 +92235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -92380,7 +92252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -92396,7 +92268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -92440,7 +92312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -92530,7 +92402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -92601,7 +92473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -92639,7 +92511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -92732,7 +92604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -92770,7 +92642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -92825,7 +92697,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -92896,7 +92767,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -93012,7 +92882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -93043,7 +92913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -93136,7 +93006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -93182,7 +93052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -93338,7 +93208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -93353,14 +93223,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: b4f5c87f7e221601ae6b84bb4e53fbb079989210981abe77fae69c94362abc09
+        config.redpanda.com/checksum: bd8064f0811f4477006c367b86a3ca709cbf758fe418153c4de99edd89783b40
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -93653,7 +93523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -93679,7 +93549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -93705,7 +93575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -93743,7 +93613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -93781,7 +93651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -93797,7 +93667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -93814,7 +93684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -93830,7 +93700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -93874,7 +93744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -93964,7 +93834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -94042,7 +93912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -94119,7 +93989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -94212,7 +94082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -94250,7 +94120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -94305,7 +94175,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -94376,7 +94245,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -94492,7 +94360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -94523,7 +94391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -94616,7 +94484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -94662,7 +94530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -94834,7 +94702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -94849,14 +94717,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: f32c3d39d665fd2d0fb7accd77510b88b3ec475a9101b8ae6c1dbe3f5922bfc6
+        config.redpanda.com/checksum: 6d57eeb3fc8cce37385d9a65aced22e7c3bd8b230fae1d372706f2d97fd4f258
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -95149,7 +95017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -95175,7 +95043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -95201,7 +95069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -95239,7 +95107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -95277,7 +95145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -95293,7 +95161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -95310,7 +95178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -95326,7 +95194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -95370,7 +95238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -95462,7 +95330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -95540,7 +95408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -95578,7 +95446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -95671,7 +95539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -95709,7 +95577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -95770,7 +95638,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -95841,7 +95708,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -95957,7 +95823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -95988,7 +95854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -96081,7 +95947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -96127,7 +95993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -96283,7 +96149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -96298,14 +96164,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0482e004a7b519b4994958383c26892aa19930c2ffb74d06d10c8d3b26139135
+        config.redpanda.com/checksum: 0316b707c2806c2584c4bac9867a095106e0332778214a2d148a2de3d6126b19
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -96598,7 +96464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -96624,7 +96490,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -96650,7 +96516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -96688,7 +96554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -96726,7 +96592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -96742,7 +96608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -96759,7 +96625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -96775,7 +96641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -96819,7 +96685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -96909,7 +96775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -96987,7 +96853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -97025,7 +96891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -97118,7 +96984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -97156,7 +97022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -97212,7 +97078,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -97284,7 +97149,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -97400,7 +97264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -97431,7 +97295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -97524,7 +97388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -97570,7 +97434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -97726,7 +97590,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -97741,14 +97605,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d6e56ebb0832c6ea315f2e71c948b1b74566a4f84196ca83906ad0b7c9bc09a9
+        config.redpanda.com/checksum: c113378df81388298c93b7ef6cba7c55ea0ef8c9161d0a7e6b849dffe80d4246
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -98041,7 +97905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -98067,7 +97931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -98093,7 +97957,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -98131,7 +97995,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -98169,7 +98033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -98185,7 +98049,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -98202,7 +98066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -98218,7 +98082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -98262,7 +98126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -98352,7 +98216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -98430,7 +98294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -98507,7 +98371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -98600,7 +98464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -98638,7 +98502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -98694,7 +98558,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -98766,7 +98629,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -98882,7 +98744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -98913,7 +98775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -99006,7 +98868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -99052,7 +98914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -99224,7 +99086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -99239,14 +99101,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -99539,7 +99401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -99565,7 +99427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -99591,7 +99453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -99629,7 +99491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -99667,7 +99529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -99683,7 +99545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -99700,7 +99562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -99716,7 +99578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -99760,7 +99622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -99852,7 +99714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -99930,7 +99792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -99968,7 +99830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -100061,7 +99923,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -100099,7 +99961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -100161,7 +100023,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -100233,7 +100094,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -100349,7 +100209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -100380,7 +100240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -100473,7 +100333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -100519,7 +100379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -100675,7 +100535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -100690,14 +100550,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9afc46d83a991f0a9d3097edcab58ecfc95be979941f151e902f8bc205b55419
+        config.redpanda.com/checksum: 5f66fd654e4814d30a05a6c37a88b3740691f219f80e279dc760f86f1337fe7e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -100990,7 +100850,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -101016,7 +100876,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -101042,7 +100902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -101080,7 +100940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -101118,7 +100978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -101134,7 +100994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -101151,7 +101011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -101167,7 +101027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -101211,7 +101071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -101301,7 +101161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -101379,7 +101239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -101417,7 +101277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -101510,7 +101370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -101548,7 +101408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -101604,7 +101464,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -101676,7 +101535,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -101792,7 +101650,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -101823,7 +101681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -101916,7 +101774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -101962,7 +101820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -102118,7 +101976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -102133,14 +101991,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d6e56ebb0832c6ea315f2e71c948b1b74566a4f84196ca83906ad0b7c9bc09a9
+        config.redpanda.com/checksum: c113378df81388298c93b7ef6cba7c55ea0ef8c9161d0a7e6b849dffe80d4246
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -102433,7 +102291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -102459,7 +102317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -102485,7 +102343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -102523,7 +102381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -102561,7 +102419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -102577,7 +102435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -102594,7 +102452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -102610,7 +102468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -102654,7 +102512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -102744,7 +102602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -102822,7 +102680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -102899,7 +102757,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -102992,7 +102850,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -103030,7 +102888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -103086,7 +102944,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -103158,7 +103015,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -103274,7 +103130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -103305,7 +103161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -103398,7 +103254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -103444,7 +103300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -103616,7 +103472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -103631,14 +103487,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -103931,7 +103787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -103957,7 +103813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -103983,7 +103839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -104021,7 +103877,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -104059,7 +103915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -104075,7 +103931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -104092,7 +103948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -104108,7 +103964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -104152,7 +104008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -104244,7 +104100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -104322,7 +104178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -104360,7 +104216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -104453,7 +104309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -104491,7 +104347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -104553,7 +104409,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -104625,7 +104480,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -104741,7 +104595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -104772,7 +104626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -104865,7 +104719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -104911,7 +104765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -105067,7 +104921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -105082,14 +104936,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9afc46d83a991f0a9d3097edcab58ecfc95be979941f151e902f8bc205b55419
+        config.redpanda.com/checksum: 5f66fd654e4814d30a05a6c37a88b3740691f219f80e279dc760f86f1337fe7e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -105382,7 +105236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -105408,7 +105262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -105434,7 +105288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -105472,7 +105326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -105510,7 +105364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -105526,7 +105380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -105543,7 +105397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -105559,7 +105413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -105603,7 +105457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -105693,7 +105547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -105771,7 +105625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -105809,7 +105663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -105902,7 +105756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -105940,7 +105794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -105996,7 +105850,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -106068,7 +105921,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -106184,7 +106036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -106215,7 +106067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -106308,7 +106160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -106354,7 +106206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -106510,7 +106362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -106525,14 +106377,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -106852,7 +106704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -106942,7 +106794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -107020,7 +106872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -107058,7 +106910,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -107151,7 +107003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -107189,7 +107041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -107245,7 +107097,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -107317,7 +107168,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -107433,7 +107283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -107464,7 +107314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -107557,7 +107407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -107603,7 +107453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -107741,7 +107591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -107756,14 +107606,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 77ca6d1dc112311fe5c1c670e1f8db39edcc128b10ec17713c8a8471281ccd26
+        config.redpanda.com/checksum: 54895ce186aa050647c268ef5d63552024654b0cc9aba1b458d7e6cd68248764
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -108083,7 +107933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -108173,7 +108023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -108251,7 +108101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -108289,7 +108139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -108382,7 +108232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -108420,7 +108270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -108502,7 +108352,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -108592,7 +108441,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -108726,7 +108574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -108757,7 +108605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -108850,7 +108698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -108896,7 +108744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -109072,7 +108920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -109087,14 +108935,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 548704b3b9fdb55b570a9a3acfe072b06f8613bec3b08e7bddc9d98f445d8f04
+        config.redpanda.com/checksum: 48a325f5c5fa8b33f626d5c76ed88b36ce2714d53487c9082b93e92d2b5c8f87
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -109432,7 +109280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -109458,7 +109306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -109484,7 +109332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -109522,7 +109370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -109560,7 +109408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -109576,7 +109424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -109593,7 +109441,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -109609,7 +109457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -109653,7 +109501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -109743,7 +109591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -109821,7 +109669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -109859,7 +109707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -109952,7 +109800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -109990,7 +109838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -110046,7 +109894,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -110120,7 +109967,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -110241,7 +110087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -110274,7 +110120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -110367,7 +110213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -110413,7 +110259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -110569,7 +110415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -110584,14 +110430,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: fd583ef56abf56bc1da1040cbc8b371141ce3ce8e65dc6e2bbf3306f1d3ea66d
+        config.redpanda.com/checksum: b129b8a33a04915b2caf0a94143ae5d556078e01495ed47b0e0861dfb831aa04
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -110896,7 +110742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -110922,7 +110768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -110948,7 +110794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -110974,7 +110820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -111012,7 +110858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -111050,7 +110896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -111088,7 +110934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -111113,7 +110959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -111129,7 +110975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -111146,7 +110992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -111162,7 +111008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -111179,7 +111025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -111195,7 +111041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -111239,7 +111085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -111335,7 +111181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -111419,7 +111265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -111457,7 +111303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -111550,7 +111396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -111588,7 +111434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -111644,7 +111490,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -111716,7 +111561,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       developer_mode: true
       empty_seed_starts_cluster: false
       enable_sasl: false
@@ -111832,7 +111676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -111863,7 +111707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -111956,7 +111800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -112002,7 +111846,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -112158,7 +112002,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -112173,14 +112017,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 52d1519d09a37760830ec1d73d414db921680be9361210d86cdf9e1b96ab32f3
+        config.redpanda.com/checksum: 1448c19b4c77431397765912ba57c87f0910d5b3b9c0299fc9266a95a8f1fa3b
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -112473,7 +112317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -112499,7 +112343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -112525,7 +112369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -112563,7 +112407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -112601,7 +112445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -112617,7 +112461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -112634,7 +112478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -112650,7 +112494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -112694,7 +112538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -112784,7 +112628,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -112862,7 +112706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -112900,7 +112744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -112993,7 +112837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -113031,7 +112875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -113087,7 +112931,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -113159,7 +113002,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -113275,7 +113117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -113306,7 +113148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -113399,7 +113241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -113445,7 +113287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -113601,7 +113443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -113616,14 +113458,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -113916,7 +113758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -113942,7 +113784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -113968,7 +113810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -114006,7 +113848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -114044,7 +113886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -114060,7 +113902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -114077,7 +113919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -114093,7 +113935,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -114110,7 +113952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -114168,7 +114010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -114258,7 +114100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -114336,7 +114178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -114374,7 +114216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -114467,7 +114309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -114505,7 +114347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -114561,7 +114403,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -114621,7 +114462,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -114736,7 +114576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -114766,7 +114606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -114859,7 +114699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -114905,7 +114745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -115054,7 +114894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -115069,14 +114909,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 907999e2ecb080ac97f540c7022de0dabf936a95aa63987c6615194756350178
+        config.redpanda.com/checksum: 13479d8b8e611d5a14186529bb5f78783a41367d8da7f00f75c6511d70af5c94
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -115368,7 +115208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -115394,7 +115234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -115420,7 +115260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -115458,7 +115298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -115496,7 +115336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -115512,7 +115352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -115529,7 +115369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -115545,7 +115385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -115562,7 +115402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -115616,7 +115456,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -115706,7 +115546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -115784,7 +115624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -115822,7 +115662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -115915,7 +115755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -115953,7 +115793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -116008,7 +115848,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -116079,7 +115918,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -116195,7 +116033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -116226,7 +116064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -116319,7 +116157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -116365,7 +116203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -116521,7 +116359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -116536,14 +116374,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: b4f5c87f7e221601ae6b84bb4e53fbb079989210981abe77fae69c94362abc09
+        config.redpanda.com/checksum: bd8064f0811f4477006c367b86a3ca709cbf758fe418153c4de99edd89783b40
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -116836,7 +116674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -116862,7 +116700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -116888,7 +116726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -116926,7 +116764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -116964,7 +116802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -116980,7 +116818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -116997,7 +116835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -117013,7 +116851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -117057,7 +116895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -117147,7 +116985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -117225,7 +117063,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -117302,7 +117140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -117395,7 +117233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -117433,7 +117271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -117488,7 +117326,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -117559,7 +117396,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -117675,7 +117511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -117706,7 +117542,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -117799,7 +117635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -117845,7 +117681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -118017,7 +117853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -118032,14 +117868,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: f32c3d39d665fd2d0fb7accd77510b88b3ec475a9101b8ae6c1dbe3f5922bfc6
+        config.redpanda.com/checksum: 6d57eeb3fc8cce37385d9a65aced22e7c3bd8b230fae1d372706f2d97fd4f258
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -118332,7 +118168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -118358,7 +118194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -118384,7 +118220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -118422,7 +118258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -118460,7 +118296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -118476,7 +118312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -118493,7 +118329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -118509,7 +118345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -118553,7 +118389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -118645,7 +118481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -118723,7 +118559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -118761,7 +118597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -118854,7 +118690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -118892,7 +118728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -118953,7 +118789,6 @@ apiVersion: v1
 data:
   bootstrap.yaml: |-
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -119024,7 +118859,6 @@ data:
         truststore_file: /etc/tls/certs/external/ca.crt
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -119140,7 +118974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -119171,7 +119005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -119264,7 +119098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -119310,7 +119144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -119466,7 +119300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -119481,14 +119315,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 0482e004a7b519b4994958383c26892aa19930c2ffb74d06d10c8d3b26139135
+        config.redpanda.com/checksum: 0316b707c2806c2584c4bac9867a095106e0332778214a2d148a2de3d6126b19
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -119781,7 +119615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -119807,7 +119641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -119833,7 +119667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -119871,7 +119705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -119909,7 +119743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -119925,7 +119759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -119942,7 +119776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -119958,7 +119792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -120002,7 +119836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -120092,7 +119926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -120170,7 +120004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -120208,7 +120042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -120301,7 +120135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -120339,7 +120173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -120395,7 +120229,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -120467,7 +120300,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -120583,7 +120415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -120614,7 +120446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -120707,7 +120539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -120753,7 +120585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -120909,7 +120741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -120924,14 +120756,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: d6e56ebb0832c6ea315f2e71c948b1b74566a4f84196ca83906ad0b7c9bc09a9
+        config.redpanda.com/checksum: c113378df81388298c93b7ef6cba7c55ea0ef8c9161d0a7e6b849dffe80d4246
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -121224,7 +121056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -121250,7 +121082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -121276,7 +121108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -121314,7 +121146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -121352,7 +121184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -121368,7 +121200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -121385,7 +121217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -121401,7 +121233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -121445,7 +121277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -121535,7 +121367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -121613,7 +121445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -121690,7 +121522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -121783,7 +121615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -121821,7 +121653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -121877,7 +121709,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -121949,7 +121780,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -122065,7 +121895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -122096,7 +121926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -122189,7 +122019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -122235,7 +122065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -122407,7 +122237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -122422,14 +122252,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -122722,7 +122552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -122748,7 +122578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -122774,7 +122604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -122812,7 +122642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -122850,7 +122680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -122866,7 +122696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -122883,7 +122713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -122899,7 +122729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -122943,7 +122773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -123035,7 +122865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -123113,7 +122943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -123151,7 +122981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -123244,7 +123074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -123282,7 +123112,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -123344,7 +123174,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: true
     enable_sasl: false
     group_topic_partitions: 16
@@ -123416,7 +123245,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -123532,7 +123360,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -123563,7 +123391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -123656,7 +123484,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -123702,7 +123530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -123858,7 +123686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -123873,14 +123701,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 9afc46d83a991f0a9d3097edcab58ecfc95be979941f151e902f8bc205b55419
+        config.redpanda.com/checksum: 5f66fd654e4814d30a05a6c37a88b3740691f219f80e279dc760f86f1337fe7e
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -124173,7 +124001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -124199,7 +124027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -124225,7 +124053,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -124263,7 +124091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -124301,7 +124129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -124317,7 +124145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -124334,7 +124162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -124350,7 +124178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -124394,7 +124222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -124484,7 +124312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -124562,7 +124390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -124600,7 +124428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -124693,7 +124521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -124731,7 +124559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -124787,7 +124615,6 @@ data:
   bootstrap.yaml: |-
     audit_enabled: false
     compacted_log_segment_size: 67108864
-    default_topic_replications: 3
     enable_rack_awareness: false
     enable_sasl: false
     group_topic_partitions: 16
@@ -124859,7 +124686,6 @@ data:
       audit_enabled: false
       compacted_log_segment_size: 67108864
       crash_loop_limit: 5
-      default_topic_replications: 3
       empty_seed_starts_cluster: false
       enable_sasl: false
       group_topic_partitions: 16
@@ -124975,7 +124801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 ---
@@ -125006,7 +124832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-rpk
   namespace: default
 ---
@@ -125099,7 +124925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -125145,7 +124971,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external
   namespace: default
 spec:
@@ -125301,7 +125127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda
   namespace: default
 spec:
@@ -125316,14 +125142,14 @@ spec:
   template:
     metadata:
       annotations:
-        config.redpanda.com/checksum: 7e9658bbe8763a1a7d95d177a6e1f634e5be32c006afb27b9cc10015cf6ddf63
+        config.redpanda.com/checksum: da9bb9910cb0667ca74fa2bc3a29b3582fe1f48c0a88ecd8365e56635c7513be
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: redpanda-statefulset
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.2
+        helm.sh/chart: redpanda-5.9.3
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -125616,7 +125442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -125642,7 +125468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -125668,7 +125494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -125706,7 +125532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -125744,7 +125570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -125760,7 +125586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -125777,7 +125603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -125793,7 +125619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -125837,7 +125663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-configuration
   namespace: default
 spec:
@@ -125927,7 +125753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.2
+    helm.sh/chart: redpanda-5.9.3
   name: redpanda-post-upgrade
   namespace: default
 spec:

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -355,3 +355,28 @@ listeners:
   admin:
     tls:
       enabled: true
+
+-- explicit-default-topic-replications --
+# Regression test for #1501. Respect default_topic_replicas if it's explicitly set.
+# ASSERT-FIELD-CONTAINS ["batch/v1/Job", "default/redpanda-post-upgrade", "{.spec.template.spec.containers[0].args[0]}", "default_topic_replications 25"]
+
+statefulset:
+  replicas: 1
+
+config:
+  cluster:
+    default_topic_replications: 25
+
+-- implicit-default-topic-replications --
+# Regression test for #1501.
+# ASSERT-FIELD-CONTAINS ["batch/v1/Job", "default/redpanda-post-upgrade", "{.spec.template.spec.containers[0].args[0]}", "default_topic_replications 3"]
+
+statefulset:
+  replicas: 10
+
+-- implicit-single-broker-default-topic-replications --
+# Regression test for #1501. When replicas < 3 no default value is injected.
+# ASSERT-FIELD-NOT-CONTAINS ["batch/v1/Job", "default/redpanda-post-upgrade", "{.spec.template.spec.containers[0].args[0]}", "default_topic_replications"]
+
+statefulset:
+  replicas: 1

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -1729,25 +1729,10 @@ func (c *NodeConfig) Translate() map[string]any {
 
 type ClusterConfig map[string]any
 
-func (c *ClusterConfig) Translate(replicas int32, skipDefaultTopic bool) map[string]any {
+func (c *ClusterConfig) Translate() map[string]any {
 	result := map[string]any{}
 
 	for k, v := range *c {
-		if k == "default_topic_replications" && !skipDefaultTopic {
-			r := int(replicas)
-			input := int(r)
-			if num, ok := helmette.AsIntegral[int](v); ok {
-				input = num
-			}
-
-			if f, ok := helmette.AsNumeric(v); ok {
-				input = int(f)
-			}
-
-			result[k] = helmette.Min(int64(input), int64(r+(r%2)-1))
-			continue
-		}
-
 		if b, ok := v.(bool); ok {
 			result[k] = b
 			continue

--- a/charts/redpanda/values.yaml
+++ b/charts/redpanda/values.yaml
@@ -1105,9 +1105,8 @@ listeners:
 config:
   rpk: {}
     # additional_start_flags:                                      # List of flags to pass to rpk, e.g., ` "--idle-poll-time-us=0"`
-  cluster:
-    default_topic_replications: 3                                  # Default replication factor for new topics
-                                                                   # There is logic in the chart that will set this to 1 if there are fewer than 3 statefulset.replicas
+  cluster: {}
+    # default_topic_replications: 3                                # Default replication factor for new topics. If not set, the chart will set it to 3 for clusters with 3 or more brokers.
     # auto_create_topics_enabled: true                             # Allow topic auto creation
     # transaction_coordinator_replication: 1                       # Replication factor for a transaction coordinator topic
     # id_allocator_replication: 1                                  # Replication factor for an ID allocator topic

--- a/go.work.sum
+++ b/go.work.sum
@@ -894,6 +894,7 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.5.0 h1:e8esj/e4R+SAOwFwN+n3zr0nYeCyeweozKfO23MvHzY=
 github.com/kisielk/gotool v1.0.0 h1:AV2c/EiW3KqPNT9ZKl07ehoAGi4C5/01Cfbblndcapg=
+github.com/klauspost/compress v1.17.4/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
 github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
@@ -961,6 +962,7 @@ github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zk
 github.com/matttproud/golang_protobuf_extensions v1.0.4/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 h1:jWpvCLoY8Z/e3VKvlsiIGKtc+UG6U5vzxaoagmhXfyg=
 github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQthUoa9bqDv0ER0wrtXnBruoNd7aNjkbP+k=
+github.com/mdelapenya/tlscert v0.1.0/go.mod h1:wrbyM/DwbFCeCeqdPX/8c6hNOqQgbf0rUDErE1uD+64=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d h1:5PJl274Y63IEHC+7izoQE9x6ikvDFZS2mDVS3drnohI=
 github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
 github.com/microcosm-cc/bluemonday v1.0.21 h1:dNH3e4PSyE4vNX+KlRGHT5KrSvjeUkoNPwEORjffHJg=
@@ -1100,6 +1102,8 @@ github.com/testcontainers/testcontainers-go/modules/redpanda v0.28.0 h1:STULzp30
 github.com/testcontainers/testcontainers-go/modules/redpanda v0.28.0/go.mod h1:vZV0T/ZZiJKj48VIR9yqliIga0bnyCNlrdfDEP//Kkw=
 github.com/testcontainers/testcontainers-go/modules/redpanda v0.29.1 h1:wqmZd30jKS1L87Va/zl7QLgjVaE/PUwjZ8XfVAAie/I=
 github.com/testcontainers/testcontainers-go/modules/redpanda v0.29.1/go.mod h1:URq0cHQv6JId/oO+ErrrTFhN6QV+TDr6D32sz7xwV5Y=
+github.com/testcontainers/testcontainers-go/modules/redpanda v0.32.0 h1:YicRA+Up3fiI1Vwtaw6MbUPoZfUUySoma6cxmjOgkMo=
+github.com/testcontainers/testcontainers-go/modules/redpanda v0.32.0/go.mod h1:4DNyEf4H091/q4qdXpVdxOne1EvvcFgNf7atLv3FqkU=
 github.com/tilinna/z85 v1.0.0 h1:uqFnJBlD01dosSeo5sK1G1YGbPuwqVHqR+12OJDRjUw=
 github.com/tilinna/z85 v1.0.0/go.mod h1:EfpFU/DUY4ddEy6CRvk2l+UQNEzHbh+bqBQS+04Nkxs=
 github.com/tklauser/go-sysconf v0.3.14 h1:g5vzr9iPFFz24v2KZXs/pvpvh8/V9Fw6vQK5ZZb78yU=
@@ -1245,6 +1249,7 @@ go.vallahaye.net/connect-gateway v0.3.1 h1:829VIFcOYgkKJTrRTf/C382MnFF4KNgZwtkCc
 go.vallahaye.net/connect-gateway v0.3.1/go.mod h1:aM7ANmNrnY2YC51bHLj9Gi0sRv14HvBZeDPtzOL3uGY=
 go.vallahaye.net/connect-gateway v0.4.3 h1:HzaHL4iZiHZG4SFxVGZ6+0G2Xf1Ce/KoezBULZA+xKs=
 go.vallahaye.net/connect-gateway v0.4.3/go.mod h1:8v5tI/tDDFxPIRGdq/eAsqPmFHrhXGaeBXvrTvfSO0k=
+golang.org/x/crypto v0.17.0/go.mod h1:gCAAfMLgwOJRpTjQ2zCCt2OcSfYMTeZVSRtQlPC7Nq4=
 golang.org/x/crypto v0.18.0/go.mod h1:R0j02AL6hcrfOiy9T4ZYp/rcWeMxM3L6QYxlOuEG1mg=
 golang.org/x/crypto v0.19.0/go.mod h1:Iy9bg/ha4yyC70EfRS8jz+B6ybOBKMaSxLj6P6oBDfU=
 golang.org/x/crypto v0.21.0/go.mod h1:0BP7YvVV9gBbVKyeTG0Gyn+gZm94bibOW5BjDEYAOMs=


### PR DESCRIPTION
Prior to this commit, `default_topic_replications` could be unexpectedly modified by the chart based on some internal math. This behavior was opaque and frustrating to users attempting to finely tune their cluster configuration.

This commit removes the default value of `default_topic_replications` in `values.yaml` and instead sets it within the chart only if `default_topic_replications` is NOT provided. This preserves the existing behavior of setting `default_topic_replications` to 3 or 1 based on `statefulset.replicas`.

Fixes #1501 K8S-334