### PR TITLE
Calculate recursively values from all chart dependencies

### DIFF
--- a/charts/connectors/chart.go
+++ b/charts/connectors/chart.go
@@ -1,0 +1,70 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// +gotohelm:filename=_chart.go.tpl
+package connectors
+
+import (
+	_ "embed"
+
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm"
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+)
+
+var (
+	// Scheme is a [runtime.Scheme] with the appropriate extensions to load all
+	// objects produced by the console chart.
+	Scheme = runtime.NewScheme()
+
+	//go:embed Chart.yaml
+	chartYAML []byte
+
+	//go:embed values.yaml
+	defaultValuesYAML []byte
+
+	// ChartLabel is the go version of the console helm chart.
+	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render)
+)
+
+// +gotohelm:ignore=true
+func init() {
+	must(scheme.AddToScheme(Scheme))
+}
+
+// +gotohelm:ignore=true
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+// render is the entrypoint to both the go and helm versions of the connectors
+// helm chart.
+// In helm, _shims.render-manifest is used to call and filter the output of
+// this function.
+// In go, this function should be call by executing [ChartLabel.Render], which will
+// handle construction of [helmette.Dot], subcharting, and output filtering.
+func render(dot *helmette.Dot) []kube.Object {
+	manifests := []kube.Object{}
+	// TODO
+
+	// NB: This slice may contain nil interfaces!
+	// Filtering happens elsewhere, don't call this function directly if you
+	// can avoid it.
+	return manifests
+}

--- a/charts/connectors/helpers.go
+++ b/charts/connectors/helpers.go
@@ -45,7 +45,7 @@ func Fullname(dot *helmette.Dot) string {
 
 func FullLabels(dot *helmette.Dot) map[string]string {
 	return helmette.Merge(map[string]string{
-		"helm.sh/chart":                Chart(dot),
+		"helm.sh/chart":                ChartLabels(dot),
 		"app.kubernetes.io/managed-by": dot.Release.Service,
 	}, PodLabels(dot))
 }
@@ -59,7 +59,7 @@ func PodLabels(dot *helmette.Dot) map[string]string {
 	}, values.CommonLabels)
 }
 
