### PR TITLE
Add KubeConfig option for genereting all resources

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -83,6 +83,7 @@ jobs:
               - '**.go'
               - 'go.mod'
               - 'go.sum'
+              - 'charts/*/Chart.yaml'
   lint:
     runs-on: ubuntu-22.04
     steps:

--- a/charts/redpanda/chart.go
+++ b/charts/redpanda/chart.go
@@ -51,7 +51,7 @@ func ChartMeta() helmette.Chart {
 	return chartMeta
 }
 
-func Dot(release helmette.Release, values PartialValues) (*helmette.Dot, error) {
+func Dot(release helmette.Release, values PartialValues, kubeConfig kube.Config) (*helmette.Dot, error) {
 	valuesYaml, err := yaml.Marshal(values)
 	if err != nil {
 		return nil, err
@@ -64,14 +64,15 @@ func Dot(release helmette.Release, values PartialValues) (*helmette.Dot, error) 
 	}
 
 	return &helmette.Dot{
-		Values:  merged,
-		Chart:   ChartMeta(),
-		Release: release,
+		Values:     merged,
+		Chart:      ChartMeta(),
+		Release:    release,
+		KubeConfig: kubeConfig,
 	}, nil
 }
 
-func Template(release helmette.Release, values PartialValues) ([]kube.Object, error) {
-	dot, err := Dot(release, values)
+func Template(release helmette.Release, values PartialValues, kubeConfig kube.Config) ([]kube.Object, error) {
+	dot, err := Dot(release, values, kubeConfig)
 	if err != nil {
 		return nil, err
 	}

--- a/charts/redpanda/chart_test.go
+++ b/charts/redpanda/chart_test.go
@@ -756,7 +756,7 @@ func TestGoHelmEquivalence(t *testing.T) {
 		Name:      "gotohelm",
 		Namespace: "mynamespace",
 		Service:   "Helm",
-	}, values)
+	}, values, kube.Config{})
 	require.NoError(t, err)
 
 	rendered, err := client.Template(context.Background(), ".", helm.TemplateOptions{


### PR DESCRIPTION
With that change new reconciler can use Dot and Template function to generate all manifests.

Reference:

https://github.com/redpanda-data/redpanda-operator/pull/223#discussion_r1752665726