### PR TITLE
Fix connectors deployment from redpanda chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@
 #### Fixed
 #### Removed
 
+### [5.9.5](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.5) - 2024-09-26
+#### Added
+#### Changed
+* Bump Redpanda container tag/application version [#1543](https://github.com/redpanda-data/helm-charts/pull/1543)
+#### Fixed
+* Connectors deployment [#1543](https://github.com/redpanda-data/helm-charts/pull/1543)
+#### Removed
+
 ### [5.9.4](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.4) - 2024-09-17
 #### Added
 #### Changed

--- a/charts/redpanda/Chart.lock
+++ b/charts/redpanda/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.7.29
 - name: connectors
   repository: https://charts.redpanda.com
-  version: 0.1.12
-digest: sha256:ed0641d28d6174d865544a5948fdaddb3b766a27473b07b0cca979efc6c3c024
-generated: "2024-08-28T15:46:40.176857+02:00"
+  version: 0.1.13
+digest: sha256:3023f8ca61cf80050d0f0e73f9e86b73ae796717c651be8765c9db90996e5462
+generated: "2024-09-26T22:13:55.854012+02:00"

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,11 +23,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.9.4
+version: 5.9.5
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: v24.2.4
+appVersion: v24.2.5
 
 # kubeVersion must be suffixed with "-0" to be able to match cloud providers
 # kubernetes versions like "v1.23.8-gke.1900". Their suffix is interpreted as a
@@ -56,7 +56,7 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+      image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
     - name: busybox
       image: busybox:latest
     - name: mintel/docker-alpine-bash-curl-jq

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.4](https://img.shields.io/badge/Version-5.9.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.4](https://img.shields.io/badge/AppVersion-v24.2.4-informational?style=flat-square)
+![Version: 5.9.5](https://img.shields.io/badge/Version-5.9.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.5](https://img.shields.io/badge/AppVersion-v24.2.5-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/ci/14-prometheus-no-tls-values.yaml
+++ b/charts/redpanda/ci/14-prometheus-no-tls-values.yaml
@@ -18,3 +18,5 @@ tls:
 
 monitoring:
   enabled: true
+  labels:
+    release: prometheus

--- a/charts/redpanda/ci/15-prometheus-tls-values.yaml
+++ b/charts/redpanda/ci/15-prometheus-tls-values.yaml
@@ -18,3 +18,5 @@ tls:
 
 monitoring:
   enabled: true
+  labels:
+    release: prometheus

--- a/charts/redpanda/templates/connectors/connectors.yaml
+++ b/charts/redpanda/templates/connectors/connectors.yaml
@@ -102,6 +102,7 @@ limitations under the License.
 {{ $connectorsValues := merge $connectorsValues (dict "Values" (dict "deployment" (dict "create" (not .Values.connectors.deployment.create)))) }}
 {{ $connectorsValues := merge $connectorsValues (dict "Values" (dict "test" (dict "create" (not .Values.connectors.test.create)))) }}
 {{ $helmVars := merge $connectorsValues .Subcharts.connectors }}
+{{ $helmVars = (dict "Chart" .Subcharts.connectors.Chart "Release" .Release "Values" (merge (dict "AsMap" $helmVars.Values) $helmVars.Values)) }}
 {{ include (print .Subcharts.connectors.Template.BasePath "/deployment.yaml") $helmVars }}
 ---
 {{ include (print .Subcharts.connectors.Template.BasePath "/tests/01-mm2-values.yaml") $helmVars }}

--- a/charts/redpanda/templates/tests/test-connector-via-console.yaml
+++ b/charts/redpanda/templates/tests/test-connector-via-console.yaml
@@ -17,8 +17,9 @@ limitations under the License.
 {{- if and .Values.tests.enabled .Values.connectors.enabled .Values.console.enabled }}
 {{- $sasl := .Values.auth.sasl }}
 {{- $values := .Values }}
-{{ $consoleValues := dict "Values" .Values.console "Release" .Release "Chart" .Subcharts.console.Chart }}
-{{ $connectorsVars := dict "Values" .Values.connectors "Release" .Release "Chart" .Subcharts.connectors.Chart }}
+{{- $consoleValues := (merge (dict) .Values.console .Subcharts.console.Values) -}}
+{{- $consoleDot := dict "Values" (dict "AsMap" $consoleValues) "Release" .Release "Chart" .Subcharts.console.Chart -}}
+{{- $connectorsDot := dict "Values" (merge (dict) .Values.connectors .Subcharts.connectors.Values) "Release" .Release "Chart" .Subcharts.connectors.Chart -}}
 {{/* brokers */}}
 {{- $kafkaBrokers := list }}
 {{- range (include "seed-server-list" . | mustFromJson) }}
@@ -61,13 +62,13 @@ spec:
 
           connectorsState () {
             echo check connectors expand status
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors?expand=status
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsDot }}:{{ .Values.connectors.connectors.restPort }}/connectors?expand=status
             echo check connectors expand info
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors?expand=info
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsDot }}:{{ .Values.connectors.connectors.restPort }}/connectors?expand=info
             echo check connector configuration
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors/$CONNECTOR_NAME
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsDot }}:{{ .Values.connectors.connectors.restPort }}/connectors/$CONNECTOR_NAME
             echo check connector topics
-            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsVars }}:{{ .Values.connectors.connectors.restPort }}/connectors/$CONNECTOR_NAME/topics
+            curl {{ template "curl-options" . }} http://{{ include "connectors.serviceName" $connectorsDot }}:{{ .Values.connectors.connectors.restPort }}/connectors/$CONNECTOR_NAME/topics
           }
           
           {{- if .Values.auth.sasl.enabled }}
@@ -147,7 +148,7 @@ spec:
           sed -i "s/JAAS_CONFIG_TARGET/$JAAS_CONFIG_TARGET/g" /tmp/mm2-conf.json
           set -x
 
-          URL=http://{{ include "console.fullname" $consoleValues }}:{{ include "console.containerPort" $consoleValues }}/api/kafka-connect/clusters/connectors/connectors
+          URL=http://{{ get ((include "console.Fullname" (dict "a" (list $consoleDot))) | fromJson) "r" }}:{{ get (fromJson (include "console.ContainerPort" (dict "a" (list $consoleDot) ))) "r" }}/api/kafka-connect/clusters/connectors/connectors
           {{/* outputting to /dev/null because the output contains the user password */}}
           echo "Creating mm2 connector"
           curl {{ template "curl-options" . }} -H 'Content-Type: application/json' "${URL}" -d @/tmp/mm2-conf.json

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -404,7 +404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -435,7 +435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -528,7 +528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -574,7 +574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -730,7 +730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -752,7 +752,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -783,7 +783,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -886,7 +886,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -905,7 +905,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -946,7 +946,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -1045,7 +1045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -1071,7 +1071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -1097,7 +1097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1135,7 +1135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1173,7 +1173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -1189,7 +1189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -1206,7 +1206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -1222,7 +1222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -1266,7 +1266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1308,7 +1308,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -1356,7 +1356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -1390,7 +1390,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -1434,7 +1434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1473,7 +1473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -1568,7 +1568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -1607,7 +1607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -1740,7 +1740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1766,7 +1766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -1856,7 +1856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -1903,7 +1903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -2035,7 +2035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -2058,7 +2058,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
     spec:
@@ -2090,7 +2090,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -2188,7 +2188,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -2203,7 +2203,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -2240,7 +2240,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -2355,7 +2355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -2399,7 +2399,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -2435,7 +2435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     testlabel: exercise_common_labels_template
   name: redpanda-post-upgrade
   namespace: default
@@ -2471,7 +2471,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -2503,7 +2503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -2541,7 +2541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -2635,7 +2635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -2673,7 +2673,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -2868,7 +2868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -2895,7 +2895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -2984,7 +2984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -3030,7 +3030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -3186,7 +3186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -3208,7 +3208,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -3239,7 +3239,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -3342,7 +3342,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -3361,7 +3361,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -3402,7 +3402,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -3501,7 +3501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -3527,7 +3527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -3553,7 +3553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -3591,7 +3591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -3629,7 +3629,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -3645,7 +3645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -3662,7 +3662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -3678,7 +3678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -3722,7 +3722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -3764,7 +3764,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -3812,7 +3812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -3845,7 +3845,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -3889,7 +3889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -3927,7 +3927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -4025,7 +4025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-users
   namespace: default
 stringData:
@@ -4042,7 +4042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -4179,7 +4179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -4227,7 +4227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -4336,7 +4336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -4361,7 +4361,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -4450,7 +4450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -4496,7 +4496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -4642,7 +4642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -4664,7 +4664,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -4706,7 +4706,7 @@ spec:
           value: SCRAM-SHA-256
         - name: RP_BOOTSTRAP_USER
           value: $(RPK_USER):$(RPK_PASS):$(RPK_SASL_MECHANISM)
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -4816,7 +4816,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -4834,7 +4834,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -4883,7 +4883,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -5003,7 +5003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -5054,7 +5054,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -5096,7 +5096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -5138,7 +5138,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -5176,7 +5176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -5214,7 +5214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -5312,7 +5312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-users
   namespace: default
 stringData:
@@ -5329,7 +5329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -5466,7 +5466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -5514,7 +5514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -5692,7 +5692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -5719,7 +5719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -5808,7 +5808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -5854,7 +5854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -6025,7 +6025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -6047,7 +6047,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -6089,7 +6089,7 @@ spec:
           value: SCRAM-SHA-256
         - name: RP_BOOTSTRAP_USER
           value: $(RPK_USER):$(RPK_PASS):$(RPK_SASL_MECHANISM)
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -6204,7 +6204,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -6226,7 +6226,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -6279,7 +6279,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -6384,7 +6384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -6410,7 +6410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -6436,7 +6436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -6474,7 +6474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -6512,7 +6512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -6528,7 +6528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -6545,7 +6545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -6561,7 +6561,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -6605,7 +6605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -6656,7 +6656,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -6710,7 +6710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -6753,7 +6753,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -6803,7 +6803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -6842,7 +6842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -6856,7 +6856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -6949,7 +6949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -6987,7 +6987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -7218,7 +7218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -7249,7 +7249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -7317,7 +7317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
 rules:
 - apiGroups:
