### PR TITLE
Add option to define auto mount service account token

### DIFF
--- a/charts/connectors/serviceaccount.go
+++ b/charts/connectors/serviceaccount.go
@@ -40,5 +40,6 @@ func ServiceAccount(dot *helmette.Dot) *corev1.ServiceAccount {
 			Name:        ServiceAccountName(dot),
 			Namespace:   dot.Release.Namespace,
 		},
+		AutomountServiceAccountToken: values.ServiceAccount.AutomountServiceAccountToken,
 	}
 }

--- a/charts/connectors/templates/_serviceaccount.go.tpl
+++ b/charts/connectors/templates/_serviceaccount.go.tpl
@@ -11,7 +11,7 @@
 {{- break -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "ServiceAccount" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "annotations" $values.serviceAccount.annotations "labels" (get (fromJson (include "connectors.FullLabels" (dict "a" (list $dot) ))) "r") "name" (get (fromJson (include "connectors.ServiceAccountName" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace )) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "ServiceAccount" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "annotations" $values.serviceAccount.annotations "labels" (get (fromJson (include "connectors.FullLabels" (dict "a" (list $dot) ))) "r") "name" (get (fromJson (include "connectors.ServiceAccountName" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace )) "automountServiceAccountToken" $values.serviceAccount.automountServiceAccountToken ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/connectors/testdata/template-cases.golden.txtar
+++ b/charts/connectors/testdata/template-cases.golden.txtar
@@ -408,6 +408,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -1210,6 +1211,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -1817,6 +1819,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -3622,6 +3625,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -4975,6 +4979,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}
@@ -5026,6 +5031,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -5839,6 +5845,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}
@@ -6161,6 +6168,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -7073,6 +7081,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -7387,6 +7396,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -8097,6 +8107,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}
@@ -8225,6 +8236,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}
@@ -8620,6 +8632,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}
@@ -8708,6 +8721,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}
@@ -8784,6 +8798,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:
@@ -9482,6 +9497,7 @@ spec:
 ---
 # Source: connectors/templates/serviceaccount.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations:

--- a/charts/connectors/values.go
+++ b/charts/connectors/values.go
@@ -193,9 +193,10 @@ type Storage struct {
 }
 
 type ServiceAccountConfig struct {
-	Create      bool              `json:"create"`
-	Annotations map[string]string `json:"annotations"`
-	Name        string            `json:"name"`
+	Annotations                  map[string]string `json:"annotations"`
+	AutomountServiceAccountToken *bool             `json:"automountServiceAccountToken,omitempty"`
+	Create                       bool              `json:"create"`
+	Name                         string            `json:"name"`
 }
 
 type ServiceConfig struct {

--- a/charts/connectors/values_partial.gen.go
+++ b/charts/connectors/values_partial.gen.go
@@ -125,9 +125,10 @@ type PartialStorage struct {
 }
 
 type PartialServiceAccountConfig struct {
-	Create      *bool             "json:\"create,omitempty\""
-	Annotations map[string]string "json:\"annotations,omitempty\""
-	Name        *string           "json:\"name,omitempty\""
+	Annotations                  map[string]string "json:\"annotations,omitempty\""
+	AutomountServiceAccountToken *bool             "json:\"automountServiceAccountToken,omitempty\""
+	Create                       *bool             "json:\"create,omitempty\""
+	Name                         *string           "json:\"name,omitempty\""
 }
 
 type PartialServiceConfig struct {

--- a/charts/redpanda/serviceaccount.go
+++ b/charts/redpanda/serviceaccount.go
@@ -40,5 +40,6 @@ func ServiceAccount(dot *helmette.Dot) *corev1.ServiceAccount {
 			Labels:      FullLabels(dot),
 			Annotations: values.ServiceAccount.Annotations,
 		},
+		AutomountServiceAccountToken: values.ServiceAccount.AutomountServiceAccountToken,
 	}
 }

