### PR TITLE
gotohelm: don't transpile in `init()`

### DIFF
--- a/pkg/gotohelm/bootstrap.go
+++ b/pkg/gotohelm/bootstrap.go
@@ -5,19 +5,9 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sync"
 
 	"golang.org/x/tools/go/packages"
-)
-
-var (
-	// bootstrapGo is the internal/bootstrap package but embedded so it can be
-	// transpiled on the fly.
-	//go:embed internal/bootstrap/*.go
-	bootstrapGo embed.FS
-
-	// shims the source [File] of _shims.tpl. It's set by the init function in
-	// bootstrap.go.
-	shims *File
 )
 
 // renderManifest is a helper function to call and render the results of a
@@ -49,41 +39,62 @@ const renderManifest = `{{- define "_shims.render-manifest" -}}
 {{- end -}}
 `
 
-func init() {
-	// Oh yes. We transpile the bootstrap package when this package is first
-	// loaded to generate _shims.tpl. It's a weird process but removes any
+// bootstrapGo is the internal/bootstrap package but embedded so it can be
+// transpiled on the fly.
+//
+//go:embed internal/bootstrap/*.go
+var bootstrapGo embed.FS
+
+// transpileBootstrap transpiles the internal/bootstrap package of gotohelm on
+// the fly with the notable exception that it does not kickoff the
+// transpilation of the bootstrap package.
+//
+// It is wrapped in a [sync.OnceValues] to amortize any follow up calls.
+var transpileBootstrap = sync.OnceValues(func() (*File, error) {
+	// NB: Transpilation is ON DEMAND. Not in init().
+	// This allows other packages/binaries to import gotohelm without needing
+	// to have the `go` binary available (packages.Load shells out to `go
+	// list`).
+	// In the future, it may make more sense to artificially inject the
+	// bootstrap package's files via an overlay rather than making it a
+	// separate build step or something of that nature. For now,
+	// sync.OnceValues is an okay middle ground.
+
+	// Otherwise, yep, we transpile the bootstrap package on the fly.
+	//
+	// It's a weird process but removes any
 	// possibility of things getting out of sync.
 	dir, _ := os.Getwd()
 
-	// First, we always bind Dir to the working directory. It could be any
-	// directory as we really just need absolute paths.
-	// bootstrapGo is turned into an Overlay such that files get loaded from it
-	// instead of go trying to find the package on disk.
-	// The bootstrap package MUST NOT load any 3rd party libraries as the
-	// loader will start complaining about the lack of a go.mod.
+	// We can reasonably convince packages.Load to read from the embedded FS.
+	// Though it seems likely this isn't 100% reliable as we always execute
+	// gotohelm from the root of this repository.
 	pkgs, err := LoadPackages(&packages.Config{
 		Dir:     dir,
 		Overlay: fsToOverlay(&bootstrapGo, dir),
 	}, filepath.Join(dir, "internal/bootstrap"))
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	// Then we transpile the loaded package as we would any other.
-	bootstrapChart, err := Transpile(pkgs[0])
+	// We call the private transpile method which doesn't bundle the _shims.tpl
+	// into the final chart.
+	bootstrapChart, err := transpile(pkgs[0])
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
 
-	// The result is then shoved into a global variable so all further calls to
-	// Transpile can make use of our shim/bootstrap layer.
-	shims = bootstrapChart.Files[0]
+	shims := bootstrapChart.Files[0]
 
 	// Attach a foot of helpers written in raw gotpl that can't be expressed in
 	// gotohelm.
 	shims.Footer = renderManifest
-}
 
+	return shims, nil
+})
+
+// fsToOverlay translates an [embed.FS] into a map[string][]byte suitable for
+// use in [packages.Config.Overlay].
 func fsToOverlay(fsys *embed.FS, prefix string) map[string][]byte {
 	overlay := map[string][]byte{}
 	if err := fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {

--- a/pkg/gotohelm/rewrite.go
+++ b/pkg/gotohelm/rewrite.go
@@ -38,9 +38,9 @@ var rewrites = []astRewrite{
 // If need be, the rewritten files can also be dumped to disk and have assertions made
 func LoadPackages(cfg *packages.Config, patterns ...string) ([]*packages.Package, error) {
 	// Ensure we're getting all the values we need (which is pretty much everything...)
-	cfg.Mode |= packages.NeedName | packages.NeedFiles | packages.NeedCompiledGoFiles | packages.NeedImports |
-		packages.NeedTypes | packages.NeedTypesSizes | packages.NeedSyntax | packages.NeedTypesInfo |
-		packages.NeedDeps | packages.NeedModule
+	cfg.Mode |= packages.NeedName | packages.NeedFiles | packages.NeedImports |
+		packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo |
+		packages.NeedDeps
 
 	pkgs, err := packages.Load(cfg, patterns...)
 	if err != nil {


### PR DESCRIPTION
Prior to this commit gotohelm could not safely be imported in other packages/binaries (namely the operator). This was due to gotohelm's init function calling `packages.Load` which delegates to `go list` which may not exist (e.g. in distroless) or be readily executable (e.g. with read-only file systems).

This commit moves the transpilation of the bootstrap package into a lazy operation which is only invoked by the transpiler. Doing so will allow other packages/binaries to consume charts in the form of `gotohelm.GoChart` without needing to worry about the transpiler.