### PR TITLE
Fix up use of helmette.SafeLookup calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 #### Added
 #### Changed
 #### Fixed
+* Fix initialization of configurations using RestToConfig when the passed in rest.Config contain on-disk value files.
 #### Removed
 * All zero, empty, or default cluster configurations have been removed from
   `values.yaml` in favor of letting redpanda determine what the defaults will

--- a/pkg/kube/config.go
+++ b/pkg/kube/config.go
@@ -19,6 +19,7 @@ func RestToConfig(cfg *rest.Config) clientcmdapi.Config {
 	clusters := make(map[string]*clientcmdapi.Cluster)
 	clusters["default-cluster"] = &clientcmdapi.Cluster{
 		Server:                   cfg.Host,
+		CertificateAuthority:     cfg.CAFile,
 		CertificateAuthorityData: cfg.CAData,
 	}
 
@@ -30,8 +31,12 @@ func RestToConfig(cfg *rest.Config) clientcmdapi.Config {
 
 	authinfos := make(map[string]*clientcmdapi.AuthInfo)
 	authinfos["default-user"] = &clientcmdapi.AuthInfo{
+		Token:                 cfg.BearerToken,
+		TokenFile:             cfg.BearerTokenFile,
 		ClientCertificateData: cfg.CertData,
+		ClientCertificate:     cfg.CertFile,
 		ClientKeyData:         cfg.KeyData,
+		ClientKey:             cfg.KeyFile,
 	}
 
 	return clientcmdapi.Config{


### PR DESCRIPTION
https://github.com/redpanda-data/redpanda-operator/pull/226 helped me discover that the clients initialized using a `rest.Config` passed in a `dot` context weren't being initialized properly when that config comes from the controller-runtime, namely since the operator service was using a service account, all of its CA/certificate/authentication settings were being pulled from disk. This fixes the `RestToConfig` method to properly initialize a `clientcmdapi.Config` object from a `rest.Config` containing parameters pulled from disk.