@@ -7339,7 +7339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -7371,7 +7371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7393,7 +7393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7440,7 +7440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -7486,7 +7486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -7642,7 +7642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -7664,7 +7664,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -7695,7 +7695,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -7798,7 +7798,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -7817,7 +7817,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -7858,7 +7858,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -7957,7 +7957,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -7983,7 +7983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -8009,7 +8009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -8047,7 +8047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -8085,7 +8085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -8101,7 +8101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -8118,7 +8118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -8134,7 +8134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -8178,7 +8178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -8220,7 +8220,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -8268,7 +8268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -8302,7 +8302,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -8346,7 +8346,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -8384,7 +8384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -8477,7 +8477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -8515,7 +8515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -8801,7 +8801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -8831,7 +8831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -8924,7 +8924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -8970,7 +8970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -9138,7 +9138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -9160,7 +9160,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -9191,7 +9191,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -9308,7 +9308,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -9329,7 +9329,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -9372,7 +9372,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -9477,7 +9477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-cert2-root-certificate
   namespace: default
 spec:
@@ -9503,7 +9503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -9529,7 +9529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -9555,7 +9555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -9593,7 +9593,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -9631,7 +9631,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -9669,7 +9669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-cert2-selfsigned-issuer
   namespace: default
 spec:
@@ -9685,7 +9685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-cert2-root-issuer
   namespace: default
 spec:
@@ -9702,7 +9702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -9718,7 +9718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -9735,7 +9735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -9751,7 +9751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -9795,7 +9795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -9837,7 +9837,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -9891,7 +9891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -9925,7 +9925,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -9975,7 +9975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -10013,7 +10013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -10106,7 +10106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -10144,7 +10144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -10369,7 +10369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -10400,7 +10400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -10493,7 +10493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -10539,7 +10539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -10695,7 +10695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -10717,7 +10717,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -10747,7 +10747,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -10850,7 +10850,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -10869,7 +10869,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -10910,7 +10910,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -11009,7 +11009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -11035,7 +11035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -11061,7 +11061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -11099,7 +11099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -11137,7 +11137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -11153,7 +11153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -11170,7 +11170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -11186,7 +11186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -11230,7 +11230,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -11272,7 +11272,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -11320,7 +11320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -11354,7 +11354,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -11398,7 +11398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -11436,7 +11436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -11529,7 +11529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -11567,7 +11567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -11627,7 +11627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -11847,7 +11847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -11878,7 +11878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -11971,7 +11971,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -12017,7 +12017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -12173,7 +12173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -12195,7 +12195,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -12226,7 +12226,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -12331,7 +12331,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -12352,7 +12352,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -12399,7 +12399,7 @@ spec:
           ext4 & wait $!
         command:
         - /bin/sh
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: fs-validator
         resources:
           limits:
@@ -12448,7 +12448,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources:
           limits:
@@ -12572,7 +12572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -12598,7 +12598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -12624,7 +12624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -12662,7 +12662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -12700,7 +12700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -12716,7 +12716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -12733,7 +12733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -12749,7 +12749,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -12793,7 +12793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -12835,7 +12835,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -12883,7 +12883,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -12917,7 +12917,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -12961,7 +12961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -12999,7 +12999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -13092,7 +13092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -13130,7 +13130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -13355,7 +13355,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -13386,7 +13386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -13479,7 +13479,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -13525,7 +13525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -13681,7 +13681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -13703,7 +13703,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -13734,7 +13734,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -13837,7 +13837,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -13856,7 +13856,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -13897,7 +13897,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -13996,7 +13996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -14022,7 +14022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -14048,7 +14048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -14088,7 +14088,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -14128,7 +14128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -14144,7 +14144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -14161,7 +14161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -14177,7 +14177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -14221,7 +14221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -14263,7 +14263,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -14311,7 +14311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -14345,7 +14345,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -14389,7 +14389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -14427,7 +14427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -14524,7 +14524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: some-users
   namespace: default
 stringData:
@@ -14545,7 +14545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -14682,7 +14682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -14742,7 +14742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -14936,7 +14936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -14967,7 +14967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -15060,7 +15060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -15106,7 +15106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -15277,7 +15277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -15299,7 +15299,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -15341,7 +15341,7 @@ spec:
           value: SCRAM-SHA-256
         - name: RP_BOOTSTRAP_USER
           value: $(RPK_USER):$(RPK_PASS):$(RPK_SASL_MECHANISM)
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -15456,7 +15456,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -15478,7 +15478,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -15531,7 +15531,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -15636,7 +15636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -15662,7 +15662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -15688,7 +15688,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -15726,7 +15726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -15764,7 +15764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -15780,7 +15780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -15797,7 +15797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -15813,7 +15813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -15857,7 +15857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -15908,7 +15908,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -15962,7 +15962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -16005,7 +16005,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -16055,7 +16055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -16093,7 +16093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -16186,7 +16186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -16224,7 +16224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -16449,7 +16449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -16480,7 +16480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -16573,7 +16573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -16619,7 +16619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -16775,7 +16775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -16797,7 +16797,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -16828,7 +16828,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -16931,7 +16931,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -16950,7 +16950,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -16991,7 +16991,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -17090,7 +17090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -17116,7 +17116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -17156,7 +17156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -17172,7 +17172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -17216,7 +17216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -17258,7 +17258,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -17306,7 +17306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -17340,7 +17340,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -17384,7 +17384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -17422,7 +17422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -17515,7 +17515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -17553,7 +17553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -17778,7 +17778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -17809,7 +17809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -17902,7 +17902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -17948,7 +17948,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -17992,7 +17992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -18036,7 +18036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -18191,7 +18191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -18213,7 +18213,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -18244,7 +18244,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -18347,7 +18347,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -18366,7 +18366,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -18407,7 +18407,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -18506,7 +18506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -18532,7 +18532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -18572,7 +18572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -18588,7 +18588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -18632,7 +18632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -18674,7 +18674,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -18722,7 +18722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -18756,7 +18756,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -18800,7 +18800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -18838,7 +18838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -18931,7 +18931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -18969,7 +18969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -19130,7 +19130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -19159,7 +19159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -19252,7 +19252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -19298,7 +19298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -19429,7 +19429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -19451,7 +19451,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -19482,7 +19482,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -19580,7 +19580,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -19595,7 +19595,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -19632,7 +19632,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -19719,7 +19719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -19773,7 +19773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -19815,7 +19815,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -19851,7 +19851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -19885,7 +19885,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -19917,7 +19917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -19955,7 +19955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -20048,7 +20048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -20086,7 +20086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -20311,7 +20311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -20342,7 +20342,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -20435,7 +20435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -20481,7 +20481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -20637,7 +20637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -20659,7 +20659,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -20690,7 +20690,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -20793,7 +20793,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -20812,7 +20812,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -20853,7 +20853,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -20952,7 +20952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -20978,7 +20978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -21004,7 +21004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -21042,7 +21042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -21080,7 +21080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -21096,7 +21096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -21113,7 +21113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -21129,7 +21129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -21146,7 +21146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -21204,7 +21204,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -21246,7 +21246,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -21294,7 +21294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -21328,7 +21328,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -21372,7 +21372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -21410,7 +21410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -21503,7 +21503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -21541,7 +21541,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -21766,7 +21766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -21797,7 +21797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -21865,7 +21865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -21899,7 +21899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
 rules:
 - apiGroups:
