### PR TITLE
Remove connectors test pod randomization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,14 @@
 #### Fixed
 #### Removed
 
+### [0.1.13](https://github.com/redpanda-data/helm-charts/releases/tag/connectors-0.1.13) - 2024-09-26
+#### Added
+#### Changed
+* Test pod name will be stable (without randomization) [#1541](https://github.com/redpanda-data/helm-charts/pull/1541)
+* Update connectors container tag/application version [#1541](https://github.com/redpanda-data/helm-charts/pull/1541)
+#### Fixed
+#### Removed
+
 ### [0.1.12](https://github.com/redpanda-data/helm-charts/releases/tag/connectors-0.1.12)
 #### Added
 #### Changed

--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.1.12
+version: 0.1.13
 
 # The app version is the default version of Redpanda Connectors to install.
 appVersion: v1.0.29

--- a/charts/connectors/Chart.yaml
+++ b/charts/connectors/Chart.yaml
@@ -26,7 +26,7 @@ type: application
 version: 0.1.13
 
 # The app version is the default version of Redpanda Connectors to install.
-appVersion: v1.0.29
+appVersion: v1.0.31
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
 # pre-release. Our "-0" allows pre-releases to be matched.
@@ -44,6 +44,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: connectors
-      image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+      image: docker.redpanda.com/redpandadata/connectors:v1.0.31
     - name: rpk
       image: docker.redpanda.com/redpandadata/redpanda:latest

--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connectors Helm chart.
 ---
 
-![Version: 0.1.12](https://img.shields.io/badge/Version-0.1.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.29](https://img.shields.io/badge/AppVersion-v1.0.29-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.29](https://img.shields.io/badge/AppVersion-v1.0.29-informational?style=flat-square)
 
 This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/connectors/README.md
+++ b/charts/connectors/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connectors Helm chart.
 ---
 
-![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.29](https://img.shields.io/badge/AppVersion-v1.0.29-informational?style=flat-square)
+![Version: 0.1.13](https://img.shields.io/badge/Version-0.1.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.0.31](https://img.shields.io/badge/AppVersion-v1.0.31-informational?style=flat-square)
 
 This page describes the official Redpanda Connectors Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/connectors/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/connectors/templates/tests/01-mm2-values.yaml
+++ b/charts/connectors/templates/tests/01-mm2-values.yaml
@@ -21,7 +21,7 @@ limitations under the License.
 apiVersion: v1
 kind: Pod
 metadata:
-  name: {{ include "connectors.fullname" . }}-mm2-test-{{ randNumeric 3 }}
+  name: {{ include "connectors.fullname" . }}-mm2-test
   namespace: {{ .Release.Namespace | quote }}
   labels:
 {{- with include "full.labels" . }}

--- a/charts/connectors/testdata/template-cases.golden.txtar
+++ b/charts/connectors/testdata/template-cases.golden.txtar
@@ -117,7 +117,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -334,7 +334,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -539,7 +539,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -740,7 +740,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -932,7 +932,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1122,7 +1122,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1363,7 +1363,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1557,7 +1557,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -1740,7 +1740,7 @@ spec:
         - prefix: W
         - prefix: 6Cgj
         - prefix: YV
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -1790317528
@@ -2000,7 +2000,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -2259,7 +2259,7 @@ spec:
           secretRef:
             name: NYC3bKPQWLc
             optional: false
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -757710692
@@ -2561,7 +2561,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -2822,7 +2822,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -3040,7 +3040,7 @@ spec:
         - prefix: Ci6EGf
           secretRef:
             name: cDwbNN
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1181508047
@@ -3270,7 +3270,7 @@ spec:
         - name: CONNECT_TLS_AUTH_KEY
           value: key/z4oRSGo
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -3508,7 +3508,7 @@ spec:
           prefix: lT
           secretRef:
             name: W
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 832341066
@@ -3833,7 +3833,7 @@ spec:
             name: IuBuoY8u5xD1D7
             optional: false
           prefix: 2xqoZ
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -4130,7 +4130,7 @@ spec:
         - name: CONNECT_TLS_AUTH_CERT
           value: cert/LP7Pcx1xGT
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -4391,7 +4391,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -4582,7 +4582,7 @@ spec:
         - name: CONNECT_TRUSTED_CERTS
           value: ca/qv
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -1400952913
@@ -4861,7 +4861,7 @@ spec:
           secretRef:
             name: u
             optional: false
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -94764338
@@ -5167,7 +5167,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -5404,7 +5404,7 @@ spec:
         - prefix: w
           secretRef:
             name: p4
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -5723,7 +5723,7 @@ spec:
           prefix: WUotCc
           secretRef:
             optional: true
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -6024,7 +6024,7 @@ spec:
         - name: CONNECT_TLS_AUTH_KEY
           value: key/IlMv6
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -6545,7 +6545,7 @@ spec:
         - name: CONNECT_TLS_AUTH_KEY
           value: key/EOAKr
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -1589865511
@@ -6906,7 +6906,7 @@ spec:
               name: hoEa
               optional: false
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1572051601
@@ -7272,7 +7272,7 @@ spec:
               name: 4L5
               optional: false
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -1801401906
@@ -7586,7 +7586,7 @@ spec:
               name: w
               optional: false
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 285554662
@@ -7970,7 +7970,7 @@ spec:
           prefix: YX
           secretRef:
             optional: false
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 724202040
@@ -8475,7 +8475,7 @@ spec:
           secretRef:
             name: eZxNk
             optional: false
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -179099947
@@ -8976,7 +8976,7 @@ spec:
           secretRef:
             name: C
             optional: true
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: -2044419963
@@ -9356,7 +9356,7 @@ spec:
           secretRef:
             name: zLL2kR
             optional: false
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 1532121771
@@ -9660,7 +9660,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -9849,7 +9849,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10038,7 +10038,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -10229,7 +10229,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3

--- a/charts/connectors/testdata/template-cases.golden.txtar
+++ b/charts/connectors/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pO5m
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: rpVz
 spec:
   ipFamilies:
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pO5m
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: rpVz
 spec:
   progressDeadlineSeconds: 600
@@ -227,7 +227,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nZ
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 5wkC
 spec:
   ipFamilies:
@@ -259,7 +259,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: nZ
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: WtC
 spec:
   progressDeadlineSeconds: 600
@@ -418,7 +418,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZZ5
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: AN
   namespace: default
 ---
@@ -432,7 +432,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZZ5
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: xp6vcIlb
 spec:
   ipFamilies:
@@ -464,7 +464,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZZ5
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: xp6vcIlb
 spec:
   progressDeadlineSeconds: 600
@@ -633,7 +633,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Wvpgs
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: kNrkCdEuw9V
 spec:
   ipFamilies:
@@ -665,7 +665,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Wvpgs
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: kNrkCdEuw9V
 spec:
   progressDeadlineSeconds: 600
@@ -825,7 +825,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xhLPt0
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 74qyne
 spec:
   ipFamilies:
@@ -857,7 +857,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xhLPt0
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 74qyne
 spec:
   progressDeadlineSeconds: 600
@@ -1015,7 +1015,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: J
 spec:
   ipFamilies:
@@ -1047,7 +1047,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: W
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: J
 spec:
   progressDeadlineSeconds: 600
@@ -1223,7 +1223,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vlci
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     m2DRq: cS
   name: "7"
   namespace: default
@@ -1240,7 +1240,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vlci
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     m2DRq: cS
   name: gkX
 spec:
@@ -1278,7 +1278,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Vlci
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     m2DRq: cS
   name: R93VG
 spec:
@@ -1448,7 +1448,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gb7J7k
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 9PY0
 spec:
   ipFamilies:
@@ -1480,7 +1480,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Gb7J7k
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: NUTO
 spec:
   progressDeadlineSeconds: 600
@@ -1639,7 +1639,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPhRiQRK
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: PNw8
 spec:
   ipFamilies:
@@ -1671,7 +1671,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tPhRiQRK
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: PNw8
 spec:
   progressDeadlineSeconds: 467220788
@@ -1828,7 +1828,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wCD97n
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: eyeD
   namespace: default
 ---
@@ -1842,7 +1842,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wCD97n
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: H
 spec:
   ipFamilies:
@@ -1878,7 +1878,7 @@ metadata:
     cUt: YvDFEsYlU
     g3hOh91HKI: CHwTjLYe2XS
     h4yNA: fJL
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: LsGZn
 spec:
   ipFamilies:
@@ -1916,7 +1916,7 @@ metadata:
     cUt: YvDFEsYlU
     g3hOh91HKI: CHwTjLYe2XS
     h4yNA: fJL
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: LsGZn
 spec:
   progressDeadlineSeconds: 600
@@ -2112,7 +2112,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xiBXju
     bX: vmmkhH2NHvdt
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     mO: pT
   name: etuP
 spec:
@@ -2148,7 +2148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: xiBXju
     bX: vmmkhH2NHvdt
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     mO: pT
   name: etuP
 spec:
@@ -2364,7 +2364,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: MexiU
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: Ac
 spec:
   ipFamilies:
@@ -2397,7 +2397,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: w8tCi3K
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: InI
 spec:
   ipFamilies:
@@ -2452,7 +2452,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dA1zsc
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: u7DU
 spec:
   ipFamilies:
@@ -2484,7 +2484,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: dA1zsc
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: u7DU
 spec:
   progressDeadlineSeconds: 600
@@ -2673,7 +2673,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bpgtWxol
     etW: "9"
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: x
 spec:
   ipFamilies:
@@ -2711,7 +2711,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cex3v
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: B5Y
 spec:
   ipFamilies:
@@ -2747,7 +2747,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cex3v
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: bGMfavR
 spec:
   progressDeadlineSeconds: 600
@@ -2906,7 +2906,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DAE
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     wR: GAm
   name: u1Dk
 spec:
@@ -2941,7 +2941,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: DAE
     fet: YGwnq
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     wR: GAm
   name: u1Dk
 spec:
@@ -3153,7 +3153,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: C
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: CVJfMb
 spec:
   ipFamilies:
@@ -3185,7 +3185,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: C
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: hX1VdtP7gp7c
 spec:
   progressDeadlineSeconds: 600
@@ -3370,7 +3370,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qQY
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: iPsih4
 spec:
   ipFamilies:
@@ -3406,7 +3406,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: qQY
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: S9NS5c
 spec:
   progressDeadlineSeconds: 600
@@ -3597,7 +3597,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: kUuRn
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: IAukfjAiE
 spec:
   ipFamilies:
@@ -3633,7 +3633,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cg
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     "y": TxHhxVY2tRx1i
   name: ABdKo
   namespace: default
@@ -3650,7 +3650,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cg
     g: Haj2trb
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     nQCD85u: 7ENE
     "y": TxHhxVY2tRx1i
   name: kt3xi
@@ -3692,7 +3692,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Cg
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     "y": TxHhxVY2tRx1i
   name: console-Cg
 spec:
@@ -3962,7 +3962,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6MJPA
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: x4Vu7vj
 spec:
   ipFamilies:
@@ -4000,7 +4000,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 6MJPA
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: cZ4G4
 spec:
   progressDeadlineSeconds: 457348204
@@ -4284,7 +4284,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZI341xw
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 9tds
 spec:
   ipFamilies:
@@ -4316,7 +4316,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ZI341xw
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 9tds
 spec:
   progressDeadlineSeconds: 600
@@ -4476,7 +4476,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Y47
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: e4W
 spec:
   ipFamilies:
@@ -4510,7 +4510,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Y47
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: e4W
 spec:
   progressDeadlineSeconds: 5438195
@@ -4686,7 +4686,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: z3C
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: UFYrvO
 spec:
   ipFamilies:
@@ -4720,7 +4720,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: z3C
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     p7R: EjfLOeG
     th6: enWXwqe
   name: uv4tHoO
@@ -4984,7 +4984,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATJ
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     op: VnL9o7
   name: jmzfCmHq
   namespace: default
@@ -4999,7 +4999,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ATJ
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     op: VnL9o7
   name: XfK7
 spec:
@@ -5038,7 +5038,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ffe2
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: maeWLc
   namespace: default
 ---
@@ -5055,7 +5055,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ffe2
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: uSz
 spec:
   ipFamilies:
@@ -5089,7 +5089,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: ffe2
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: OL1
 spec:
   progressDeadlineSeconds: 600
@@ -5262,7 +5262,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "3"
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 9VQ
 spec:
   ipFamilies:
@@ -5294,7 +5294,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: "3"
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: ZvvoA
 spec:
   progressDeadlineSeconds: 600
@@ -5530,7 +5530,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tl2YFI
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: IyM
 spec:
   ipFamilies:
@@ -5570,7 +5570,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: tl2YFI
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: IyM
 spec:
   progressDeadlineSeconds: 533336746
@@ -5849,7 +5849,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P7
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: UQ27oL
   namespace: default
 ---
@@ -5864,7 +5864,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: P7
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: IVe
 spec:
   ipFamilies:
@@ -5899,7 +5899,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pLehdV
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: MnW8I02
 spec:
   ipFamilies:
@@ -5935,7 +5935,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pLehdV
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: pPZgwOOt
 spec:
   progressDeadlineSeconds: 600
@@ -6136,7 +6136,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 8geRNocLQ
 spec:
   ipFamilies:
@@ -6173,7 +6173,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bz0yr
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: LVtVe0en
   namespace: default
 ---
@@ -6190,7 +6190,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: bz0yr
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     kt: ""
   name: crWrH
 spec:
@@ -6236,7 +6236,7 @@ metadata:
     app.kubernetes.io/name: Pt
     c: fgV
     eHykHSeD: M0vI4
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     ik: hu
     trc: W
   name: 1hV
@@ -6280,7 +6280,7 @@ metadata:
     app.kubernetes.io/name: PeueQ
     co: MffSo
     fdioW3StBvzyh: z
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     ofToM: "n"
     wle: mprjb
   name: mC3vFeP
@@ -6347,7 +6347,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: taotfWzUIl
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     lp92O: 1QnD84Dhxl
   name: GxFDpR9IkU
 spec:
@@ -6382,7 +6382,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: taotfWzUIl
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: VW0lF
 spec:
   progressDeadlineSeconds: -1260879447
@@ -6690,7 +6690,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 03U7
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: "87"
 spec:
   ipFamilies:
@@ -6731,7 +6731,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 03U7
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: vRXgQsUzl3
 spec:
   progressDeadlineSeconds: -1761307563
@@ -7047,7 +7047,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: BX8JrNja9K1E
     eYdK: Cku
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     ztF1: wwq1
   name: mCI
 spec:
@@ -7085,7 +7085,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mn
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: ZkHM
   namespace: default
 ---
@@ -7101,7 +7101,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mn
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: El70
 spec:
   ipFamilies:
@@ -7137,7 +7137,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: mn
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: jio8f
 spec:
   progressDeadlineSeconds: -1221802348
@@ -7400,7 +7400,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4iNcef5
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     "n": ""
   name: FKhGHe3aO
   namespace: default
@@ -7418,7 +7418,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4iNcef5
     g: 0z9gQt4Yj
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     "n": ""
   name: KxK
 spec:
@@ -7465,7 +7465,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 4iNcef5
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     "n": ""
   name: NCw6T6UcQY
 spec:
@@ -7754,7 +7754,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ur
     eP0gw: ZlmzgOXE
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: bjGFkzr
 spec:
   ipFamilies:
@@ -7796,7 +7796,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: Ur
     eP0gw: ZlmzgOXE
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: AqjekuF
 spec:
   progressDeadlineSeconds: 1079618075
@@ -8109,7 +8109,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s9WyH2Y
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: w
   namespace: default
 ---
@@ -8127,7 +8127,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: s9WyH2Y
     fzz: CLoaDJm9w
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     rryVp: TZ
   name: 8Tb8k
 spec:
@@ -8169,7 +8169,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: WdYlcGB
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     xYCcuP: zC
   name: L
 spec:
@@ -8234,7 +8234,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: R64C
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: c
   namespace: default
 ---
@@ -8248,7 +8248,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: R64C
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     t7u5eHUdpR: nq6injR
   name: L
 spec:
@@ -8286,7 +8286,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: R64C
     e1: EPUL4
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: ZNfeDYT
 spec:
   progressDeadlineSeconds: -1210754760
@@ -8631,7 +8631,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8UJFy
     h52qwPFCCL1xE: q
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: Vk
   namespace: default
 ---
@@ -8648,7 +8648,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: 8UJFy
     h52qwPFCCL1xE: q
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: 58KMN
 spec:
   ipFamilies:
@@ -8717,7 +8717,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fa1XvkvO
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: cl
   namespace: default
 ---
@@ -8732,7 +8732,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: fa1XvkvO
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: UrU9Bs
 spec:
   ipFamilies:
@@ -8795,7 +8795,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wN
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     ytV2tl: icxW
   name: 3m
   namespace: default
@@ -8812,7 +8812,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wN
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     ytV2tl: icxW
   name: xW
 spec:
@@ -8851,7 +8851,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: wN
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     ytV2tl: icxW
   name: Bl0rL2
 spec:
@@ -9131,7 +9131,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: r7G
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     x3: e1lz
   name: w4DG
 spec:
@@ -9165,7 +9165,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: r7G
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     x3: e1lz
   name: xPmln
 spec:
@@ -9495,7 +9495,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pyCdF
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     wy9DijfF9: pY
   name: zr1OY
   namespace: default
@@ -9512,7 +9512,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: pyCdF
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
     uH: o
     wy9DijfF9: pY
   name: 37ihe
@@ -9550,7 +9550,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   ipFamilies:
@@ -9582,7 +9582,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -9742,7 +9742,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   ipFamilies:
@@ -9774,7 +9774,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -9931,7 +9931,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   ipFamilies:
@@ -9963,7 +9963,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -10120,7 +10120,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   ipFamilies:
@@ -10152,7 +10152,7 @@ metadata:
     app.kubernetes.io/instance: console
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: console-connectors
 spec:
   progressDeadlineSeconds: 600


### PR DESCRIPTION
#### https://github.com/redpanda-data/helm-charts/commit/68d22ae1bb7f99d82ca396bc0b3e522e80c31ce2

In Redpanda chart testdata can not exclude connectors test pod as connectors.yaml
negates the test.create boolean and always creates test pod.

#### https://github.com/redpanda-data/helm-charts/commit/3cdd5af23197f72c204229163774df9babf66f38

Latest release [docker hub v1.0.31](https://hub.docker.com/layers/redpandadata/connectors/v1.0.31/images/sha256-64fa274eaaca6d9c3463f237b579f64f43caec2cce26329b03b986f473ab014c?context=explore)