### PR TITLE
gotohelm: update doc.go

### DIFF
--- a/pkg/gotohelm/doc.go
+++ b/pkg/gotohelm/doc.go
@@ -11,22 +11,56 @@
 // gotohelm takes the approach of bootstrapping a rudimentary LISP-y
 // programming language within helm templates using the available builtins.
 //
-// # Functions
+// # Directives
+//
+// Directives in the form of `+gotohelm:DIRECTIVE=VALUE` may be specified as go
+// comments on the file, function, or type they modify.
+//
+//	// +gotohelm:filename=NAME        // Changes the name of the transpiled file to NAME.
+//	// +gotohelm:ignore=true          // Skips transpilation of the annotated file, function, or type.
+//	// +gotohelm:namespace=NAMESPACE  // Changes the namespace of transpiled package.
+//	// +gotohelm:builtin=BUILTIN_FUNC // Replaces transpilation of the annotated function with `BUILTIN_FUNC`.
+//
+// # Interop
+//
+// Transpiled go functions can be invoked within existing templates using the
+// following syntax:
+//
+//	((include NAMESPACE.NAME (dict "a" (list ARGS...))) | fromJson | get "r")
+//
+// # Limitations
+//
+//   - There is no "trap door" to fallback to raw templates
+//   - Switch statements, in all forms, are not currently supported
+//   - Type assertions don't work.
+//   - Most forms of incompatibility are handled with panics and fmt.Sprintf.
+//   - As all data is represented as JSON within helm. All numeric types must
+//     be treated as float64s. [helmette.AsIntegral] may be used to approximate
+//     integrals numbers.
+//
+// # Internals
+//
 // Functions are "implemented" by abusing the `include` builtin and are turned
 // into `define` blocks. Return values are wrapped in a dictionary and
 // marshalled to JSON. (Almost like Internet Explorer circa 2011).
-// Function calls are then a pipline of `(include NAME ARGS...) | fromJson | get RETURNKEY`
+// Function calls are then a pipeline of
 //
-// # Interop
-// Transpiled go functions can be invoked within existing templates using the
-// following syntax: `((include NAME (dict "a" (list ARGS...))) | fromJson | get "r")`
+//	(include NAME ARGS...) | fromJson | get RETURNKEY
 //
-// # Limitations
-//   - There is no "trap door" to fallback to raw templates
-//   - Switch statements, in all forms, are not currently supported
-//   - Code must deal with the "lowest common denominator" of .Values in the form
-//     of map[string]any. Values coalescing has not yet been implemented.
-//   - Type assertions don't work.
-//   - Many helpers and bits of syntax are missing.
-//   - Most forms of incompatibility are handled with panics and fmt.Sprintf.
+// Structs are represented as their JSON representation. Any implementer of
+// [json.Marshaller] or [json.Unmarshaller], such as [resource.Quantity] will
+// need to be special cased within the transpiler itself.
+//
+// Certain types of go syntax are difficult to transpile. To preserve
+// simplicity of the transpiler, more complicated pieces of syntax are
+// re-written to equivalent syntax that can more easily be transpiled.
+// Particularly, anything that returns multiple values.
+//
+//	value, ok := dict[key]
+//
+// Becomes
+//
+//	tmp_tuple_1 := helmette.DictTest(dict, key)
+//	value := tmp_tuple_1.T1
+//	ok := tmp_tuple_1.T2
 package gotohelm


### PR DESCRIPTION
This commit updates gotohelm's doc.go as it had grown a bit out of date and didn't render particularly well in godoc.