@@ -21921,7 +21921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -21953,7 +21953,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21975,7 +21975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21997,7 +21997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -22019,7 +22019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -22072,7 +22072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -22120,7 +22120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -22166,7 +22166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -22322,7 +22322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -22344,7 +22344,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -22375,7 +22375,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -22478,7 +22478,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -22512,7 +22512,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -22553,7 +22553,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -22652,7 +22652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -22678,7 +22678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -22704,7 +22704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -22742,7 +22742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -22780,7 +22780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -22796,7 +22796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -22813,7 +22813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -22829,7 +22829,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -22873,7 +22873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -22915,7 +22915,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -22963,7 +22963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -22997,7 +22997,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -23041,7 +23041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -23079,7 +23079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -23172,7 +23172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -23210,7 +23210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -23435,7 +23435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -23466,7 +23466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -23559,7 +23559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -23605,7 +23605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -23761,7 +23761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -23783,7 +23783,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -23814,7 +23814,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -23920,7 +23920,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -23939,7 +23939,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -23980,7 +23980,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -24079,7 +24079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -24105,7 +24105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -24131,7 +24131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -24169,7 +24169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -24207,7 +24207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -24223,7 +24223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -24240,7 +24240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -24256,7 +24256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -24300,7 +24300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -24342,7 +24342,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -24390,7 +24390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -24424,7 +24424,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -24468,7 +24468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -24506,7 +24506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -24599,7 +24599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -24637,7 +24637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -24862,7 +24862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -24893,7 +24893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -24986,7 +24986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -25032,7 +25032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -25188,7 +25188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -25210,7 +25210,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -25241,7 +25241,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -25344,7 +25344,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -25363,7 +25363,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -25404,7 +25404,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -25503,7 +25503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -25529,7 +25529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -25555,7 +25555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -25595,7 +25595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -25635,7 +25635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -25651,7 +25651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -25668,7 +25668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -25684,7 +25684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -25728,7 +25728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -25770,7 +25770,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -25818,7 +25818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -25852,7 +25852,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -25896,7 +25896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -25973,7 +25973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -26066,7 +26066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -26104,7 +26104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -26339,7 +26339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -26370,7 +26370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -26463,7 +26463,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -26509,7 +26509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -26681,7 +26681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -26703,7 +26703,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -26734,7 +26734,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -26839,7 +26839,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -26858,7 +26858,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -26915,7 +26915,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -27017,7 +27017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -27043,7 +27043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -27069,7 +27069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -27107,7 +27107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -27145,7 +27145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -27161,7 +27161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -27178,7 +27178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -27194,7 +27194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -27238,7 +27238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -27302,7 +27302,7 @@ spec:
           value: ${AWS_REGION}
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -27350,7 +27350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -27384,7 +27384,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -27428,7 +27428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -27505,7 +27505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -27598,7 +27598,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -27636,7 +27636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -27872,7 +27872,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -27903,7 +27903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -27996,7 +27996,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -28042,7 +28042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -28214,7 +28214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -28236,7 +28236,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -28267,7 +28267,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -28372,7 +28372,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -28391,7 +28391,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -28448,7 +28448,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -28550,7 +28550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -28576,7 +28576,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -28602,7 +28602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -28640,7 +28640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -28678,7 +28678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -28694,7 +28694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -28711,7 +28711,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -28727,7 +28727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -28771,7 +28771,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -28837,7 +28837,7 @@ spec:
           value: US-WEST1
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -28885,7 +28885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -28919,7 +28919,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -28963,7 +28963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -29040,7 +29040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -29133,7 +29133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -29171,7 +29171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -29405,7 +29405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -29436,7 +29436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -29529,7 +29529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -29575,7 +29575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -29747,7 +29747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -29769,7 +29769,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -29800,7 +29800,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -29905,7 +29905,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -29924,7 +29924,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -29981,7 +29981,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -30084,7 +30084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -30110,7 +30110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -30136,7 +30136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -30174,7 +30174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -30212,7 +30212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -30228,7 +30228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -30245,7 +30245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -30261,7 +30261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -30305,7 +30305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -30367,7 +30367,7 @@ spec:
           value: "true"
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -30415,7 +30415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -30449,7 +30449,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -30493,7 +30493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -30531,7 +30531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -30624,7 +30624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -30662,7 +30662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -30896,7 +30896,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -30927,7 +30927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -31020,7 +31020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -31066,7 +31066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -31222,7 +31222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -31244,7 +31244,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -31275,7 +31275,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -31380,7 +31380,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -31399,7 +31399,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -31456,7 +31456,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -31559,7 +31559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -31585,7 +31585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -31611,7 +31611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -31649,7 +31649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -31687,7 +31687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -31703,7 +31703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -31720,7 +31720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -31736,7 +31736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -31780,7 +31780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -31840,7 +31840,7 @@ spec:
           value: "true"
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -31888,7 +31888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -31922,7 +31922,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -31966,7 +31966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -32043,7 +32043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -32136,7 +32136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -32174,7 +32174,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -32409,7 +32409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -32440,7 +32440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -32533,7 +32533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -32579,7 +32579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -32751,7 +32751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -32773,7 +32773,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -32804,7 +32804,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -32909,7 +32909,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -32928,7 +32928,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -32985,7 +32985,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -33099,7 +33099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -33125,7 +33125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -33151,7 +33151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -33189,7 +33189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -33227,7 +33227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -33243,7 +33243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -33260,7 +33260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -33276,7 +33276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -33320,7 +33320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -33384,7 +33384,7 @@ spec:
           value: ${AWS_REGION}
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -33432,7 +33432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -33466,7 +33466,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -33510,7 +33510,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -33587,7 +33587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -33680,7 +33680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -33718,7 +33718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -33954,7 +33954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -33985,7 +33985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -34078,7 +34078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -34124,7 +34124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -34296,7 +34296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -34318,7 +34318,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -34349,7 +34349,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -34454,7 +34454,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -34473,7 +34473,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -34530,7 +34530,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -34644,7 +34644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -34670,7 +34670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -34696,7 +34696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -34734,7 +34734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -34772,7 +34772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -34788,7 +34788,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -34805,7 +34805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -34821,7 +34821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -34865,7 +34865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -34931,7 +34931,7 @@ spec:
           value: US-WEST1
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -34979,7 +34979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -35013,7 +35013,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -35057,7 +35057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -35134,7 +35134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -35227,7 +35227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -35265,7 +35265,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -35499,7 +35499,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -35530,7 +35530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -35623,7 +35623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -35669,7 +35669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -35841,7 +35841,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -35863,7 +35863,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -35894,7 +35894,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -35999,7 +35999,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -36018,7 +36018,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -36075,7 +36075,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -36191,7 +36191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -36217,7 +36217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -36243,7 +36243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -36281,7 +36281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -36319,7 +36319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -36335,7 +36335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -36352,7 +36352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -36368,7 +36368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -36412,7 +36412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -36474,7 +36474,7 @@ spec:
           value: "true"
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -36522,7 +36522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -36556,7 +36556,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -36600,7 +36600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -36638,7 +36638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -36731,7 +36731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -36769,7 +36769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -37003,7 +37003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -37034,7 +37034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -37127,7 +37127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -37173,7 +37173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -37329,7 +37329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -37351,7 +37351,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -37382,7 +37382,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -37487,7 +37487,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -37506,7 +37506,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -37563,7 +37563,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -37679,7 +37679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -37705,7 +37705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -37731,7 +37731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -37769,7 +37769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -37807,7 +37807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -37823,7 +37823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -37840,7 +37840,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -37856,7 +37856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -37900,7 +37900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -37960,7 +37960,7 @@ spec:
           value: "true"
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -38008,7 +38008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -38042,7 +38042,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -38086,7 +38086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -38163,7 +38163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -38256,7 +38256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -38294,7 +38294,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -38529,7 +38529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -38560,7 +38560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -38653,7 +38653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -38699,7 +38699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -38871,7 +38871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -38893,7 +38893,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -38924,7 +38924,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -39029,7 +39029,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -39048,7 +39048,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -39105,7 +39105,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -39219,7 +39219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -39245,7 +39245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -39271,7 +39271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -39309,7 +39309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -39347,7 +39347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -39363,7 +39363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -39380,7 +39380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -39396,7 +39396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -39440,7 +39440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -39504,7 +39504,7 @@ spec:
           value: ${AWS_REGION}
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -39552,7 +39552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -39586,7 +39586,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -39630,7 +39630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -39707,7 +39707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -39800,7 +39800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -39838,7 +39838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -40074,7 +40074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -40105,7 +40105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -40198,7 +40198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -40244,7 +40244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -40416,7 +40416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -40438,7 +40438,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -40469,7 +40469,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -40574,7 +40574,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -40593,7 +40593,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -40650,7 +40650,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -40764,7 +40764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -40790,7 +40790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -40816,7 +40816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -40854,7 +40854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -40892,7 +40892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -40908,7 +40908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -40925,7 +40925,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -40941,7 +40941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -40985,7 +40985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -41051,7 +41051,7 @@ spec:
           value: US-WEST1
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -41099,7 +41099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -41133,7 +41133,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -41177,7 +41177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -41254,7 +41254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -41347,7 +41347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -41385,7 +41385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -41619,7 +41619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -41650,7 +41650,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -41743,7 +41743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -41789,7 +41789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -41961,7 +41961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -41983,7 +41983,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -42014,7 +42014,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -42119,7 +42119,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -42138,7 +42138,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -42195,7 +42195,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -42311,7 +42311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -42337,7 +42337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -42363,7 +42363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -42401,7 +42401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -42439,7 +42439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -42455,7 +42455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -42472,7 +42472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -42488,7 +42488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -42532,7 +42532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -42594,7 +42594,7 @@ spec:
           value: "true"
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -42642,7 +42642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -42676,7 +42676,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -42720,7 +42720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -42758,7 +42758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -42851,7 +42851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -42889,7 +42889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -43123,7 +43123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -43154,7 +43154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -43247,7 +43247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -43293,7 +43293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -43449,7 +43449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -43471,7 +43471,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -43502,7 +43502,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -43607,7 +43607,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -43626,7 +43626,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -43683,7 +43683,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -43799,7 +43799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -43825,7 +43825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -43851,7 +43851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -43889,7 +43889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -43927,7 +43927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -43943,7 +43943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -43960,7 +43960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -43976,7 +43976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -44020,7 +44020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -44080,7 +44080,7 @@ spec:
           value: "true"
         - name: RPK_CLOUD_STORAGE_SEGMENT_MAX_UPLOAD_INTERVAL_SEC
           value: "1"
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -44128,7 +44128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -44162,7 +44162,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -44206,7 +44206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -44244,7 +44244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -44337,7 +44337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -44375,7 +44375,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -44600,7 +44600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -44631,7 +44631,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -44724,7 +44724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -44770,7 +44770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -44926,7 +44926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -44948,7 +44948,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -44979,7 +44979,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -45082,7 +45082,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -45101,7 +45101,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -45142,7 +45142,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -45241,7 +45241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -45267,7 +45267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -45293,7 +45293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -45331,7 +45331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -45369,7 +45369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -45385,7 +45385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -45402,7 +45402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -45418,7 +45418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -45462,7 +45462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -45504,7 +45504,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -45552,7 +45552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -45586,7 +45586,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -45630,7 +45630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -45668,7 +45668,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -45761,7 +45761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -45799,7 +45799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -46024,7 +46024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -46055,7 +46055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -46148,7 +46148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -46194,7 +46194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -46350,7 +46350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -46373,7 +46373,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -46404,7 +46404,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -46507,7 +46507,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -46526,7 +46526,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -46567,7 +46567,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -46666,7 +46666,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -46692,7 +46692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -46718,7 +46718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -46756,7 +46756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -46794,7 +46794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -46810,7 +46810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -46827,7 +46827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -46843,7 +46843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -46887,7 +46887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -46929,7 +46929,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -46977,7 +46977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -47011,7 +47011,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -47055,7 +47055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -47093,7 +47093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -47186,7 +47186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -47224,7 +47224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -47449,7 +47449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -47480,7 +47480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -47573,7 +47573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -47619,7 +47619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -47775,7 +47775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -47797,7 +47797,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -47832,7 +47832,7 @@ spec:
           value: THIS_IS_AN_EXAMPLE
         - name: POD_IP
           value: This is an override and will break the deployment
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -47937,7 +47937,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -47956,7 +47956,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -47997,7 +47997,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -48096,7 +48096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -48122,7 +48122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -48148,7 +48148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -48186,7 +48186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -48224,7 +48224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -48240,7 +48240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -48257,7 +48257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -48273,7 +48273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -48317,7 +48317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -48359,7 +48359,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -48407,7 +48407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -48441,7 +48441,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -48485,7 +48485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -48523,7 +48523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -48616,7 +48616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -48654,7 +48654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -48937,7 +48937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -48969,7 +48969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -49064,7 +49064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -49110,7 +49110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -49277,7 +49277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -49299,7 +49299,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -49330,7 +49330,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -49441,7 +49441,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -49460,7 +49460,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -49501,7 +49501,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -49600,7 +49600,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -49626,7 +49626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -49652,7 +49652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -49690,7 +49690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -49728,7 +49728,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -49744,7 +49744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -49761,7 +49761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -49777,7 +49777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -49821,7 +49821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -49863,7 +49863,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -49911,7 +49911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -49945,7 +49945,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -49989,7 +49989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -50030,7 +50030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -50123,7 +50123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -50161,7 +50161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -50386,7 +50386,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -50417,7 +50417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -50510,7 +50510,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -50559,7 +50559,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -50718,7 +50718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -50743,7 +50743,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -50780,7 +50780,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -50883,7 +50883,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -50902,7 +50902,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -50943,7 +50943,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -51045,7 +51045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -51071,7 +51071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -51097,7 +51097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -51135,7 +51135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -51173,7 +51173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -51189,7 +51189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -51206,7 +51206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -51222,7 +51222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -51266,7 +51266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -51308,7 +51308,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -51356,7 +51356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -51390,7 +51390,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -51434,7 +51434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -51472,7 +51472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -51565,7 +51565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -51603,7 +51603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -51828,7 +51828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -51859,7 +51859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -51927,7 +51927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -51961,7 +51961,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
 rules:
 - apiGroups:
