### PR TITLE
Handle corev1.Volume in Unwrap function

### DIFF
--- a/pkg/gotohelm/helmette/shims.go
+++ b/pkg/gotohelm/helmette/shims.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/mitchellh/mapstructure"
 	"github.com/redpanda-data/helm-charts/pkg/valuesutil"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/yaml"
@@ -114,6 +115,8 @@ func Unwrap[T any](from Values) T {
 			switch reflect.New(to).Interface().(type) {
 			case *resource.Quantity:
 				return valuesutil.UnmarshalInto[*resource.Quantity](val)
+			case *corev1.Volume:
+				return valuesutil.UnmarshalInto[*corev1.Volume](val)
 			}
 			return val, nil
 		}),

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.go
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.go
@@ -14,13 +14,14 @@ import (
 )
 
 type Values struct {
-	Quantity *resource.Quantity
+	Quantity     *resource.Quantity
+	ExtraVolumes *corev1.Volume `json:"extraVolumes,omitempty"`
 }
 
 func K8s(dot *helmette.Dot) map[string]any {
 	return map[string]any{
 		"Objects": []metav1.Object{
-			pod(),
+			pod(dot),
 			pdb(),
 			service(),
 		},
@@ -55,7 +56,24 @@ func K8s(dot *helmette.Dot) map[string]any {
 	}
 }
 
-func pod() *corev1.Pod {
+func pod(dot *helmette.Dot) *corev1.Pod {
+	values := helmette.Unwrap[Values](dot.Values)
+
+	vol := []corev1.Volume{
+		{
+			Name: "included",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  "secretReference",
+					DefaultMode: ptr.To[int32](0o420),
+				},
+			},
+		},
+	}
+	if values.ExtraVolumes != nil {
+		vol = append(vol, *values.ExtraVolumes)
+	}
+
 	return &corev1.Pod{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "v1",
@@ -64,6 +82,9 @@ func pod() *corev1.Pod {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "spacename",
 			Name:      "eman",
+		},
+		Spec: corev1.PodSpec{
+			Volumes: vol,
 		},
 	}
 }

--- a/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
+++ b/pkg/gotohelm/testdata/src/example/k8s/k8s.yaml
@@ -5,16 +5,22 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list (10 | int) (11 | int) "12") "ptr.Deref" (list ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (3 | int) (4 | int)) ))) "r") | int) ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") | int) (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list "" "oh?") ))) "r")) "ptr.To" (list "hello" (0 | int) (dict )) "ptr.Equal" (list (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (coalesce nil)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (3 | int) (3 | int)) ))) "r")) "lookup" (get (fromJson (include "k8s.lookup" (dict "a" (list $dot) ))) "r") "quantity" (get (fromJson (include "k8s.quantity" (dict "a" (list $dot) ))) "r") "resources" (dict "cpu" (get (fromJson (include "_shims.resource_MustParse" (dict "a" (list "100m") ))) "r") ) )) | toJson -}}
+{{- (dict "r" (dict "Objects" (list (get (fromJson (include "k8s.pod" (dict "a" (list $dot) ))) "r") (get (fromJson (include "k8s.pdb" (dict "a" (list ) ))) "r") (get (fromJson (include "k8s.service" (dict "a" (list ) ))) "r")) "intstr" (list (10 | int) (11 | int) "12") "ptr.Deref" (list ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (3 | int) (4 | int)) ))) "r") | int) ((get (fromJson (include "_shims.ptr_Deref" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") | int) (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list "" "oh?") ))) "r")) "ptr.To" (list "hello" (0 | int) (dict )) "ptr.Equal" (list (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (coalesce nil)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (coalesce nil) (3 | int)) ))) "r") (get (fromJson (include "_shims.ptr_Equal" (dict "a" (list (3 | int) (3 | int)) ))) "r")) "lookup" (get (fromJson (include "k8s.lookup" (dict "a" (list $dot) ))) "r") "quantity" (get (fromJson (include "k8s.quantity" (dict "a" (list $dot) ))) "r") "resources" (dict "cpu" (get (fromJson (include "_shims.resource_MustParse" (dict "a" (list "100m") ))) "r") ) )) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "k8s.pod" -}}
+{{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $vol := (list (mustMergeOverwrite (dict "name" "" ) (mustMergeOverwrite (dict ) (dict "secret" (mustMergeOverwrite (dict ) (dict "secretName" "secretReference" "defaultMode" (0o420 | int) )) )) (dict "name" "included" ))) -}}
+{{- if (ne $values.extraVolumes (coalesce nil)) -}}
+{{- $vol = (concat (default (list ) $vol) (list $values.extraVolumes)) -}}
+{{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "containers" (coalesce nil) ) "status" (dict ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Pod" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "namespace" "spacename" "name" "eman" )) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) "spec" (dict "containers" (coalesce nil) ) "status" (dict ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "Pod" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "namespace" "spacename" "name" "eman" )) "spec" (mustMergeOverwrite (dict "containers" (coalesce nil) ) (dict "volumes" $vol )) ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/pkg/gotohelm/transpiler_test.go
+++ b/pkg/gotohelm/transpiler_test.go
@@ -27,6 +27,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -78,6 +79,12 @@ var testSpecs = map[string]TestSpec{
 			// examples/ for details.
 			// {"Quantity": 999.110},  // Float64 which rounds down
 			// {"Quantity": 999.999},  // Float64 which rounds up
+			{"extraVolumes": corev1.Volume{
+				Name: "test",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{SecretName: "test", DefaultMode: ptr.To[int32](0o420)},
+				},
+			}},
 		},
 	},
 	"sprig": {


### PR DESCRIPTION
When helm chart values would have declared and used corev1.Volume, then unwrap function would fail in case calling it from go runtime. Many functions have the following unwrap call:

```
values := helmette.Unwrap[Values](dot.Values)
```

which fails when unit test that compares go rendered vs helm template rendered kubernetes objects.