--- a/charts/redpanda/templates/_serviceaccount.go.tpl
+++ b/charts/redpanda/templates/_serviceaccount.go.tpl
@@ -11,7 +11,7 @@
 {{- break -}}
 {{- end -}}
 {{- $_is_returning = true -}}
-{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "ServiceAccount" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (get (fromJson (include "redpanda.ServiceAccountName" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "annotations" $values.serviceAccount.annotations )) ))) | toJson -}}
+{{- (dict "r" (mustMergeOverwrite (dict "metadata" (dict "creationTimestamp" (coalesce nil) ) ) (mustMergeOverwrite (dict ) (dict "apiVersion" "v1" "kind" "ServiceAccount" )) (dict "metadata" (mustMergeOverwrite (dict "creationTimestamp" (coalesce nil) ) (dict "name" (get (fromJson (include "redpanda.ServiceAccountName" (dict "a" (list $dot) ))) "r") "namespace" $dot.Release.Namespace "labels" (get (fromJson (include "redpanda.FullLabels" (dict "a" (list $dot) ))) "r") "annotations" $values.serviceAccount.annotations )) "automountServiceAccountToken" $values.serviceAccount.automountServiceAccountToken ))) | toJson -}}
 {{- break -}}
 {{- end -}}
 {{- end -}}

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -6632,6 +6632,7 @@ metadata:
 ---
 # Source: redpanda/templates/entry-point.yaml
 apiVersion: v1
+automountServiceAccountToken: null
 kind: ServiceAccount
 metadata:
   annotations: {}

--- a/charts/redpanda/values.go
+++ b/charts/redpanda/values.go
@@ -675,9 +675,10 @@ func (Statefulset) JSONSchemaExtend(schema *jsonschema.Schema) {
 }
 
 type ServiceAccountCfg struct {
-	Create      bool              `json:"create" jsonschema:"required"`
-	Name        string            `json:"name" jsonschema:"required"`
-	Annotations map[string]string `json:"annotations" jsonschema:"required"`
+	Annotations                  map[string]string `json:"annotations" jsonschema:"required"`
+	AutomountServiceAccountToken *bool             `json:"automountServiceAccountToken,omitempty"`
+	Create                       bool              `json:"create" jsonschema:"required"`
+	Name                         string            `json:"name" jsonschema:"required"`
 }
 
 type RBAC struct {

--- a/charts/redpanda/values.schema.json
+++ b/charts/redpanda/values.schema.json
@@ -4327,6 +4327,9 @@
           },
           "type": "object"
         },
+        "automountServiceAccountToken": {
+          "type": "boolean"
+        },
         "create": {
           "type": "boolean"
         },
@@ -4335,9 +4338,9 @@
         }
       },
       "required": [
+        "annotations",
         "create",
-        "name",
-        "annotations"
+        "name"
       ],
       "type": "object"
     },

--- a/charts/redpanda/values_partial.gen.go
+++ b/charts/redpanda/values_partial.gen.go
@@ -298,9 +298,10 @@ type PartialStatefulset struct {
 }
 
 type PartialServiceAccountCfg struct {
-	Create      *bool             "json:\"create,omitempty\" jsonschema:\"required\""
-	Name        *string           "json:\"name,omitempty\" jsonschema:\"required\""
-	Annotations map[string]string "json:\"annotations,omitempty\" jsonschema:\"required\""
+	Annotations                  map[string]string "json:\"annotations,omitempty\" jsonschema:\"required\""
+	AutomountServiceAccountToken *bool             "json:\"automountServiceAccountToken,omitempty\""
+	Create                       *bool             "json:\"create,omitempty\" jsonschema:\"required\""
+	Name                         *string           "json:\"name,omitempty\" jsonschema:\"required\""
 }
 
 type PartialRBAC struct {


### PR DESCRIPTION
Similarly to console and operator helm chart the values provides option to define auto mount boolean.

https://github.com/redpanda-data/helm-charts/issues/1525 [K8S-360]

[K8S-360]: https://redpandadata.atlassian.net/browse/K8S-360?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