@@ -51983,7 +51983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -52015,7 +52015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52037,7 +52037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52059,7 +52059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -52081,7 +52081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -52134,7 +52134,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -52182,7 +52182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -52228,7 +52228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -52384,7 +52384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -52406,7 +52406,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -52437,7 +52437,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -52540,7 +52540,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext:
@@ -52586,7 +52586,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -52627,7 +52627,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -52726,7 +52726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -52752,7 +52752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -52778,7 +52778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -52816,7 +52816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -52854,7 +52854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -52870,7 +52870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -52887,7 +52887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -52903,7 +52903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -52947,7 +52947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -52989,7 +52989,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -53037,7 +53037,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -53071,7 +53071,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 2222
@@ -53115,7 +53115,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -53153,7 +53153,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -53246,7 +53246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -53284,7 +53284,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -53344,7 +53344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -53564,7 +53564,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -53595,7 +53595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -53663,7 +53663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -53697,7 +53697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -53719,7 +53719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -53772,7 +53772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -53820,7 +53820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -53866,7 +53866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -54022,7 +54022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -54044,7 +54044,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -54075,7 +54075,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -54178,7 +54178,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -54197,7 +54197,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -54234,7 +54234,7 @@ spec:
           xfs & wait $!
         command:
         - /bin/sh
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: fs-validator
         resources: {}
         securityContext:
@@ -54275,7 +54275,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -54378,7 +54378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -54404,7 +54404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -54430,7 +54430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -54468,7 +54468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -54506,7 +54506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -54522,7 +54522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -54539,7 +54539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -54555,7 +54555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -54599,7 +54599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -54641,7 +54641,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -54689,7 +54689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -54723,7 +54723,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -54767,7 +54767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -54805,7 +54805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -54898,7 +54898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -54936,7 +54936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -55161,7 +55161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -55192,7 +55192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -55276,7 +55276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: redpanda-connectors
 spec:
   ipFamilies:
@@ -55334,7 +55334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -55380,7 +55380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -55424,7 +55424,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: connectors
-    helm.sh/chart: connectors-0.1.12
+    helm.sh/chart: connectors-0.1.13
   name: redpanda-connectors
 spec:
   progressDeadlineSeconds: 600
@@ -55499,7 +55499,7 @@ spec:
         - name: CONNECT_TLS_ENABLED
           value: "false"
         envFrom: []
-        image: docker.redpanda.com/redpandadata/connectors:v1.0.29
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
         imagePullPolicy: IfNotPresent
         livenessProbe:
           failureThreshold: 3
@@ -55692,7 +55692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -55714,7 +55714,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -55745,7 +55745,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -55848,7 +55848,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -55867,7 +55867,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -55908,7 +55908,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -56007,7 +56007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -56033,7 +56033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -56059,7 +56059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -56097,7 +56097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -56135,7 +56135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -56151,7 +56151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -56168,7 +56168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -56184,7 +56184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -56228,7 +56228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -56270,7 +56270,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -56318,7 +56318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -56352,7 +56352,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -56396,7 +56396,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -56434,7 +56434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -56527,7 +56527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -56565,7 +56565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -56790,7 +56790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -56821,7 +56821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -56914,7 +56914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -56960,7 +56960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -57116,7 +57116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -57138,7 +57138,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -57169,7 +57169,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -57272,7 +57272,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -57291,7 +57291,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -57332,7 +57332,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -57431,7 +57431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -57457,7 +57457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -57483,7 +57483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -57523,7 +57523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -57563,7 +57563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -57579,7 +57579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -57596,7 +57596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -57612,7 +57612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -57656,7 +57656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -57698,7 +57698,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -57746,7 +57746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -57780,7 +57780,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -57824,7 +57824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -57863,7 +57863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -57956,7 +57956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -57994,7 +57994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -58219,7 +58219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -58250,7 +58250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -58344,7 +58344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -58391,7 +58391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: change-name-external
   namespace: default
 spec:
@@ -58548,7 +58548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -58571,7 +58571,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
         test: test
     spec:
@@ -58604,7 +58604,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -58707,7 +58707,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -58726,7 +58726,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -58767,7 +58767,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -58867,7 +58867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -58893,7 +58893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -58919,7 +58919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -58957,7 +58957,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -58995,7 +58995,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -59011,7 +59011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -59028,7 +59028,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -59044,7 +59044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -59061,7 +59061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -59119,7 +59119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -59161,7 +59161,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -59209,7 +59209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -59243,7 +59243,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -59287,7 +59287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -59325,7 +59325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -59418,7 +59418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -59456,7 +59456,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -59681,7 +59681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -59712,7 +59712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -59805,7 +59805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -59851,7 +59851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -60007,7 +60007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -60029,7 +60029,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -60069,7 +60069,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -60172,7 +60172,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -60191,7 +60191,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -60232,7 +60232,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -60337,7 +60337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -60363,7 +60363,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -60389,7 +60389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -60427,7 +60427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -60465,7 +60465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -60481,7 +60481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -60498,7 +60498,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -60514,7 +60514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -60558,7 +60558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -60609,7 +60609,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources:
           limits:
@@ -60667,7 +60667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -60710,7 +60710,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 1000
@@ -60760,7 +60760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -60798,7 +60798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -60891,7 +60891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -60929,7 +60929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -61154,7 +61154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -61185,7 +61185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -61278,7 +61278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -61324,7 +61324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -61480,7 +61480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -61502,7 +61502,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -61542,7 +61542,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -61645,7 +61645,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -61664,7 +61664,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -61705,7 +61705,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -61810,7 +61810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -61836,7 +61836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -61862,7 +61862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -61900,7 +61900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -61938,7 +61938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -61954,7 +61954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -61971,7 +61971,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -61987,7 +61987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -62031,7 +62031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -62082,7 +62082,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources:
           limits:
@@ -62142,7 +62142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -62185,7 +62185,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 1000
@@ -62235,7 +62235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -62273,7 +62273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -62366,7 +62366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -62404,7 +62404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -62629,7 +62629,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -62660,7 +62660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -62753,7 +62753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -62799,7 +62799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -62955,7 +62955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -62977,7 +62977,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -63008,7 +63008,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -63111,7 +63111,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -63132,7 +63132,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -63173,7 +63173,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -63272,7 +63272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -63298,7 +63298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -63324,7 +63324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -63362,7 +63362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -63400,7 +63400,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -63416,7 +63416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -63433,7 +63433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -63449,7 +63449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -63493,7 +63493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -63535,7 +63535,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -63585,7 +63585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -63619,7 +63619,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -63665,7 +63665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -63687,7 +63687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -63780,7 +63780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -63818,7 +63818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -64025,7 +64025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -64057,7 +64057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -64072,7 +64072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -64118,7 +64118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -64162,7 +64162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -64184,7 +64184,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -64486,7 +64486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -64512,7 +64512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -64538,7 +64538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -64564,7 +64564,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -64602,7 +64602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -64640,7 +64640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -64678,7 +64678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -64703,7 +64703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -64719,7 +64719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -64736,7 +64736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -64752,7 +64752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -64769,7 +64769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -64785,7 +64785,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -64806,7 +64806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -64902,7 +64902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -64986,7 +64986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -65024,7 +65024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -65117,7 +65117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -65155,7 +65155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -65380,7 +65380,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -65411,7 +65411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -65504,7 +65504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -65550,7 +65550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -65706,7 +65706,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -65728,7 +65728,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -65759,7 +65759,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -65862,7 +65862,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -65881,7 +65881,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -65922,7 +65922,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -66021,7 +66021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -66047,7 +66047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -66073,7 +66073,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -66099,7 +66099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -66125,7 +66125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -66142,7 +66142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -66186,7 +66186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -66228,7 +66228,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -66276,7 +66276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -66310,7 +66310,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -66354,7 +66354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -66431,7 +66431,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -66528,7 +66528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-users
   namespace: default
 stringData:
@@ -66545,7 +66545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -66682,7 +66682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -66742,7 +66742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -66946,7 +66946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -66977,7 +66977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -67070,7 +67070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -67116,7 +67116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -67303,7 +67303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -67325,7 +67325,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -67367,7 +67367,7 @@ spec:
           value: SCRAM-SHA-256
         - name: RP_BOOTSTRAP_USER
           value: $(RPK_USER):$(RPK_PASS):$(RPK_SASL_MECHANISM)
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -67482,7 +67482,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -67504,7 +67504,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -67557,7 +67557,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -67662,7 +67662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -67688,7 +67688,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -67714,7 +67714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -67752,7 +67752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -67790,7 +67790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -67806,7 +67806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -67823,7 +67823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -67839,7 +67839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -67883,7 +67883,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -67936,7 +67936,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -67990,7 +67990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -68033,7 +68033,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -68083,7 +68083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -68160,7 +68160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -68253,7 +68253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -68291,7 +68291,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -68516,7 +68516,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -68547,7 +68547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -68640,7 +68640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -68686,7 +68686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -68858,7 +68858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -68880,7 +68880,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -68911,7 +68911,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -69014,7 +69014,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -69033,7 +69033,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -69074,7 +69074,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -69173,7 +69173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -69199,7 +69199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -69225,7 +69225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -69263,7 +69263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -69301,7 +69301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -69317,7 +69317,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -69334,7 +69334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -69350,7 +69350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -69394,7 +69394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -69438,7 +69438,7 @@ spec:
         env:
         - name: REDPANDA_LICENSE
           value: ${REDPANDA_LICENSE}
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -69486,7 +69486,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -69520,7 +69520,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -69564,7 +69564,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -69602,7 +69602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -69695,7 +69695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -69733,7 +69733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -69958,7 +69958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -69989,7 +69989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -70082,7 +70082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -70128,7 +70128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -70289,7 +70289,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -70311,7 +70311,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -70342,7 +70342,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -70445,7 +70445,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -70464,7 +70464,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -70505,7 +70505,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -70604,7 +70604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -70630,7 +70630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -70656,7 +70656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -70694,7 +70694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -70732,7 +70732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -70748,7 +70748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -70765,7 +70765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -70781,7 +70781,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -70825,7 +70825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -70872,7 +70872,7 @@ spec:
             secretKeyRef:
               key: license-key
               name: redpanda-license
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -70920,7 +70920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -70954,7 +70954,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -72487,7 +72487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -72525,7 +72525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -72618,7 +72618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -72656,7 +72656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -72881,7 +72881,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -72912,7 +72912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -73005,7 +73005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -73051,7 +73051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -73207,7 +73207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -73229,7 +73229,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -73260,7 +73260,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -73364,7 +73364,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -73383,7 +73383,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -73424,7 +73424,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -73523,7 +73523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -73549,7 +73549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -73575,7 +73575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -73613,7 +73613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -73651,7 +73651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -73667,7 +73667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -73684,7 +73684,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -73700,7 +73700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -73744,7 +73744,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -73786,7 +73786,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -73835,7 +73835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -73869,7 +73869,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           allowPrivilegeEscalation: false
@@ -73914,7 +73914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -73952,7 +73952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -74045,7 +74045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -74083,7 +74083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -74308,7 +74308,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -74339,7 +74339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -74432,7 +74432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -74478,7 +74478,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -74634,7 +74634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -74656,7 +74656,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -74687,7 +74687,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -74791,7 +74791,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -74810,7 +74810,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -74851,7 +74851,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -74950,7 +74950,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -74976,7 +74976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -75002,7 +75002,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -75040,7 +75040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -75078,7 +75078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -75094,7 +75094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -75111,7 +75111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -75127,7 +75127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -75171,7 +75171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -75213,7 +75213,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -75262,7 +75262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -75296,7 +75296,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           allowPrivilegeEscalation: false
@@ -75341,7 +75341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -75379,7 +75379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -75472,7 +75472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -75510,7 +75510,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -75735,7 +75735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -75766,7 +75766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -75859,7 +75859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -75905,7 +75905,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -76061,7 +76061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -76083,7 +76083,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -76114,7 +76114,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -76217,7 +76217,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -76236,7 +76236,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -76277,7 +76277,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -76376,7 +76376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -76402,7 +76402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -76428,7 +76428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -76466,7 +76466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -76504,7 +76504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -76520,7 +76520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -76537,7 +76537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -76553,7 +76553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -76597,7 +76597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -76639,7 +76639,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -76687,7 +76687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -76721,7 +76721,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -76765,7 +76765,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -76803,7 +76803,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -76900,7 +76900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-users
   namespace: default
 stringData:
