### PR TITLE
Handle empty string correctly using Empty function

### DIFF
--- a/pkg/gotohelm/helmette/sprig.go
+++ b/pkg/gotohelm/helmette/sprig.go
@@ -262,7 +262,7 @@ func Empty(value any) bool {
 		return v.IsZero()
 
 	case reflect.Pointer:
-		if !v.IsNil() && v.Elem().Kind() == reflect.Struct {
+		if !v.IsNil() && v.Elem().Kind() == reflect.Struct || v.Elem().Kind() == reflect.String {
 			return v.Elem().IsZero()
 		}
 	}

--- a/pkg/gotohelm/helmette/sprig_test.go
+++ b/pkg/gotohelm/helmette/sprig_test.go
@@ -13,6 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 )
 
+func TestEmpty(t *testing.T) {
+	var ptrString *string
+	require.True(t, helmette.Empty(""))
+	require.True(t, helmette.Empty(ptrString))
+}
+
 func TestDig(t *testing.T) {
 	values := map[string]any{
 		"k1": "v1",

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.go
@@ -240,6 +240,7 @@ func default_() []any {
 func empty() []bool {
 	return []bool{
 		helmette.Empty(nil),
+		helmette.Empty(""),
 		helmette.Empty([]string{}),
 		helmette.Empty([]string{""}),
 		helmette.Empty(map[string]any{}),

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.rewritten.go
@@ -249,6 +249,7 @@ func default_() []any {
 func empty() []bool {
 	return []bool{
 		helmette.Empty(nil),
+		helmette.Empty(""),
 		helmette.Empty([]string{}),
 		helmette.Empty([]string{""}),
 		helmette.Empty(map[string]any{}),

--- a/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
+++ b/pkg/gotohelm/testdata/src/example/sprig/sprig.yaml
@@ -193,7 +193,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (list (empty (coalesce nil)) (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" (coalesce nil) )) (empty (1 | int)) (empty (0 | int)) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict ) (dict ))) (empty (mustMergeOverwrite (dict ) (dict "Value" (1 | int) ))))) | toJson -}}
+{{- (dict "r" (list (empty (coalesce nil)) (empty "") (empty (list )) (empty (list "")) (empty (dict )) (empty (dict "key" (coalesce nil) )) (empty (1 | int)) (empty (0 | int)) (empty false) (empty true) (empty "") (empty "hello") (empty (mustMergeOverwrite (dict ) (dict ))) (empty (mustMergeOverwrite (dict ) (dict "Value" (1 | int) ))))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
In the sprig shim the empty string was not handled correctly. That's why console tag in the Go vs Helm template unit test was failing. Go execution had default value for console tag as empty string. The logic that took console tag version from Chart appVersion was overwritten in the `containerImage` function. In the end container did not have tag when Console chart was rendered.