-func Chart(dot *helmette.Dot) string {
+func ChartLabels(dot *helmette.Dot) string {
 	chart := fmt.Sprintf("%s-%s", dot.Chart.Name, dot.Chart.Version)
 	return trunc(helmette.Replace("+", "_", chart))
 }

--- a/charts/connectors/templates/_chart.go.tpl
+++ b/charts/connectors/templates/_chart.go.tpl
@@ -1,0 +1,13 @@
+{{- /* Generated from "chart.go" */ -}}
+
+{{- define "connectors.render" -}}
+{{- $dot := (index .a 0) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $manifests := (list ) -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" $manifests) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+

--- a/charts/connectors/templates/_helpers.go.tpl
+++ b/charts/connectors/templates/_helpers.go.tpl
@@ -39,7 +39,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (merge (dict ) (dict "helm.sh/chart" (get (fromJson (include "connectors.Chart" (dict "a" (list $dot) ))) "r") "app.kubernetes.io/managed-by" $dot.Release.Service ) (get (fromJson (include "connectors.PodLabels" (dict "a" (list $dot) ))) "r"))) | toJson -}}
+{{- (dict "r" (merge (dict ) (dict "helm.sh/chart" (get (fromJson (include "connectors.ChartLabels" (dict "a" (list $dot) ))) "r") "app.kubernetes.io/managed-by" $dot.Release.Service ) (get (fromJson (include "connectors.PodLabels" (dict "a" (list $dot) ))) "r"))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}
@@ -55,7 +55,7 @@
 {{- end -}}
 {{- end -}}
 
-{{- define "connectors.Chart" -}}
+{{- define "connectors.ChartLabels" -}}
 {{- $dot := (index .a 0) -}}
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}

--- a/charts/console/chart_test.go
+++ b/charts/console/chart_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	fuzz "github.com/google/gofuzz"
-	"github.com/redpanda-data/helm-charts/charts/redpanda"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/helm-charts/pkg/helm"
 	"github.com/redpanda-data/helm-charts/pkg/kube"
@@ -196,7 +195,7 @@ func TestGoHelmEquivalence(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	helmObjs, err := kube.DecodeYAML(rendered, redpanda.Scheme)
+	helmObjs, err := kube.DecodeYAML(rendered, Scheme)
 	require.NoError(t, err)
 
 	slices.SortStableFunc(helmObjs, func(a, b kube.Object) int {

--- a/charts/redpanda/chart.go
+++ b/charts/redpanda/chart.go
@@ -21,6 +21,8 @@ import (
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/redpanda-data/helm-charts/charts/connectors"
+	"github.com/redpanda-data/helm-charts/charts/console"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/helm-charts/pkg/kube"
@@ -40,7 +42,7 @@ var (
 	defaultValuesYAML []byte
 
 	// Chart is the go version of the redpanda helm chart.
-	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render)
+	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render, console.Chart, connectors.Chart)
 )
 
 // +gotohelm:ignore=true

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	golang.org/x/exp v0.0.0-20240416160154-fe59bbe5cc7f
 	golang.org/x/net v0.25.0
 	golang.org/x/tools v0.20.0
+	gopkg.in/yaml.v3 v3.0.1
 	helm.sh/helm/v3 v3.14.4
 	k8s.io/api v0.29.5
 	k8s.io/apimachinery v0.29.5
@@ -205,7 +206,6 @@ require (
 	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.29.5 // indirect
 	k8s.io/apiserver v0.29.5 // indirect
 	k8s.io/cli-runtime v0.29.0 // indirect

--- a/pkg/gotohelm/gochart_test.go
+++ b/pkg/gotohelm/gochart_test.go
@@ -1,0 +1,193 @@
+package gotohelm
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/gonvenience/ytbx"
+	"github.com/homeport/dyff/pkg/dyff"
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/helm-charts/pkg/helm"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
+	"github.com/redpanda-data/helm-charts/pkg/testutil"
+	"github.com/stretchr/testify/require"
+	yamlv3 "gopkg.in/yaml.v3"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+var (
+	//go:embed testdata/subchart/root/Chart.yaml
+	rootChart []byte
+
+	//go:embed testdata/subchart/values-overwrite/Chart.yaml
+	valuesOverwriteChart []byte
+
+	//go:embed testdata/subchart/dependency-excluded-by-default/Chart.yaml
+	depExcludedChart []byte
+
+	//go:embed testdata/subchart/dependency-included-by-default/Chart.yaml
+	depIncludedChart []byte
+
+	//go:embed testdata/subchart/dependency/Chart.yaml
+	depChart []byte
+
+	//go:embed testdata/subchart/root/values.yaml
+	rootDefaultValuesYAML []byte
+
+	//go:embed testdata/subchart/values-overwrite/values.yaml
+	valuesOverwriteDefaultValuesYAML []byte
+
+	//go:embed testdata/subchart/dependency-excluded-by-default/values.yaml
+	depExcludedDefaultValuesYAML []byte
+
+	//go:embed testdata/subchart/dependency-included-by-default/values.yaml
+	depIncludedDefaultValuesYAML []byte
+
+	//go:embed testdata/subchart/dependency/values.yaml
+	depDefaultValuesYAML []byte
+)
+
+func TestDependencyChainRender(t *testing.T) {
+	// The chart dependency graph
+	//            ┌───────────────┐   ┌──────────┐
+	//     ┌─────►│valuesOverwrite├──►│Dependency│
+	//     │      └───────────────┘   └──────────┘
+	//     │
+	// ┌───┴┐     ┌──────────┐        ┌──────────┐
+	// │root┼────►│ExcludeDep├───────►│Dependency│
+	// └───┬┘     └──────────┘        └──────────┘
+	//     │
+	//     │      ┌──────────┐        ┌───────────┐
+	//     └─────►│IncludeDep├───────►│Dependency │
+	//            └──────────┘        └───────────┘
+	// Graph created by https://asciiflow.com/#/
+	//
+	// ExcludeDep - has condition that points to value which is false.
+	// IncludeDep - has condition that points to value which is true.
+	// valuesOverwrite - does not have any condition
+	//
+	// All charts are creating Config map which has one data, the rendered values
+	dep, err := Load(depChart, depDefaultValuesYAML, renderConfigMap)
+	require.NoError(t, err)
+	valuesOverwrite, err := Load(valuesOverwriteChart, valuesOverwriteDefaultValuesYAML, renderConfigMap, dep)
+	require.NoError(t, err)
+	excludeDep, err := Load(depExcludedChart, depExcludedDefaultValuesYAML, renderConfigMap, dep)
+	require.NoError(t, err)
+	includeDep, err := Load(depIncludedChart, depIncludedDefaultValuesYAML, renderConfigMap, dep)
+	require.NoError(t, err)
+	root, err := Load(rootChart, rootDefaultValuesYAML, renderConfigMap, valuesOverwrite, excludeDep, includeDep)
+	require.NoError(t, err)
+
+	helmCli, err := helm.New(helm.Options{ConfigHome: testutil.TempDir(t)})
+	require.NoError(t, err)
+
+	for _, chartPath := range []string{
+		"./testdata/subchart/dependency",
+		"./testdata/subchart/dependency-excluded-by-default",
+		"./testdata/subchart/dependency-included-by-default",
+		"./testdata/subchart/values-overwrite",
+		"./testdata/subchart/root",
+	} {
+		out, err := exec.Command("helm", "dep", "build", chartPath).CombinedOutput()
+		if err != nil {
+			require.NoErrorf(t, err, "failed to run helm dep build: %s", out)
+		}
+	}
+
+	inputVal, err := os.ReadFile("testdata/subchart/root/input-val.yaml")
+	require.NoError(t, err)
+
+	inputValues := map[string]any{}
+
+	err = yaml.Unmarshal(inputVal, &inputValues)
+	require.NoError(t, err)
+
+	expected, err := helmCli.Template(context.Background(), "testdata/subchart/root", helm.TemplateOptions{
+		Name:      "subchart",
+		Namespace: "test",
+		Values:    inputValues,
+		Version:   "0.0.1",
+	})
+	require.NoError(t, err)
+
+	actual, err := root.Render(kube.Config{}, helmette.Release{}, inputValues)
+	require.NoError(t, err)
+
+	actualByte, err := convertToString(actual)
+	require.NoError(t, err)
+
+	actualDocuments, err := ytbx.LoadDocuments(actualByte)
+	require.NoError(t, err)
+
+	expectedDocuments, err := ytbx.LoadDocuments(expected)
+	require.NoError(t, err)
+
+	sorter := func(a, b *yamlv3.Node) int {
+		aNode, err := ytbx.Grab(a, "data.values")
+		require.NoError(t, err)
+		bNode, err := ytbx.Grab(b, "data.values")
+		require.NoError(t, err)
+		return strings.Compare(aNode.Value, bNode.Value)
+	}
+	slices.SortStableFunc(actualDocuments, sorter)
+	slices.SortStableFunc(expectedDocuments, sorter)
+
+	report, err := dyff.CompareInputFiles(
+		ytbx.InputFile{Documents: expectedDocuments},
+		ytbx.InputFile{Documents: actualDocuments},
+	)
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	if len(report.Diffs) > 0 {
+		hr := dyff.HumanReport{Report: report, OmitHeader: true}
+
+		var buf bytes.Buffer
+		require.NoError(t, hr.WriteReport(&buf))
+
+		require.Fail(t, buf.String())
+	}
+}
+
+func convertToString(objs []kube.Object) ([]byte, error) {
+	b := bytes.NewBuffer(nil)
+	for _, obj := range objs {
+		fmt.Fprintf(b, "---\n%s\n", MustMarshalYAML(obj))
+	}
+	return b.Bytes(), nil
+}
+
+func MustMarshalYAML(x any) string {
+	bs, err := yaml.Marshal(x)
+	if err != nil {
+		panic(err)
+	}
+	return string(bs)
+}
+
+func renderConfigMap(dot *helmette.Dot) []kube.Object {
+	return []kube.Object{
+		&corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "ConfigMap",
+				APIVersion: "v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: dot.Chart.Name,
+			},
+			Data: map[string]string{
+				"values": MustMarshalYAML(dot.Values),
+			},
+		},
+	}
+}

--- a/pkg/gotohelm/testdata/.gitignore
+++ b/pkg/gotohelm/testdata/.gitignore
@@ -1,1 +1,4 @@
 pkg/
+
+# After helm dep update/build the work tree will consist of depedent charts.
+*/**/charts/

--- a/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/Chart.lock
+++ b/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: dependency
+  repository: file://../dependency
+  version: 0.0.1
+digest: sha256:f5dc4fa81c55180d5ede69f2598678ce2e106fbdd0030ba60f7efe23d62af1fe
+generated: "2024-10-12T15:29:59.329747+02:00"

--- a/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/Chart.yaml
+++ b/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/Chart.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: dependency-excluded-by-default
+type: application
+version: 0.0.1
+appVersion: v1.0.0
+kubeVersion: ">= 1.25.0-0"
+dependencies:
+  - name: dependency
+    condition: disabled-dependency
+    repository: "file://../dependency"
+    version: 0.0.1

--- a/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/templates/config-map.tpl
+++ b/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/templates/config-map.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: dep-excluded
+data:
+  values: |
+    {{- toYaml .Values | nindent 4 }}

--- a/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/values.yaml
+++ b/pkg/gotohelm/testdata/subchart/dependency-excluded-by-default/values.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# The key `disabled-dependency` is for indicating that the condition
+# in Chart.yaml, is not meet by default. If the values for the condition
+# `disabled-dependency` would be set to true by default helm would render
+# values and the resources from dependent helm chart.
+disabled-dependency: false
+
+dependency:
+  # This key and value should be rendered by helm engine regardless of the
+  # dependency condition
+  change-me: disabled-dependency-change

--- a/pkg/gotohelm/testdata/subchart/dependency-included-by-default/Chart.lock
+++ b/pkg/gotohelm/testdata/subchart/dependency-included-by-default/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: dependency
+  repository: file://../dependency
+  version: 0.0.1
+digest: sha256:0967a8e5b168d98113b2cdc928c21f11f49e5623e451e73a3ea55c26307f7871
+generated: "2024-10-12T15:30:04.192588+02:00"

--- a/pkg/gotohelm/testdata/subchart/dependency-included-by-default/Chart.yaml
+++ b/pkg/gotohelm/testdata/subchart/dependency-included-by-default/Chart.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: dependency-included-by-default
+type: application
+version: 0.0.1
+appVersion: v1.0.0
+kubeVersion: ">= 1.25.0-0"
+dependencies:
+  - name: dependency
+    condition: enabled-dependency
+    repository: "file://../dependency"
+    version: 0.0.1

--- a/pkg/gotohelm/testdata/subchart/dependency-included-by-default/templates/config-map.tpl
+++ b/pkg/gotohelm/testdata/subchart/dependency-included-by-default/templates/config-map.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: dependency-included-by-default
+data:
+  values: |
+    {{- toYaml .Values | nindent 4 }}

--- a/pkg/gotohelm/testdata/subchart/dependency-included-by-default/values.yaml
+++ b/pkg/gotohelm/testdata/subchart/dependency-included-by-default/values.yaml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The key `enabled-dependency` should is intentionally set to `true`, so
+# that dependency helm chart values and resources will be rendered.
+enabled-dependency: true
+
+dependency:
+  # This key and value should be rendered by helm engine regardless of the
+  # dependency condition
+  change-me: enabled-dependency-change

--- a/pkg/gotohelm/testdata/subchart/dependency/Chart.yaml
+++ b/pkg/gotohelm/testdata/subchart/dependency/Chart.yaml
@@ -1,0 +1,21 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: dependency
+type: application
+version: 0.0.1
+appVersion: v1.0.0
+kubeVersion: ">= 1.25.0-0"

--- a/pkg/gotohelm/testdata/subchart/dependency/templates/config-map.tpl
+++ b/pkg/gotohelm/testdata/subchart/dependency/templates/config-map.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: dependency
+data:
+  values: |
+    {{- toYaml .Values | nindent 4 }}

--- a/pkg/gotohelm/testdata/subchart/dependency/values.yaml
+++ b/pkg/gotohelm/testdata/subchart/dependency/values.yaml
@@ -1,0 +1,19 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+change-me: default
+do-not-change: default
+
+root-overwrite: default

--- a/pkg/gotohelm/testdata/subchart/root/Chart.lock
+++ b/pkg/gotohelm/testdata/subchart/root/Chart.lock
@@ -1,0 +1,12 @@
+dependencies:
+- name: values-overwrite
+  repository: file://../values-overwrite
+  version: 0.0.1
+- name: dependency-included-by-default
+  repository: file://../dependency-included-by-default
+  version: 0.0.1
+- name: dependency-excluded-by-default
+  repository: file://../dependency-excluded-by-default
+  version: 0.0.1
+digest: sha256:55706e25ada265313648f7c2592bbe58b35e699b50561e441c034752f67b3be1
+generated: "2024-10-13T11:55:03.789466+02:00"

--- a/pkg/gotohelm/testdata/subchart/root/Chart.yaml
+++ b/pkg/gotohelm/testdata/subchart/root/Chart.yaml
@@ -1,0 +1,33 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: root-chart-test
+type: application
+version: 0.0.1
+appVersion: v1.0.0
+kubeVersion: ">= 1.25.0-0"
+dependencies:
+  - name: values-overwrite
+    version: 0.0.1
+    repository: "file://../values-overwrite"
+  - name: dependency-included-by-default
+    condition: dependency-included-by-default.enabled-dependency
+    version: 0.0.1
+    repository: "file://../dependency-included-by-default"
+  - name: dependency-excluded-by-default
+    condition: dependency-excluded-by-default.disabled-dependency
+    version: 0.0.1
+    repository: "file://../dependency-excluded-by-default"

--- a/pkg/gotohelm/testdata/subchart/root/input-val.yaml
+++ b/pkg/gotohelm/testdata/subchart/root/input-val.yaml
@@ -1,0 +1,9 @@
+change-me: changed
+value-addition: true
+
+values-overwrite:
+  change-me: changed
+  value-addition: true
+  dependency:
+    change-me: changed
+    value-addition: true

--- a/pkg/gotohelm/testdata/subchart/root/templates/config-map.tpl
+++ b/pkg/gotohelm/testdata/subchart/root/templates/config-map.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: root-chart-test
+data:
+  values: |
+    {{- toYaml .Values | nindent 4 }}

--- a/pkg/gotohelm/testdata/subchart/root/values.yaml
+++ b/pkg/gotohelm/testdata/subchart/root/values.yaml
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+change-me: default
+do-not-change: default
+
+values-overwrite:
+  change-me: root-change-me
+  root-overwrite: root-overwrite
+  root-addition: true
+  dependency:
+    change-me: root-change-me
+    root-overwrite: root-overwrite
+    root-addition: true
+
+dependency-included-by-default:
+  change-me: testing
+  root-overwrite: testing
+  root-addition: true
+
+dependency-excluded-by-default:
+  change-me: testing
+  root-overwrite: testing
+  root-addition: true

--- a/pkg/gotohelm/testdata/subchart/values-overwrite/Chart.lock
+++ b/pkg/gotohelm/testdata/subchart/values-overwrite/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: dependency
+  repository: file://../dependency
+  version: 0.0.1
+digest: sha256:5e098a1292054e12c17bbdedad80dafcd8519bd6ad356f70555f6fa0c06237e9
+generated: "2024-10-12T15:29:47.072287+02:00"

--- a/pkg/gotohelm/testdata/subchart/values-overwrite/Chart.yaml
+++ b/pkg/gotohelm/testdata/subchart/values-overwrite/Chart.yaml
@@ -1,0 +1,26 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v2
+name: values-overwrite
+type: application
+version: 0.0.1
+appVersion: v1.0.0
+kubeVersion: ">= 1.25.0-0"
+dependencies:
+  # This dependency does not have condition intentionally
+  - name: dependency
+    repository: "file://../dependency"
+    version: 0.0.1

--- a/pkg/gotohelm/testdata/subchart/values-overwrite/templates/config-map.tpl
+++ b/pkg/gotohelm/testdata/subchart/values-overwrite/templates/config-map.tpl
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: values-overwrite
+data:
+  values: |
+    {{- toYaml .Values | nindent 4 }}

--- a/pkg/gotohelm/testdata/subchart/values-overwrite/values.yaml
+++ b/pkg/gotohelm/testdata/subchart/values-overwrite/values.yaml
@@ -1,0 +1,23 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+change-me: default
+do-not-change: default
+
+root-overwrite: default
+
+dependency:
+  values-overwrite-addition: true
+  change-me: values-overwrite-change-me


### PR DESCRIPTION
To correctly render objects from root chart along with it's dependency all values needs to be calculated. From each dependency default values could be overwrited by higher level chart or even input values. The condition need to disable not only rendering but the values calculation too.