@@ -76920,7 +76920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -77057,7 +77057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -77117,7 +77117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -77310,7 +77310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -77341,7 +77341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -77434,7 +77434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -77480,7 +77480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -77651,7 +77651,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -77673,7 +77673,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -77715,7 +77715,7 @@ spec:
           value: SCRAM-SHA-256
         - name: RP_BOOTSTRAP_USER
           value: $(RPK_USER):$(RPK_PASS):$(RPK_SASL_MECHANISM)
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -77830,7 +77830,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -77852,7 +77852,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -77905,7 +77905,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -78010,7 +78010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -78036,7 +78036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -78062,7 +78062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -78100,7 +78100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -78138,7 +78138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -78154,7 +78154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -78171,7 +78171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -78187,7 +78187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -78231,7 +78231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -78282,7 +78282,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -78336,7 +78336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -78379,7 +78379,7 @@ spec:
           value: kubernetes-controller
         - name: RPK_SASL_MECHANISM
           value: SCRAM-SHA-256
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -78453,7 +78453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -78491,7 +78491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -78584,7 +78584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -78622,7 +78622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -78847,7 +78847,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -78878,7 +78878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -78971,7 +78971,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -79017,7 +79017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -79173,7 +79173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -79195,7 +79195,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -79488,7 +79488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -79514,7 +79514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -79540,7 +79540,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -79578,7 +79578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -79616,7 +79616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -79632,7 +79632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -79649,7 +79649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -79665,7 +79665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -79709,7 +79709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -79799,7 +79799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -79870,7 +79870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -79947,7 +79947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -80040,7 +80040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -80078,7 +80078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -80302,7 +80302,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -80333,7 +80333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -80426,7 +80426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -80472,7 +80472,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -80644,7 +80644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -80666,7 +80666,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -80959,7 +80959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -80985,7 +80985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -81011,7 +81011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -81049,7 +81049,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -81087,7 +81087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -81103,7 +81103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -81120,7 +81120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -81136,7 +81136,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -81180,7 +81180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -81272,7 +81272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -81343,7 +81343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -81381,7 +81381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -81474,7 +81474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -81512,7 +81512,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -81742,7 +81742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -81773,7 +81773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -81866,7 +81866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -81912,7 +81912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -82068,7 +82068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -82090,7 +82090,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -82383,7 +82383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -82409,7 +82409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -82435,7 +82435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -82473,7 +82473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -82511,7 +82511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -82527,7 +82527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -82544,7 +82544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -82560,7 +82560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -82604,7 +82604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -82694,7 +82694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -82777,7 +82777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -82815,7 +82815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -82908,7 +82908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -82946,7 +82946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -83171,7 +83171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -83202,7 +83202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -83295,7 +83295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -83341,7 +83341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -83497,7 +83497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -83519,7 +83519,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -83812,7 +83812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -83838,7 +83838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -83864,7 +83864,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -83902,7 +83902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -83940,7 +83940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -83956,7 +83956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -83973,7 +83973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -83989,7 +83989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -84033,7 +84033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -84123,7 +84123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -84194,7 +84194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -84271,7 +84271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -84364,7 +84364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -84402,7 +84402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -84626,7 +84626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -84657,7 +84657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -84750,7 +84750,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -84796,7 +84796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -84968,7 +84968,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -84990,7 +84990,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -85283,7 +85283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -85309,7 +85309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -85335,7 +85335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -85373,7 +85373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -85411,7 +85411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -85427,7 +85427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -85444,7 +85444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -85460,7 +85460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -85504,7 +85504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -85596,7 +85596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -85667,7 +85667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -85705,7 +85705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -85798,7 +85798,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -85836,7 +85836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -86066,7 +86066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -86097,7 +86097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -86190,7 +86190,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -86236,7 +86236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -86392,7 +86392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -86414,7 +86414,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -86707,7 +86707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -86733,7 +86733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -86759,7 +86759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -86797,7 +86797,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -86835,7 +86835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -86851,7 +86851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -86868,7 +86868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -86884,7 +86884,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -86928,7 +86928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -87018,7 +87018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -87089,7 +87089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -87127,7 +87127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -87220,7 +87220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -87258,7 +87258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -87483,7 +87483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -87514,7 +87514,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -87607,7 +87607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -87653,7 +87653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -87809,7 +87809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -87831,7 +87831,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -88124,7 +88124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -88150,7 +88150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -88176,7 +88176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -88214,7 +88214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -88252,7 +88252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -88268,7 +88268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -88285,7 +88285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -88301,7 +88301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -88345,7 +88345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -88435,7 +88435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -88506,7 +88506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -88583,7 +88583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -88676,7 +88676,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -88714,7 +88714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -88938,7 +88938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -88969,7 +88969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -89062,7 +89062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -89108,7 +89108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -89280,7 +89280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -89302,7 +89302,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -89595,7 +89595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -89621,7 +89621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -89647,7 +89647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -89685,7 +89685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -89723,7 +89723,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -89739,7 +89739,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -89756,7 +89756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -89772,7 +89772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -89816,7 +89816,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -89908,7 +89908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -89979,7 +89979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -90017,7 +90017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -90110,7 +90110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -90148,7 +90148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -90378,7 +90378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -90409,7 +90409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -90502,7 +90502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -90548,7 +90548,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -90704,7 +90704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -90726,7 +90726,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -91019,7 +91019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -91045,7 +91045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -91071,7 +91071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -91109,7 +91109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -91147,7 +91147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -91163,7 +91163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -91180,7 +91180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -91196,7 +91196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -91240,7 +91240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -91330,7 +91330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -91401,7 +91401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -91439,7 +91439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -91532,7 +91532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -91570,7 +91570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -91795,7 +91795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -91826,7 +91826,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -91919,7 +91919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -91965,7 +91965,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -92121,7 +92121,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -92143,7 +92143,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -92436,7 +92436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -92462,7 +92462,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -92488,7 +92488,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -92526,7 +92526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -92564,7 +92564,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -92580,7 +92580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -92597,7 +92597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -92613,7 +92613,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -92657,7 +92657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -92747,7 +92747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -92825,7 +92825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -92902,7 +92902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -92995,7 +92995,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -93033,7 +93033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -93257,7 +93257,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -93288,7 +93288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -93381,7 +93381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -93427,7 +93427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -93599,7 +93599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -93621,7 +93621,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -93914,7 +93914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -93940,7 +93940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -93966,7 +93966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -94004,7 +94004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -94042,7 +94042,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -94058,7 +94058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -94075,7 +94075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -94091,7 +94091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -94135,7 +94135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -94227,7 +94227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -94305,7 +94305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -94343,7 +94343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -94436,7 +94436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -94474,7 +94474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -94704,7 +94704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -94735,7 +94735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -94828,7 +94828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -94874,7 +94874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -95030,7 +95030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -95052,7 +95052,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -95345,7 +95345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -95371,7 +95371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -95397,7 +95397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -95435,7 +95435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -95473,7 +95473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -95489,7 +95489,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -95506,7 +95506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -95522,7 +95522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -95566,7 +95566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -95656,7 +95656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -95734,7 +95734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -95772,7 +95772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -95865,7 +95865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -95903,7 +95903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -96129,7 +96129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -96160,7 +96160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -96253,7 +96253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -96299,7 +96299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -96455,7 +96455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -96477,7 +96477,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -96770,7 +96770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -96796,7 +96796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -96822,7 +96822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -96860,7 +96860,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -96898,7 +96898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -96914,7 +96914,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -96931,7 +96931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -96947,7 +96947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -96991,7 +96991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -97081,7 +97081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -97159,7 +97159,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -97236,7 +97236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -97329,7 +97329,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -97367,7 +97367,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -97592,7 +97592,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -97623,7 +97623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -97716,7 +97716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -97762,7 +97762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -97934,7 +97934,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -97956,7 +97956,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -98249,7 +98249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -98275,7 +98275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -98301,7 +98301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -98339,7 +98339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -98377,7 +98377,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -98393,7 +98393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -98410,7 +98410,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -98426,7 +98426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -98470,7 +98470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -98562,7 +98562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -98640,7 +98640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -98678,7 +98678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -98771,7 +98771,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -98809,7 +98809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -99040,7 +99040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -99071,7 +99071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -99164,7 +99164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -99210,7 +99210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -99366,7 +99366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -99388,7 +99388,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -99681,7 +99681,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -99707,7 +99707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -99733,7 +99733,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -99771,7 +99771,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -99809,7 +99809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -99825,7 +99825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -99842,7 +99842,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -99858,7 +99858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -99902,7 +99902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -99992,7 +99992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -100070,7 +100070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -100108,7 +100108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -100201,7 +100201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -100239,7 +100239,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -100465,7 +100465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -100496,7 +100496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -100589,7 +100589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -100635,7 +100635,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -100791,7 +100791,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -100813,7 +100813,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -101106,7 +101106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -101132,7 +101132,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -101158,7 +101158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -101196,7 +101196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -101234,7 +101234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -101250,7 +101250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -101267,7 +101267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -101283,7 +101283,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -101327,7 +101327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -101417,7 +101417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -101495,7 +101495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -101572,7 +101572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -101665,7 +101665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -101703,7 +101703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -101928,7 +101928,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -101959,7 +101959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -102052,7 +102052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -102098,7 +102098,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -102270,7 +102270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -102292,7 +102292,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -102585,7 +102585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -102611,7 +102611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -102637,7 +102637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -102675,7 +102675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -102713,7 +102713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -102729,7 +102729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -102746,7 +102746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -102762,7 +102762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -102806,7 +102806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -102898,7 +102898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -102976,7 +102976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -103014,7 +103014,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -103107,7 +103107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -103145,7 +103145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -103376,7 +103376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -103407,7 +103407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -103500,7 +103500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -103546,7 +103546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -103702,7 +103702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -103724,7 +103724,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -104017,7 +104017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -104043,7 +104043,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -104069,7 +104069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -104107,7 +104107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -104145,7 +104145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -104161,7 +104161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -104178,7 +104178,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -104194,7 +104194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -104238,7 +104238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -104328,7 +104328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -104406,7 +104406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -104444,7 +104444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -104537,7 +104537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -104575,7 +104575,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -104800,7 +104800,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -104831,7 +104831,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -104924,7 +104924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -104970,7 +104970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -105126,7 +105126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -105148,7 +105148,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -105179,7 +105179,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -105282,7 +105282,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -105301,7 +105301,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -105342,7 +105342,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -105468,7 +105468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -105510,7 +105510,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -105558,7 +105558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -105592,7 +105592,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -105636,7 +105636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -105674,7 +105674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -105767,7 +105767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -105805,7 +105805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -106030,7 +106030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -106061,7 +106061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -106154,7 +106154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -106200,7 +106200,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -106338,7 +106338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -106360,7 +106360,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -106391,7 +106391,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -106494,7 +106494,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -106513,7 +106513,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -106554,7 +106554,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -106680,7 +106680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -106722,7 +106722,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -106770,7 +106770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -106804,7 +106804,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -106836,7 +106836,7 @@ spec:
         secret:
           defaultMode: 288
           secretName: some-secret
