### PR TITLE
remove mintel/docker-alpine-bash-curl-jq from chart.yaml annotations

### DIFF
--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -59,5 +59,3 @@ annotations:
       image: docker.redpanda.com/redpandadata/redpanda:v24.2.5
     - name: busybox
       image: busybox:latest
-    - name: mintel/docker-alpine-bash-curl-jq
-      image: mintel/docker-alpine-bash-curl-jq:latest


### PR DESCRIPTION
Remove `mintel/docker-alpine-bash-curl-jq` image annotation from Chart.yaml for ArtifactHub to avoid any noise or concern from folks who believe the chart deploys curl and jq on an relatively stale image.

![image](https://github.com/user-attachments/assets/5f4b1e60-ee25-4a39-a6af-948ff2ba30ea)
