### PR TITLE
Add Enabled flag in Console values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -266,8 +266,12 @@
 
 ### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/console-FILLMEIN) - YYYY-MM-DD
 #### Added
+* Add Enabled flag that is used in Redpanda chart
+* Add test example for oidc configuration [#1503](https://github.com/redpanda-data/helm-charts/pull/1503)
 #### Changed
+* Align Console init container default value 
 #### Fixed
+* License json tag to correctly set Console license [#1510](https://github.com/redpanda-data/helm-charts/pull/1510)
 #### Removed
 
 ### [0.7.29](https://github.com/redpanda-data/helm-charts/releases/tag/console-0.7.29) - 2024-08-19

--- a/charts/console/values.go
+++ b/charts/console/values.go
@@ -56,6 +56,7 @@ type Values struct {
 	Deployment                   DeploymentConfig                  `json:"deployment"`
 	Strategy                     appsv1.DeploymentStrategy         `json:"strategy"`
 	Tests                        Enableable                        `json:"tests"`
+	Enabled                      *bool                             `json:"enabled,omitempty"`
 }
 
 type DeploymentConfig struct {

--- a/charts/console/values_partial.gen.go
+++ b/charts/console/values_partial.gen.go
@@ -50,6 +50,7 @@ type PartialValues struct {
 	Deployment                   *PartialDeploymentConfig          "json:\"deployment,omitempty\""
 	Strategy                     *appsv1.DeploymentStrategy        "json:\"strategy,omitempty\""
 	Tests                        *PartialEnableable                "json:\"tests,omitempty\""
+	Enabled                      *bool                             "json:\"enabled,omitempty\""
 }
 
 type PartialImage struct {


### PR DESCRIPTION
To allow Redpanda subcharting of Console values the Enabled flag should be
declared as Console chart dependency condition require to have enabled flag.

Reference:
https://github.com/redpanda-data/helm-charts/blob/370de8a6ac1dfa88784e1220f82bf1ddb54bc635/charts/redpanda/Chart.yaml#L39
https://github.com/redpanda-data/helm-charts/blob/370de8a6ac1dfa88784e1220f82bf1ddb54bc635/charts/redpanda/values.yaml#L149
https://github.com/redpanda-data/helm-charts/blob/370de8a6ac1dfa88784e1220f82bf1ddb54bc635/charts/redpanda/values.go#L86

Based on https://github.com/redpanda-data/helm-charts/pull/1554