--- testdata/TestTemplate/internal-trust-stores.yaml.golden --
+-- testdata/TestTemplate/enable-connectors.yaml.golden --
 ---
 # Source: redpanda/templates/poddisruptionbudget.yaml
 apiVersion: policy/v1
@@ -106848,7 +106848,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -106886,7 +106886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -106979,7 +106979,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -107017,7 +107017,1777 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-configurator
+  namespace: default
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+    cp /tmp/base-config/bootstrap.yaml /etc/redpanda/.bootstrap.yaml
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+type: Opaque
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
+    compacted_log_segment_size: 67108864
+    enable_rack_awareness: false
+    enable_sasl: false
+    kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    storage_min_free_bytes: 1073741824
+  redpanda.yaml: |-
+    config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      crash_loop_limit: 5
+      empty_seed_starts_cluster: false
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          ca_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          ca_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/configmap.yaml
+apiVersion: v1
+data:
+  profile: |-
+    admin_api:
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-rpk
+  namespace: default
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: v1
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect:
+      clusters:
+      - name: connectors
+        password: ""
+        tls:
+          caFilepath: ""
+          certFilepath: ""
+          enabled: false
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        token: ""
+        url: http://redpanda-connectors.default.svc.cluster.local:8083
+        username: ""
+      connectTimeout: 0
+      enabled: true
+      readTimeout: 0
+      requestTimeout: 0
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          caFilepath: /mnt/cert/schemaregistry/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        caFilepath: /mnt/cert/kafka/default/ca.crt
+        certFilepath: ""
+        enabled: true
+        insecureSkipTlsVerify: false
+        keyFilepath: ""
+    redpanda:
+      adminApi:
+        enabled: true
+        tls:
+          caFilepath: /mnt/cert/adminapi/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://redpanda.default.svc.cluster.local.:9644
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: redpanda-console
+---
+# Source: redpanda/charts/connectors/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: connectors
+    helm.sh/chart: connectors-0.1.13
+  name: redpanda-connectors
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: rest-api
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  - name: prometheus
+    port: 9404
+    protocol: TCP
+    targetPort: 9404
+  selector:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: connectors
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: redpanda/charts/console/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: redpanda-console
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
+  selector:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: console
+  type: ClusterIP
+---
+# Source: redpanda/templates/service.internal.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+    monitoring.redpanda.com/enabled: "false"
+  name: redpanda
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: null
+    name: admin
+    port: 9644
+    protocol: TCP
+    targetPort: 9644
+  - name: http
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  - name: kafka
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  - name: rpc
+    port: 33145
+    protocol: TCP
+    targetPort: 33145
+  - name: schemaregistry
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: redpanda-statefulset
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: redpanda
+  type: ClusterIP
+---
+# Source: redpanda/templates/service.nodeport.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-external
+  namespace: default
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: admin-default
+    nodePort: 31644
+    port: 9645
+    protocol: TCP
+    targetPort: 0
+  - name: kafka-default
+    nodePort: 31092
+    port: 9094
+    protocol: TCP
+    targetPort: 0
+  - name: http-default
+    nodePort: 30082
+    port: 8083
+    protocol: TCP
+    targetPort: 0
+  - name: schema-default
+    nodePort: 30081
+    port: 8084
+    protocol: TCP
+    targetPort: 0
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: redpanda-statefulset
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: redpanda
+  sessionAffinity: None
+  type: NodePort
+---
+# Source: redpanda/templates/connectors/connectors.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: connectors
+    helm.sh/chart: connectors-0.1.13
+  name: redpanda-connectors
+spec:
+  progressDeadlineSeconds: 600
+  replicas: null
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: connectors
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: connectors
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: connectors
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: connectors
+    spec:
+      affinity:
+        nodeAffinity: {}
+        podAffinity: {}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: connectors
+                app.kubernetes.io/instance: redpanda
+                app.kubernetes.io/name: connectors
+            namespaces:
+            - default
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command: null
+        env:
+        - name: CONNECT_CONFIGURATION
+          value: |-
+            rest.advertised.port=8083
+            rest.port=8083
+            key.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+            value.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+            group.id=connectors-cluster
+            offset.storage.topic=_internal_connectors_offsets
+            config.storage.topic=_internal_connectors_configs
+            status.storage.topic=_internal_connectors_status
+            offset.storage.redpanda.remote.read=false
+            offset.storage.redpanda.remote.write=false
+            config.storage.redpanda.remote.read=false
+            config.storage.redpanda.remote.write=false
+            status.storage.redpanda.remote.read=false
+            status.storage.redpanda.remote.write=false
+            offset.storage.replication.factor=-1
+            config.storage.replication.factor=-1
+            status.storage.replication.factor=-1
+            producer.linger.ms=1
+            producer.batch.size=131072
+            config.providers=file,secretsManager,env
+            config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
+            config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider
+        - name: CONNECT_ADDITIONAL_CONFIGURATION
+          value: ""
+        - name: CONNECT_BOOTSTRAP_SERVERS
+          value: redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093
+        - name: CONNECT_GC_LOG_ENABLED
+          value: "false"
+        - name: CONNECT_HEAP_OPTS
+          value: -Xms256M -Xmx2G
+        - name: CONNECT_LOG_LEVEL
+          value: warn
+        - name: CONNECT_TLS_ENABLED
+          value: "true"
+        - name: CONNECT_TRUSTED_CERTS
+          value: ca/ca.crt
+        envFrom: []
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: rest-api
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: connectors-cluster
+        ports:
+        - containerPort: 8083
+          name: rest-api
+          protocol: TCP
+        - containerPort: 9404
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /connectors
+            port: rest-api
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2350Mi
+          requests:
+            cpu: "1"
+            memory: 2350Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /opt/kafka/connect-certs/ca
+          name: truststore
+        - mountPath: /tmp
+          name: rp-connect-tmp
+      dnsPolicy: ClusterFirst
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: Always
+      schedulerName: ""
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 101
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      tolerations: []
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: connectors
+            app.kubernetes.io/instance: redpanda
+            app.kubernetes.io/name: connectors
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: truststore
+        secret:
+          defaultMode: 292
+          secretName: redpanda-default-cert
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 5Mi
+        name: rp-connect-tmp
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: redpanda-console
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: console
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        checksum-redpanda-chart/config: b22919d0130d0b5d8d29e11d30b2119a0639739f5643b7ce1e9f94e38de30c6e
+        checksum/config: 74234e98afe7498fb5daf1f36ac2d78acc339464f950703b8c019892f982b90b
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: console
+    spec:
+      affinity: {}
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --config.filepath=/etc/console/configs/config.yaml
+        command: null
+        env:
+        - name: KAFKA_TLS_CAFILEPATH
+          value: /mnt/cert/kafka/default/ca.crt
+        - name: KAFKA_SCHEMAREGISTRY_TLS_CAFILEPATH
+          value: /mnt/cert/schemaregistry/default/ca.crt
+        envFrom: []
+        image: docker.redpanda.com/redpandadata/console:v2.7.0
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /admin/health
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: console
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /admin/health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/console/configs
+          name: configs
+          readOnly: true
+        - mountPath: /mnt/cert/kafka/default
+          name: kafka-default-cert
+          readOnly: true
+        - mountPath: /mnt/cert/schemaregistry/default
+          name: schemaregistry-default-cert
+          readOnly: true
+        - mountPath: /mnt/cert/adminapi/default
+          name: adminapi-default-cert
+          readOnly: true
+      imagePullSecrets: []
+      initContainers: []
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      serviceAccountName: redpanda-console
+      tolerations: []
+      topologySpreadConstraints: []
+      volumes:
+      - configMap:
+          name: redpanda-console
+        name: configs
+      - name: kafka-default-cert
+        secret:
+          defaultMode: 272
+          secretName: redpanda-default-cert
+      - name: schemaregistry-default-cert
+        secret:
+          defaultMode: 272
+          secretName: redpanda-default-cert
+      - name: adminapi-default-cert
+        secret:
+          defaultMode: 272
+          secretName: redpanda-default-cert
+---
+# Source: redpanda/templates/statefulset.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: redpanda
+  serviceName: redpanda
+  template:
+    metadata:
+      annotations:
+        config.redpanda.com/checksum: d696a04723a2d2ab62276a5d6a0edc91462858e405794bedd5051e062efea3c4
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: redpanda
+        helm.sh/chart: redpanda-5.9.5
+        redpanda.com/poddisruptionbudget: redpanda
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: redpanda-statefulset
+                app.kubernetes.io/instance: redpanda
+                app.kubernetes.io/name: redpanda
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command:
+        - rpk
+        - redpanda
+        - start
+        - --advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145
+        env:
+        - name: SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                timeout -v 45 bash -x /var/lifecycle/postStart.sh
+                true
+          preStop:
+            exec:
+              command:
+              - /bin/bash
+              - -c
+              - |
+                timeout -v 45 bash -x /var/lifecycle/preStop.sh
+                true # do not fail and cause the pod to terminate
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+              "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        name: redpanda
+        ports:
+        - containerPort: 9644
+          name: admin
+        - containerPort: 9645
+          name: admin-default
+        - containerPort: 8082
+          name: http
+        - containerPort: 8083
+          name: http-default
+        - containerPort: 9093
+          name: kafka
+        - containerPort: 9094
+          name: kafka-default
+        - containerPort: 33145
+          name: rpc
+        - containerPort: 8081
+          name: schemaregistry
+        - containerPort: 8084
+          name: schema-default
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+              RESULT=$(rpk cluster health)
+              echo $RESULT
+              echo $RESULT | grep 'Healthy:.*true'
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 0
+        resources:
+          limits:
+            cpu: 1
+            memory: 2.5Gi
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+              echo $RESULT
+              echo $RESULT | grep ready
+          failureThreshold: 120
+          initialDelaySeconds: 1
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /tmp/base-config
+          name: redpanda
+        - mountPath: /var/lifecycle
+          name: lifecycle-scripts
+        - mountPath: /var/lib/redpanda/data
+          name: datadir
+      - args:
+        - -c
+        - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
+          & wait $!
+        command:
+        - /bin/sh
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
+        name: config-watcher
+        resources: {}
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/secrets/config-watcher/scripts
+          name: redpanda-config-watcher
+      imagePullSecrets: null
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - rpk redpanda tune all
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
+        name: tuning
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_RESOURCE
+          privileged: true
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: redpanda
+      - command:
+        - /bin/bash
+        - -c
+        - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+          & wait $!
+        env:
+        - name: CONFIGURATOR_SCRIPT
+          value: /etc/secrets/configurator/scripts/configurator.sh
+        - name: SERVICE_NAME
+          valueFrom:
+            configMapKeyRef: null
+            fieldRef:
+              fieldPath: metadata.name
+            resourceFieldRef: null
+            secretKeyRef: null
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
+        name: redpanda-configurator
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: null
+          runAsGroup: 101
+          runAsNonRoot: null
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /tmp/base-config
+          name: redpanda
+        - mountPath: /etc/secrets/configurator/scripts/
+          name: redpanda-configurator
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 90
+      tolerations: []
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: redpanda-statefulset
+            app.kubernetes.io/instance: redpanda
+            app.kubernetes.io/name: redpanda
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - name: lifecycle-scripts
+        secret:
+          defaultMode: 509
+          secretName: redpanda-sts-lifecycle
+      - configMap:
+          name: redpanda
+        name: redpanda
+      - emptyDir: {}
+        name: config
+      - name: redpanda-configurator
+        secret:
+          defaultMode: 509
+          secretName: redpanda-configurator
+      - name: redpanda-config-watcher
+        secret:
+          defaultMode: 509
+          secretName: redpanda-config-watcher
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      annotations: null
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+      name: datadir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+    status: {}
+---
+# Source: redpanda/templates/console/configmap-and-deployment.yaml
+# before license changes, this was not printing a secret, so we gather in which case to print
+# for now only if we have a license do we print, however, this may be an issue for some
+# since if we do include a license we MUST also print all secret items.
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-default-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-default-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-external-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-external-root-certificate
+  duration: 43800h
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-default-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-cert
+---
+# Source: redpanda/templates/certs.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-external-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-cert
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-default-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-default-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-external-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/cert-issuers.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-external-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/connectors/connectors.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redpanda-connectors-mm2-test
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: connectors
+    helm.sh/chart: connectors-0.1.13
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  restartPolicy: Never
+  containers:
+    - name: create-mm2
+      image: docker.redpanda.com/redpandadata/redpanda:latest
+      command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          trap connectorsState ERR
+
+          connectorsState () {
+            echo check connectors expand status
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors?expand=status
+            echo check connectors expand info
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors?expand=info
+            echo check connector configuration
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors/$CONNECTOR_NAME
+            echo check connector topics
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors/$CONNECTOR_NAME/topics
+          }
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors
+
+          SASL_MECHANISM="PLAIN"
+
+          rpk profile create test
+          rpk profile set tls.enabled=true brokers=redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093
+          rpk profile set tls.ca=/redpanda-certs/ca.crt
+          CONNECT_TLS_ENABLED=true
+          SECURITY_PROTOCOL=PLAINTEXT
+          if [[ -n "$CONNECT_SASL_MECHANISM" && $CONNECT_TLS_ENABLED == "true" ]]; then
+            SECURITY_PROTOCOL="SASL_SSL"
+          elif [[ -n "$CONNECT_SASL_MECHANISM" ]]; then
+            SECURITY_PROTOCOL="SASL_PLAINTEXT"
+          elif [[ $CONNECT_TLS_ENABLED == "true" ]]; then
+            SECURITY_PROTOCOL="SSL"
+          fi
+
+          rpk topic list
+          rpk topic create test-topic
+          rpk topic list
+          echo "Test message!" | rpk topic produce test-topic
+
+          CONNECTOR_NAME=mm2-$RANDOM
+          cat << 'EOF' > /tmp/mm2-conf.json
+          {
+            "name": "CONNECTOR_NAME",
+            "config": {
+              "connector.class": "org.apache.kafka.connect.mirror.MirrorSourceConnector",
+              "topics": "test-topic",
+              "replication.factor": "1",
+              "tasks.max": "1",
+              "source.cluster.bootstrap.servers": "redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093",
+              "target.cluster.bootstrap.servers": "redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093",
+              "target.cluster.alias": "test-only",
+              "source.cluster.alias": "source",
+              "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+              "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+              "source->target.enabled": "true",
+              "target->source.enabled": "false",
+              "sync.topic.configs.interval.seconds": "5",
+              "sync.topics.configs.enabled": "true",
+              "source.cluster.ssl.truststore.type": "PEM",
+              "target.cluster.ssl.truststore.type": "PEM",
+              "source.cluster.ssl.truststore.location": "/opt/kafka/connect-certs/ca/ca.crt",
+              "target.cluster.ssl.truststore.location": "/opt/kafka/connect-certs/ca/ca.crt",
+              JAAS_CONFIG_SOURCE
+              JAAS_CONFIG_TARGET
+              "source.cluster.security.protocol": "SECURITY_PROTOCOL",
+              "target.cluster.security.protocol": "SECURITY_PROTOCOL",
+              "source.cluster.sasl.mechanism": "SASL_MECHANISM",
+              "target.cluster.sasl.mechanism": "SASL_MECHANISM",
+              "offset-syncs.topic.replication.factor": 1
+            }
+          }
+          EOF
+
+          sed -i "s/CONNECTOR_NAME/$CONNECTOR_NAME/g" /tmp/mm2-conf.json
+          sed -i "s/SASL_MECHANISM/$SASL_MECHANISM/g" /tmp/mm2-conf.json
+          sed -i "s/SECURITY_PROTOCOL/$SECURITY_PROTOCOL/g" /tmp/mm2-conf.json
+          set +x
+          sed -i "s/JAAS_CONFIG_SOURCE/$JAAS_CONFIG_SOURCE/g" /tmp/mm2-conf.json
+          sed -i "s/JAAS_CONFIG_TARGET/$JAAS_CONFIG_TARGET/g" /tmp/mm2-conf.json
+          set -x
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  -H 'Content-Type: application/json' http://redpanda-connectors:8083/connectors -d @/tmp/mm2-conf.json
+
+          # The rpk topic consume could fail for the first few times as kafka connect needs
+          # to spawn the task and copy one message from the source topic. To solve this race condition
+          # the retry should be implemented in bash for rpk topic consume or other mechanism that
+          # can confirm source connectors started its execution. As a fast fix fixed 30 second fix is added.
+          sleep 30
+
+          rpk topic consume source.test-topic -n 1 | grep "Test message!"
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  -X DELETE http://redpanda-connectors:8083/connectors/$CONNECTOR_NAME
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors
+
+          rpk topic delete test-topic source.test-topic mm2-offset-syncs.test-only.internal
+      volumeMounts:
+        - mountPath: /redpanda-certs
+          name: redpanda-ca
+        - mountPath: /tmp
+          name: rp-connect-tmp
+  volumes:
+    - name: redpanda-ca
+      secret:
+        defaultMode: 0444
+        secretName: redpanda-default-cert
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 5Mi
+      name: rp-connect-tmp
+---
+# Source: redpanda/templates/post-install-upgrade-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-configuration
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      generateName: redpanda-post-
+      labels:
+        app.kubernetes.io/component: redpanda-post-install
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+    spec:
+      affinity: {}
+      containers:
+      - args:
+        - |
+          set -e
+          if [[ -n "$REDPANDA_LICENSE" ]] then
+            rpk cluster license set "$REDPANDA_LICENSE"
+          fi
+
+
+
+
+          rpk cluster config export -f /tmp/cfg.yml
+
+
+          for KEY in "${!RPK_@}"; do
+            if ! [[ "$KEY" =~ ^(RPK_USER|RPK_PASS|RPK_SASL_MECHANISM)$ ]]; then
+              config="${KEY#*RPK_}"
+              rpk redpanda config set --config /tmp/cfg.yml "${config,,}" "${!KEY}"
+            fi
+          done
+
+
+          rpk cluster config import -f /tmp/cfg.yml
+        command:
+        - bash
+        - -c
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
+        name: post-install
+        resources: {}
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+      imagePullSecrets: null
+      nodeSelector: {}
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      tolerations: null
+      volumes:
+      - configMap:
+          name: redpanda
+        name: config
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+---
+# Source: redpanda/templates/post-upgrade.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-10"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-post-upgrade
+  namespace: default
+spec:
+  backoffLimit: null
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda-post-upgrade
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+      name: redpanda
+    spec:
+      affinity: {}
+      containers:
+      - args:
+        - |
+          set -e
+
+          rpk cluster config set default_topic_replications 3
+          rpk cluster config set storage_min_free_bytes 1073741824
+          if [ -d "/etc/secrets/users/" ]; then
+              IFS=":" read -r USER_NAME PASSWORD MECHANISM < <(grep "" $(find /etc/secrets/users/* -print))
+              curl -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors --ssl-reqd \
+              --cacert "/etc/tls/certs/default/ca.crt" \
+              -X PUT -u ${USER_NAME}:${PASSWORD} \
+              https://redpanda.default.svc.cluster.local.:9644/v1/debug/restart_service?service=schema-registry || true
+          fi
+        command:
+        - /bin/bash
+        - -c
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
+        name: post-upgrade
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+      imagePullSecrets: null
+      nodeSelector: {}
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      tolerations: []
+      volumes:
+      - configMap:
+          name: redpanda
+        name: config
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+-- testdata/TestTemplate/internal-trust-stores.yaml.golden --
+---
+# Source: redpanda/templates/poddisruptionbudget.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: redpanda
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/serviceaccount.yaml
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.0
+    helm.sh/chart: console-0.7.29
+  name: redpanda-console
+  namespace: default
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-sts-lifecycle
+  namespace: default
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+type: Opaque
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
+  name: redpanda-config-watcher
+  namespace: default
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    # rpk cluster health can exit non-zero if it's unable to dial brokers. This
+    # can happen for many reasons but we never want this script to crash as it
+    # would take down yet another broker and make a bad situation worse.
+    # Instead, just wait for the command to eventually exit zero.
+    echo "Waiting for cluster to be ready"
+    until rpk cluster health --watch --exit-when-healthy; do
+      echo "rpk cluster health failed. Waiting 5 seconds before trying again..."
+      sleep 5
+    done
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+type: Opaque
+---
+# Source: redpanda/templates/secrets.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -107304,7 +109074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -107335,7 +109105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -107428,7 +109198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -107474,7 +109244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -107650,7 +109420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -107672,7 +109442,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -107703,7 +109473,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -107817,7 +109587,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -107836,7 +109606,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -107877,7 +109647,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -108010,7 +109780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -108036,7 +109806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -108062,7 +109832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -108100,7 +109870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -108138,7 +109908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -108154,7 +109924,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -108171,7 +109941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -108187,7 +109957,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -108231,7 +110001,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -108273,7 +110043,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -108321,7 +110091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -108355,7 +110125,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -108399,7 +110169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -108437,7 +110207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -108530,7 +110300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -108568,7 +110338,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -108800,7 +110570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -108833,7 +110603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -108926,7 +110696,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -108972,7 +110742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -109128,7 +110898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -109150,7 +110920,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -109181,7 +110951,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -109286,7 +111056,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -109307,7 +111077,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -109350,7 +111120,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -109455,7 +111225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -109481,7 +111251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -109507,7 +111277,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -109533,7 +111303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -109571,7 +111341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -109609,7 +111379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -109647,7 +111417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -109672,7 +111442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -109688,7 +111458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -109705,7 +111475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -109721,7 +111491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -109738,7 +111508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -109754,7 +111524,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -109798,7 +111568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -109840,7 +111610,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -109894,7 +111664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -109928,7 +111698,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -109978,7 +111748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -110016,7 +111786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -110109,7 +111879,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -110147,7 +111917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -110372,7 +112142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -110403,7 +112173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -110496,7 +112266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -110542,7 +112312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -110698,7 +112468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -110720,7 +112490,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -110751,7 +112521,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -110854,7 +112624,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -110873,7 +112643,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -110914,7 +112684,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -111013,7 +112783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -111039,7 +112809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -111065,7 +112835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -111103,7 +112873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -111141,7 +112911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -111157,7 +112927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -111174,7 +112944,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -111190,7 +112960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -111234,7 +113004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -111276,7 +113046,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -111324,7 +113094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -111358,7 +113128,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -111402,7 +113172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -111440,7 +113210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -111533,7 +113303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -111571,7 +113341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -111796,7 +113566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -111827,7 +113597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -111920,7 +113690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -111966,7 +113736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -112122,7 +113892,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -112144,7 +113914,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -112175,7 +113945,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -112278,7 +114048,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -112297,7 +114067,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -112338,7 +114108,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -112437,7 +114207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -112463,7 +114233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -112489,7 +114259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -112527,7 +114297,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -112565,7 +114335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -112581,7 +114351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -112598,7 +114368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -112614,7 +114384,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -112631,7 +114401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -112689,7 +114459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -112731,7 +114501,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -112779,7 +114549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -112813,7 +114583,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -112857,7 +114627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -112895,7 +114665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -112988,7 +114758,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -113026,7 +114796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -113238,7 +115008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -113268,7 +115038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -113361,7 +115131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -113407,7 +115177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -113556,7 +115326,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -113578,7 +115348,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -113609,7 +115379,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -113711,7 +115481,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -113730,7 +115500,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -113771,7 +115541,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -113870,7 +115640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -113896,7 +115666,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -113922,7 +115692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -113960,7 +115730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -113998,7 +115768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -114014,7 +115784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -114031,7 +115801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -114047,7 +115817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -114064,7 +115834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -114118,7 +115888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -114160,7 +115930,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -114208,7 +115978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -114242,7 +116012,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101
@@ -114286,7 +116056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -114324,7 +116094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -114417,7 +116187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -114455,7 +116225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -114680,7 +116450,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -114711,7 +116481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -114804,7 +116574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -114850,7 +116620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -115006,7 +116776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -115028,7 +116798,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -115321,7 +117091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -115347,7 +117117,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -115373,7 +117143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -115411,7 +117181,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -115449,7 +117219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -115465,7 +117235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -115482,7 +117252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -115498,7 +117268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -115542,7 +117312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -115632,7 +117402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -115710,7 +117480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -115787,7 +117557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -115880,7 +117650,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -115918,7 +117688,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -116142,7 +117912,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -116173,7 +117943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -116266,7 +118036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -116312,7 +118082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -116484,7 +118254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -116506,7 +118276,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -116799,7 +118569,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -116825,7 +118595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -116851,7 +118621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -116889,7 +118659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -116927,7 +118697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -116943,7 +118713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -116960,7 +118730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -116976,7 +118746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -117020,7 +118790,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -117112,7 +118882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -117190,7 +118960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -117228,7 +118998,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -117321,7 +119091,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -117359,7 +119129,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -117589,7 +119359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -117620,7 +119390,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -117713,7 +119483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -117759,7 +119529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -117915,7 +119685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -117937,7 +119707,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -118230,7 +120000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -118256,7 +120026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -118282,7 +120052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -118320,7 +120090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -118358,7 +120128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -118374,7 +120144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -118391,7 +120161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -118407,7 +120177,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -118451,7 +120221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -118541,7 +120311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -118619,7 +120389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -118657,7 +120427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -118750,7 +120520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -118788,7 +120558,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -119014,7 +120784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -119045,7 +120815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -119138,7 +120908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -119184,7 +120954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -119340,7 +121110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -119362,7 +121132,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -119655,7 +121425,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -119681,7 +121451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -119707,7 +121477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -119745,7 +121515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -119783,7 +121553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -119799,7 +121569,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -119816,7 +121586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -119832,7 +121602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -119876,7 +121646,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -119966,7 +121736,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -120044,7 +121814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -120121,7 +121891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -120214,7 +121984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -120252,7 +122022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -120477,7 +122247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -120508,7 +122278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -120601,7 +122371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -120647,7 +122417,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -120819,7 +122589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -120841,7 +122611,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -121134,7 +122904,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -121160,7 +122930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -121186,7 +122956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -121224,7 +122994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -121262,7 +123032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -121278,7 +123048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -121295,7 +123065,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -121311,7 +123081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -121355,7 +123125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -121447,7 +123217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -121525,7 +123295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -121563,7 +123333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -121656,7 +123426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -121694,7 +123464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -121925,7 +123695,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -121956,7 +123726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -122049,7 +123819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -122095,7 +123865,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -122251,7 +124021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -122273,7 +124043,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -122566,7 +124336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -122592,7 +124362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -122618,7 +124388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -122656,7 +124426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -122694,7 +124464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -122710,7 +124480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -122727,7 +124497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -122743,7 +124513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -122787,7 +124557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -122877,7 +124647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -122955,7 +124725,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -122993,7 +124763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -123086,7 +124856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -123124,7 +124894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -123349,7 +125119,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 ---
@@ -123380,7 +125150,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-rpk
   namespace: default
 ---
@@ -123473,7 +125243,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -123519,7 +125289,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external
   namespace: default
 spec:
@@ -123675,7 +125445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda
   namespace: default
 spec:
@@ -123697,7 +125467,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.4
+        helm.sh/chart: redpanda-5.9.5
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -123728,7 +125498,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         lifecycle:
           postStart:
             exec:
@@ -123831,7 +125601,7 @@ spec:
         command:
         - /bin/sh
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: config-watcher
         resources: {}
         securityContext: {}
@@ -123850,7 +125620,7 @@ spec:
         - /bin/bash
         - -c
         - rpk redpanda tune all
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: tuning
         resources: {}
         securityContext:
@@ -123891,7 +125661,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: status.hostIP
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: redpanda-configurator
         resources: {}
         securityContext:
@@ -123990,7 +125760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -124016,7 +125786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -124042,7 +125812,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -124080,7 +125850,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -124118,7 +125888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -124134,7 +125904,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -124151,7 +125921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -124167,7 +125937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -124211,7 +125981,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-configuration
   namespace: default
 spec:
@@ -124253,7 +126023,7 @@ spec:
         - bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-install
         resources: {}
         securityContext:
@@ -124301,7 +126071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.4
+    helm.sh/chart: redpanda-5.9.5
   name: redpanda-post-upgrade
   namespace: default
 spec:
@@ -124335,7 +126105,7 @@ spec:
         - /bin/bash
         - -c
         env: []
-        image: docker.redpanda.com/redpandadata/redpanda:v24.2.4
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
         name: post-upgrade
         securityContext:
           runAsGroup: 101

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -19720,6 +19720,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.9.5
+    release: prometheus
   name: redpanda
   namespace: default
 spec:
@@ -21147,6 +21148,7 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
     helm.sh/chart: redpanda-5.9.5
+    release: prometheus
   name: redpanda
   namespace: default
 spec:

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -380,3 +380,9 @@ statefulset:
 
 statefulset:
   replicas: 1
+
+-- enable-connectors --
+# ASSERT-NO-ERROR
+# ASSERT-GOLDEN
+connectors:
+  enabled: true


### PR DESCRIPTION
Prerequisite https://github.com/redpanda-data/helm-charts/pull/1541

Bump Redpanda application (container tag). Fix conenctors deployment to work
correctly with gotohelm transpiled code.

Fixes #1511