### PR TITLE
redpanda: export `Types`

### DIFF
--- a/charts/redpanda/chart.go
+++ b/charts/redpanda/chart.go
@@ -26,6 +26,13 @@ import (
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm"
 	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
 	"github.com/redpanda-data/helm-charts/pkg/kube"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 )
@@ -44,6 +51,32 @@ var (
 	// Chart is the go version of the redpanda helm chart.
 	Chart = gotohelm.MustLoad(chartYAML, defaultValuesYAML, render, console.Chart, connectors.Chart)
 )
+
+// Types returns a slice containing the set of all [kube.Object] types that
+// could be returned by the redpanda chart.
+// +gotohelm:ignore=true
+func Types() []kube.Object {
+	return []kube.Object{
+		&appsv1.Deployment{},
+		&appsv1.StatefulSet{},
+		&autoscalingv2.HorizontalPodAutoscaler{},
+		&batchv1.Job{},
+		&certmanagerv1.Certificate{},
+		&certmanagerv1.Issuer{},
+		&corev1.ConfigMap{},
+		&corev1.Secret{},
+		&corev1.ServiceAccount{},
+		&corev1.Service{},
+		&monitoringv1.PodMonitor{},
+		&monitoringv1.ServiceMonitor{},
+		&networkingv1.Ingress{},
+		&policyv1.PodDisruptionBudget{},
+		&rbacv1.ClusterRoleBinding{},
+		&rbacv1.ClusterRole{},
+		&rbacv1.RoleBinding{},
+		&rbacv1.Role{},
+	}
+}
 
 // +gotohelm:ignore=true
 func init() {

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -67860,6 +67860,1789 @@ spec:
         name: base-config
       - emptyDir: {}
         name: config
+-- testdata/TestTemplate/all-possible-objects.yaml.golden --
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda
+  namespace: default
+spec:
+  maxUnavailable: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: redpanda
+      redpanda.com/poddisruptionbudget: redpanda
+---
+# Source: redpanda/charts/console/templates/entry-point.yaml
+apiVersion: v1
+automountServiceAccountToken: true
+kind: ServiceAccount
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  name: redpanda-console
+  namespace: default
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-sts-lifecycle
+  namespace: default
+stringData:
+  common.sh: |-
+    #!/usr/bin/env bash
+
+    # the SERVICE_NAME comes from the metadata.name of the pod, essentially the POD_NAME
+    CURL_URL="https://${SERVICE_NAME}.redpanda.default.svc.cluster.local:9644"
+
+    # commands used throughout
+    CURL_NODE_ID_CMD="curl --silent --fail --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/node_config"
+
+    CURL_MAINTENANCE_DELETE_CMD_PREFIX='curl -X DELETE --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_PUT_CMD_PREFIX='curl -X PUT --silent -o /dev/null -w "%{http_code}"'
+    CURL_MAINTENANCE_GET_CMD="curl -X GET --silent --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/maintenance"
+  postStart.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    postStartHook () {
+      set -x
+
+      touch /tmp/postStartHookStarted
+
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Clearing maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_DELETE_CMD="${CURL_MAINTENANCE_DELETE_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      # a 400 here would mean not in maintenance mode
+      until [ "${status:-}" = '"200"' ] || [ "${status:-}" = '"400"' ]; do
+          status=$(${CURL_MAINTENANCE_DELETE_CMD})
+          sleep 0.5
+      done
+
+      touch /tmp/postStartHookFinished
+    }
+
+    postStartHook
+    true
+  preStop.sh: |-
+    #!/usr/bin/env bash
+    # This code should be similar if not exactly the same as that found in the panda-operator, see
+    # https://github.com/redpanda-data/redpanda/blob/e51d5b7f2ef76d5160ca01b8c7a8cf07593d29b6/src/go/k8s/pkg/resources/secret.go
+
+    touch /tmp/preStopHookStarted
+
+    # path below should match the path defined on the statefulset
+    source /var/lifecycle/common.sh
+
+    set -x
+
+    preStopHook () {
+      until NODE_ID=$(${CURL_NODE_ID_CMD} | grep -o '\"node_id\":[^,}]*' | grep -o '[^: ]*$'); do
+          sleep 0.5
+      done
+
+      echo "Setting maintenance mode on node ${NODE_ID}"
+      CURL_MAINTENANCE_PUT_CMD="${CURL_MAINTENANCE_PUT_CMD_PREFIX} --cacert /etc/tls/certs/default/ca.crt ${CURL_URL}/v1/brokers/${NODE_ID}/maintenance"
+      until [ "${status:-}" = '"200"' ]; do
+          status=$(${CURL_MAINTENANCE_PUT_CMD})
+          sleep 0.5
+      done
+
+      until [ "${finished:-}" = "true" ] || [ "${draining:-}" = "false" ]; do
+          res=$(${CURL_MAINTENANCE_GET_CMD})
+          finished=$(echo $res | grep -o '\"finished\":[^,}]*' | grep -o '[^: ]*$')
+          draining=$(echo $res | grep -o '\"draining\":[^,}]*' | grep -o '[^: ]*$')
+          sleep 0.5
+      done
+
+      touch /tmp/preStopHookFinished
+    }
+    preStopHook
+    true
+type: Opaque
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-config-watcher
+  namespace: default
+stringData:
+  sasl-user.sh: |-
+    #!/usr/bin/env bash
+
+    trap 'error_handler $? $LINENO' ERR
+
+    error_handler() {
+      echo "Error: ($1) occurred at line $2"
+    }
+
+    set -e
+
+    # rpk cluster health can exit non-zero if it's unable to dial brokers. This
+    # can happen for many reasons but we never want this script to crash as it
+    # would take down yet another broker and make a bad situation worse.
+    # Instead, just wait for the command to eventually exit zero.
+    echo "Waiting for cluster to be ready"
+    until rpk cluster health --watch --exit-when-healthy; do
+      echo "rpk cluster health failed. Waiting 5 seconds before trying again..."
+      sleep 5
+    done
+    echo "Nothing to do. Sleeping..."
+    sleep infinity
+type: Opaque
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-configurator
+  namespace: default
+stringData:
+  configurator.sh: |-
+    set -xe
+    SERVICE_NAME=$1
+    KUBERNETES_NODE_NAME=$2
+    POD_ORDINAL=${SERVICE_NAME##*-}
+    BROKER_INDEX=`expr $POD_ORDINAL + 1`
+
+    CONFIG=/etc/redpanda/redpanda.yaml
+
+    # Setup config files
+    cp /tmp/base-config/redpanda.yaml "${CONFIG}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":9093}"
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[0] "$LISTENER"
+
+    ADVERTISED_KAFKA_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_KAFKA_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":31092}")
+
+    rpk redpanda config --config "$CONFIG" set redpanda.advertised_kafka_api[1] "${ADVERTISED_KAFKA_ADDRESSES[$POD_ORDINAL]}"
+
+    LISTENER="{\"address\":\"${SERVICE_NAME}.redpanda.default.svc.cluster.local.\",\"name\":\"internal\",\"port\":8082}"
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[0] "$LISTENER"
+
+    ADVERTISED_HTTP_ADDRESSES=()
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    PREFIX_TEMPLATE=""
+    ADVERTISED_HTTP_ADDRESSES+=("{\"address\":\"${SERVICE_NAME}\",\"name\":\"default\",\"port\":30082}")
+
+    rpk redpanda config --config "$CONFIG" set pandaproxy.advertised_pandaproxy_api[1] "${ADVERTISED_HTTP_ADDRESSES[$POD_ORDINAL]}"
+type: Opaque
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+data:
+  bootstrap.yaml: |-
+    audit_enabled: false
+    cloud_storage_cache_size: 5368709120
+    cloud_storage_enable_remote_read: true
+    cloud_storage_enable_remote_write: true
+    cloud_storage_enabled: false
+    compacted_log_segment_size: 67108864
+    default_topic_replications: 3
+    enable_rack_awareness: false
+    enable_sasl: false
+    kafka_connection_rate_limit: 1000
+    kafka_enable_authorization: false
+    log_segment_size_max: 268435456
+    log_segment_size_min: 16777216
+    max_compacted_log_segment_size: 536870912
+    storage_min_free_bytes: 1073741824
+  redpanda.yaml: |-
+    config_file: /etc/redpanda/redpanda.yaml
+    pandaproxy:
+      pandaproxy_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8082
+      - address: 0.0.0.0
+        name: default
+        port: 8083
+      pandaproxy_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    pandaproxy_client:
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+    redpanda:
+      admin:
+      - address: 0.0.0.0
+        name: internal
+        port: 9644
+      - address: 0.0.0.0
+        name: default
+        port: 9645
+      admin_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      crash_loop_limit: 5
+      empty_seed_starts_cluster: false
+      kafka_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 9093
+      - address: 0.0.0.0
+        name: default
+        port: 9094
+      kafka_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+      rpc_server:
+        address: 0.0.0.0
+        port: 33145
+      rpc_server_tls:
+        cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      seed_servers:
+      - host:
+          address: redpanda-0.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-1.redpanda.default.svc.cluster.local.
+          port: 33145
+      - host:
+          address: redpanda-2.redpanda.default.svc.cluster.local.
+          port: 33145
+    rpk:
+      additional_start_flags:
+      - --default-log-level=info
+      - --memory=2048M
+      - --reserve-memory=205M
+      - --smp=1
+      admin_api:
+        addresses:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9644
+        - redpanda-1.redpanda.default.svc.cluster.local.:9644
+        - redpanda-2.redpanda.default.svc.cluster.local.:9644
+        tls:
+          ca_file: /etc/tls/certs/default/ca.crt
+      enable_memory_locking: false
+      kafka_api:
+        brokers:
+        - redpanda-0.redpanda.default.svc.cluster.local.:9093
+        - redpanda-1.redpanda.default.svc.cluster.local.:9093
+        - redpanda-2.redpanda.default.svc.cluster.local.:9093
+        tls:
+          ca_file: /etc/tls/certs/default/ca.crt
+      overprovisioned: false
+      tune_aio_events: true
+    schema_registry:
+      schema_registry_api:
+      - address: 0.0.0.0
+        name: internal
+        port: 8081
+      - address: 0.0.0.0
+        name: default
+        port: 8084
+      schema_registry_api_tls:
+      - cert_file: /etc/tls/certs/default/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/default/tls.key
+        name: internal
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      - cert_file: /etc/tls/certs/external/tls.crt
+        enabled: true
+        key_file: /etc/tls/certs/external/tls.key
+        name: default
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/external/ca.crt
+    schema_registry_client:
+      broker_tls:
+        enabled: true
+        require_client_auth: false
+        truststore_file: /etc/tls/certs/default/ca.crt
+      brokers:
+      - address: redpanda-0.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-1.redpanda.default.svc.cluster.local.
+        port: 9093
+      - address: redpanda-2.redpanda.default.svc.cluster.local.
+        port: 9093
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda
+  namespace: default
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+data:
+  profile: |-
+    admin_api:
+      addresses:
+      - redpanda-0:31644
+      - redpanda-1:31644
+      - redpanda-2:31644
+      tls:
+        ca_file: ca.crt
+    kafka_api:
+      brokers:
+      - redpanda-0:31092
+      - redpanda-1:31092
+      - redpanda-2:31092
+      tls:
+        ca_file: ca.crt
+    name: default
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-rpk
+  namespace: default
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+data:
+  config.yaml: |
+    # from .Values.console.config
+    connect:
+      clusters:
+      - name: connectors
+        password: ""
+        tls:
+          caFilepath: ""
+          certFilepath: ""
+          enabled: false
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        token: ""
+        url: http://redpanda-connectors.default.svc.cluster.local:8083
+        username: ""
+      connectTimeout: 0
+      enabled: true
+      readTimeout: 0
+      requestTimeout: 0
+    kafka:
+      brokers:
+      - redpanda-0.redpanda.default.svc.cluster.local.:9093
+      - redpanda-1.redpanda.default.svc.cluster.local.:9093
+      - redpanda-2.redpanda.default.svc.cluster.local.:9093
+      sasl:
+        enabled: false
+      schemaRegistry:
+        enabled: true
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://redpanda-0.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-1.redpanda.default.svc.cluster.local.:8081
+        - https://redpanda-2.redpanda.default.svc.cluster.local.:8081
+      tls:
+        caFilepath: /etc/tls/certs/default/ca.crt
+        certFilepath: ""
+        enabled: true
+        insecureSkipTlsVerify: false
+        keyFilepath: ""
+    redpanda:
+      adminApi:
+        enabled: true
+        tls:
+          caFilepath: /etc/tls/certs/default/ca.crt
+          certFilepath: ""
+          enabled: true
+          insecureSkipTlsVerify: false
+          keyFilepath: ""
+        urls:
+        - https://redpanda.default.svc.cluster.local.:9644
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  name: redpanda-console
+---
+# Source: redpanda/charts/connectors/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: connectors
+    helm.sh/chart: connectors-0.1.13
+  name: redpanda-connectors
+spec:
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  ports:
+  - name: rest-api
+    port: 8083
+    protocol: TCP
+    targetPort: 8083
+  - name: prometheus
+    port: 9404
+    protocol: TCP
+    targetPort: 9404
+  selector:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: connectors
+  sessionAffinity: None
+  type: ClusterIP
+---
+# Source: redpanda/charts/console/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  name: redpanda-console
+  namespace: default
+spec:
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 0
+  selector:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: console
+  type: ClusterIP
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-external
+  namespace: default
+spec:
+  externalTrafficPolicy: Local
+  ports:
+  - name: admin-default
+    nodePort: 31644
+    port: 9645
+    protocol: TCP
+    targetPort: 0
+  - name: kafka-default
+    nodePort: 31092
+    port: 9094
+    protocol: TCP
+    targetPort: 0
+  - name: http-default
+    nodePort: 30082
+    port: 8083
+    protocol: TCP
+    targetPort: 0
+  - name: schema-default
+    nodePort: 30081
+    port: 8084
+    protocol: TCP
+    targetPort: 0
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: redpanda-statefulset
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: redpanda
+  sessionAffinity: None
+  type: NodePort
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+    monitoring.redpanda.com/enabled: "false"
+  name: redpanda
+  namespace: default
+spec:
+  clusterIP: None
+  ports:
+  - appProtocol: null
+    name: admin
+    port: 9644
+    protocol: TCP
+    targetPort: 9644
+  - name: http
+    port: 8082
+    protocol: TCP
+    targetPort: 8082
+  - name: kafka
+    port: 9093
+    protocol: TCP
+    targetPort: 9093
+  - name: rpc
+    port: 33145
+    protocol: TCP
+    targetPort: 33145
+  - name: schemaregistry
+    port: 8081
+    protocol: TCP
+    targetPort: 8081
+  publishNotReadyAddresses: true
+  selector:
+    app.kubernetes.io/component: redpanda-statefulset
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/name: redpanda
+  type: ClusterIP
+---
+# Source: redpanda/templates/connectors/connectors.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: connectors
+    helm.sh/chart: connectors-0.1.13
+  name: redpanda-connectors
+spec:
+  progressDeadlineSeconds: 600
+  replicas: null
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: connectors
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: connectors
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: connectors
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: connectors
+    spec:
+      affinity:
+        nodeAffinity: {}
+        podAffinity: {}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: connectors
+                app.kubernetes.io/instance: redpanda
+                app.kubernetes.io/name: connectors
+            namespaces:
+            - default
+            topologyKey: kubernetes.io/hostname
+      containers:
+      - command: null
+        env:
+        - name: CONNECT_CONFIGURATION
+          value: |-
+            rest.advertised.port=8083
+            rest.port=8083
+            key.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+            value.converter=org.apache.kafka.connect.converters.ByteArrayConverter
+            group.id=connectors-cluster
+            offset.storage.topic=_internal_connectors_offsets
+            config.storage.topic=_internal_connectors_configs
+            status.storage.topic=_internal_connectors_status
+            offset.storage.redpanda.remote.read=false
+            offset.storage.redpanda.remote.write=false
+            config.storage.redpanda.remote.read=false
+            config.storage.redpanda.remote.write=false
+            status.storage.redpanda.remote.read=false
+            status.storage.redpanda.remote.write=false
+            offset.storage.replication.factor=-1
+            config.storage.replication.factor=-1
+            status.storage.replication.factor=-1
+            producer.linger.ms=1
+            producer.batch.size=131072
+            config.providers=file,secretsManager,env
+            config.providers.file.class=org.apache.kafka.common.config.provider.FileConfigProvider
+            config.providers.env.class=org.apache.kafka.common.config.provider.EnvVarConfigProvider
+        - name: CONNECT_ADDITIONAL_CONFIGURATION
+          value: ""
+        - name: CONNECT_BOOTSTRAP_SERVERS
+          value: redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093
+        - name: CONNECT_GC_LOG_ENABLED
+          value: "false"
+        - name: CONNECT_HEAP_OPTS
+          value: -Xms256M -Xmx2G
+        - name: CONNECT_LOG_LEVEL
+          value: warn
+        - name: CONNECT_TLS_ENABLED
+          value: "true"
+        - name: CONNECT_TRUSTED_CERTS
+          value: ca/ca.crt
+        envFrom: []
+        image: docker.redpanda.com/redpandadata/connectors:v1.0.31
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /
+            port: rest-api
+            scheme: HTTP
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: connectors-cluster
+        ports:
+        - containerPort: 8083
+          name: rest-api
+          protocol: TCP
+        - containerPort: 9404
+          name: prometheus
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 2
+          httpGet:
+            path: /connectors
+            port: rest-api
+            scheme: HTTP
+          initialDelaySeconds: 60
+          periodSeconds: 10
+          successThreshold: 3
+          timeoutSeconds: 5
+        resources:
+          limits:
+            cpu: "1"
+            memory: 2350Mi
+          requests:
+            cpu: "1"
+            memory: 2350Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /opt/kafka/connect-certs/ca
+          name: truststore
+        - mountPath: /tmp
+          name: rp-connect-tmp
+      dnsPolicy: ClusterFirst
+      imagePullSecrets: []
+      nodeSelector: {}
+      restartPolicy: Always
+      schedulerName: ""
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+        runAsUser: 101
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 30
+      tolerations: []
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: connectors
+            app.kubernetes.io/instance: redpanda
+            app.kubernetes.io/name: connectors
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: truststore
+        secret:
+          defaultMode: 292
+          secretName: redpanda-default-cert
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 5Mi
+        name: rp-connect-tmp
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  name: redpanda-console
+  namespace: default
+spec:
+  replicas: null
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: console
+  strategy: {}
+  template:
+    metadata:
+      annotations:
+        checksum-redpanda-chart/config: 71a88dc7a5147c97b5b7f51931035e1aa62cdceb27860879d1681e5b80d057fe
+        checksum/config: 71a88dc7a5147c97b5b7f51931035e1aa62cdceb27860879d1681e5b80d057fe
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: console
+    spec:
+      affinity: {}
+      automountServiceAccountToken: true
+      containers:
+      - args:
+        - --config.filepath=/etc/console/configs/config.yaml
+        command: null
+        env: []
+        envFrom: []
+        image: docker.redpanda.com/redpandadata/console:v2.7.2
+        imagePullPolicy: IfNotPresent
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /admin/health
+            port: http
+          initialDelaySeconds: 0
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        name: console
+        ports:
+        - containerPort: 8080
+          name: http
+          protocol: TCP
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /admin/health
+            port: http
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+        resources: {}
+        securityContext:
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /etc/console/configs
+          name: configs
+          readOnly: true
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+      imagePullSecrets: []
+      initContainers: null
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        fsGroup: 99
+        runAsUser: 99
+      serviceAccountName: redpanda-console
+      tolerations: []
+      topologySpreadConstraints: []
+      volumes:
+      - configMap:
+          name: redpanda-console
+        name: configs
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 272
+          secretName: redpanda-default-cert
+---
+# Source: redpanda/charts/console/templates/entry-point.yaml
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  name: redpanda-console
+spec:
+  maxReplicas: 100
+  metrics:
+  - resource:
+      name: cpu
+      target:
+        averageUtilization: 80
+        type: Utilization
+    type: Resource
+  minReplicas: 1
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: redpanda-console
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda
+  namespace: default
+spec:
+  podManagementPolicy: Parallel
+  replicas: 3
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: redpanda-statefulset
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: redpanda
+  serviceName: redpanda
+  template:
+    metadata:
+      annotations:
+        config.redpanda.com/checksum: d696a04723a2d2ab62276a5d6a0edc91462858e405794bedd5051e062efea3c4
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda-statefulset
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: redpanda
+        helm.sh/chart: redpanda-5.9.9
+        redpanda.com/poddisruptionbudget: redpanda
+    spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                app.kubernetes.io/component: redpanda-statefulset
+                app.kubernetes.io/instance: redpanda
+                app.kubernetes.io/name: redpanda
+            topologyKey: kubernetes.io/hostname
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - rpk
+        - redpanda
+        - start
+        - --advertise-rpc-addr=$(SERVICE_NAME).redpanda.default.svc.cluster.local.:33145
+        env:
+        - name: SERVICE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.7
+        lifecycle:
+          postStart:
+            exec:
+              command:
+              - bash
+              - -c
+              - 'timeout -v 45 bash -x /var/lifecycle/postStart.sh 2>&1 | sed "s/^/lifecycle-hook
+                post-start $(date): /" | tee /proc/1/fd/1; true'
+          preStop:
+            exec:
+              command:
+              - bash
+              - -c
+              - 'timeout -v 45 bash -x /var/lifecycle/preStop.sh 2>&1 | sed "s/^/lifecycle-hook
+                pre-stop $(date): /" | tee /proc/1/fd/1; true'
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt
+              "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready"
+          failureThreshold: 3
+          initialDelaySeconds: 10
+          periodSeconds: 10
+        name: redpanda
+        ports:
+        - containerPort: 9644
+          name: admin
+        - containerPort: 9645
+          name: admin-default
+        - containerPort: 8082
+          name: http
+        - containerPort: 8083
+          name: http-default
+        - containerPort: 9093
+          name: kafka
+        - containerPort: 9094
+          name: kafka-default
+        - containerPort: 33145
+          name: rpc
+        - containerPort: 8081
+          name: schemaregistry
+        - containerPort: 8084
+          name: schema-default
+        readinessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -x
+              RESULT=$(rpk cluster health)
+              echo $RESULT
+              echo $RESULT | grep 'Healthy:.*true'
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 0
+        resources:
+          limits:
+            cpu: 1
+            memory: 2.5Gi
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        startupProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              set -e
+              RESULT=$(curl --silent --fail -k -m 5 --cacert /etc/tls/certs/default/ca.crt "https://${SERVICE_NAME}.redpanda.default.svc.cluster.local.:9644/v1/status/ready")
+              echo $RESULT
+              echo $RESULT | grep ready
+          failureThreshold: 120
+          initialDelaySeconds: 1
+          periodSeconds: 10
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /tmp/base-config
+          name: base-config
+        - mountPath: /var/lifecycle
+          name: lifecycle-scripts
+        - mountPath: /var/lib/redpanda/data
+          name: datadir
+      - args:
+        - -c
+        - trap "exit 0" TERM; exec /etc/secrets/config-watcher/scripts/sasl-user.sh
+          & wait $!
+        command:
+        - /bin/sh
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.7
+        name: config-watcher
+        resources: {}
+        securityContext: {}
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /etc/secrets/config-watcher/scripts
+          name: redpanda-config-watcher
+      imagePullSecrets: null
+      initContainers:
+      - command:
+        - /bin/bash
+        - -c
+        - rpk redpanda tune all
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.7
+        name: tuning
+        resources: {}
+        securityContext:
+          capabilities:
+            add:
+            - SYS_RESOURCE
+          privileged: true
+          runAsGroup: 0
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: base-config
+      - command:
+        - /bin/bash
+        - -c
+        - trap "exit 0" TERM; exec $CONFIGURATOR_SCRIPT "${SERVICE_NAME}" "${KUBERNETES_NODE_NAME}"
+          & wait $!
+        env:
+        - name: CONFIGURATOR_SCRIPT
+          value: /etc/secrets/configurator/scripts/configurator.sh
+        - name: SERVICE_NAME
+          valueFrom:
+            configMapKeyRef: null
+            fieldRef:
+              fieldPath: metadata.name
+            resourceFieldRef: null
+            secretKeyRef: null
+        - name: KUBERNETES_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: HOST_IP_ADDRESS
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: status.hostIP
+        image: docker.redpanda.com/redpandadata/redpanda:v24.2.7
+        name: redpanda-configurator
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: null
+          runAsGroup: 101
+          runAsNonRoot: null
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /etc/redpanda
+          name: config
+        - mountPath: /tmp/base-config
+          name: base-config
+        - mountPath: /etc/secrets/configurator/scripts/
+          name: redpanda-configurator
+      - command:
+        - /redpanda-operator
+        - envsubst
+        - /tmp/base-config/bootstrap.yaml
+        - --output
+        - /tmp/config/.bootstrap.yaml
+        env: null
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v2.2.5-24.2.7
+        name: bootstrap-yaml-envsubst
+        resources:
+          limits:
+            cpu: 100m
+            memory: 125Mi
+          requests:
+            cpu: 100m
+            memory: 125Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /tmp/config/
+          name: config
+        - mountPath: /tmp/base-config/
+          name: base-config
+      nodeSelector: {}
+      priorityClassName: ""
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      terminationGracePeriodSeconds: 90
+      tolerations: []
+      topologySpreadConstraints:
+      - labelSelector:
+          matchLabels:
+            app.kubernetes.io/component: redpanda-statefulset
+            app.kubernetes.io/instance: redpanda
+            app.kubernetes.io/name: redpanda
+        maxSkew: 1
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      volumes:
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - name: lifecycle-scripts
+        secret:
+          defaultMode: 509
+          secretName: redpanda-sts-lifecycle
+      - configMap:
+          name: redpanda
+        name: base-config
+      - emptyDir: {}
+        name: config
+      - name: redpanda-configurator
+        secret:
+          defaultMode: 509
+          secretName: redpanda-configurator
+      - name: redpanda-config-watcher
+        secret:
+          defaultMode: 509
+          secretName: redpanda-config-watcher
+      - name: datadir
+        persistentVolumeClaim:
+          claimName: datadir
+  updateStrategy:
+    type: RollingUpdate
+  volumeClaimTemplates:
+  - metadata:
+      annotations: null
+      creationTimestamp: null
+      labels:
+        app.kubernetes.io/component: redpanda
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+      name: datadir
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 20Gi
+    status: {}
+---
+# Source: redpanda/charts/console/templates/entry-point.yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  name: redpanda-console
+spec:
+  ingressClassName: null
+  rules:
+  - host: chart-example.local
+    http:
+      paths:
+      - backend:
+          service:
+            name: redpanda-console
+            port:
+              number: 8080
+        path: /
+        pathType: ImplementationSpecific
+  tls: null
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-default-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-default-root-certificate
+  duration: 43800h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-external-root-certificate
+  namespace: default
+spec:
+  commonName: redpanda-external-root-certificate
+  duration: 43800h0m0s
+  isCA: true
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-selfsigned-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-default-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h0m0s
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-default-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-default-cert
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-external-cert
+  namespace: default
+spec:
+  dnsNames:
+  - redpanda-cluster.redpanda.default.svc.cluster.local
+  - redpanda-cluster.redpanda.default.svc
+  - redpanda-cluster.redpanda.default
+  - '*.redpanda-cluster.redpanda.default.svc.cluster.local'
+  - '*.redpanda-cluster.redpanda.default.svc'
+  - '*.redpanda-cluster.redpanda.default'
+  - redpanda.default.svc.cluster.local
+  - redpanda.default.svc
+  - redpanda.default
+  - '*.redpanda.default.svc.cluster.local'
+  - '*.redpanda.default.svc'
+  - '*.redpanda.default'
+  duration: 43800h0m0s
+  isCA: false
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: redpanda-external-root-issuer
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+  secretName: redpanda-external-cert
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-default-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-default-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-default-root-certificate
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-external-selfsigned-issuer
+  namespace: default
+spec:
+  selfSigned: {}
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-external-root-issuer
+  namespace: default
+spec:
+  ca:
+    secretName: redpanda-external-root-certificate
+---
+# Source: redpanda/charts/connectors/templates/pod-monitor.yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  annotations: {}
+  creationTimestamp: null
+  labels: {}
+  name: redpanda-connectors
+spec:
+  namespaceSelector:
+    any: true
+  podMetricsEndpoints:
+  - bearerTokenSecret:
+      key: ""
+    path: /
+    port: prometheus
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: connectors
+      app.kubernetes.io/instance: redpanda
+      app.kubernetes.io/name: connectors
+---
+# Source: redpanda/charts/console/templates/tests/test-connection.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "redpanda-console-test-connection"
+  namespace: "default"
+  labels:
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: console
+    app.kubernetes.io/version: v2.7.2
+    helm.sh/chart: console-0.7.30
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['redpanda-console:8080']
+  restartPolicy: Never
+  priorityClassName:
+---
+# Source: redpanda/templates/connectors/connectors.yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redpanda-connectors-mm2-test
+  namespace: "default"
+  labels:
+    app.kubernetes.io/component: connectors
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: connectors
+    helm.sh/chart: connectors-0.1.13
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  restartPolicy: Never
+  containers:
+    - name: create-mm2
+      image: docker.redpanda.com/redpandadata/redpanda:latest
+      command:
+        - /bin/bash
+        - -c
+        - |
+          set -xe
+
+          trap connectorsState ERR
+
+          connectorsState () {
+            echo check connectors expand status
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors?expand=status
+            echo check connectors expand info
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors?expand=info
+            echo check connector configuration
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors/$CONNECTOR_NAME
+            echo check connector topics
+            curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors/$CONNECTOR_NAME/topics
+          }
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors
+
+          SASL_MECHANISM="PLAIN"
+
+          rpk profile create test
+          rpk profile set tls.enabled=true brokers=redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093
+          rpk profile set tls.ca=/redpanda-certs/ca.crt
+          CONNECT_TLS_ENABLED=true
+          SECURITY_PROTOCOL=PLAINTEXT
+          if [[ -n "$CONNECT_SASL_MECHANISM" && $CONNECT_TLS_ENABLED == "true" ]]; then
+            SECURITY_PROTOCOL="SASL_SSL"
+          elif [[ -n "$CONNECT_SASL_MECHANISM" ]]; then
+            SECURITY_PROTOCOL="SASL_PLAINTEXT"
+          elif [[ $CONNECT_TLS_ENABLED == "true" ]]; then
+            SECURITY_PROTOCOL="SSL"
+          fi
+
+          rpk topic list
+          rpk topic create test-topic
+          rpk topic list
+          echo "Test message!" | rpk topic produce test-topic
+
+          CONNECTOR_NAME=mm2-$RANDOM
+          cat << 'EOF' > /tmp/mm2-conf.json
+          {
+            "name": "CONNECTOR_NAME",
+            "config": {
+              "connector.class": "org.apache.kafka.connect.mirror.MirrorSourceConnector",
+              "topics": "test-topic",
+              "replication.factor": "1",
+              "tasks.max": "1",
+              "source.cluster.bootstrap.servers": "redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093",
+              "target.cluster.bootstrap.servers": "redpanda-0.redpanda.default.svc.cluster.local.:9093,redpanda-1.redpanda.default.svc.cluster.local.:9093,redpanda-2.redpanda.default.svc.cluster.local.:9093",
+              "target.cluster.alias": "test-only",
+              "source.cluster.alias": "source",
+              "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+              "value.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
+              "source->target.enabled": "true",
+              "target->source.enabled": "false",
+              "sync.topic.configs.interval.seconds": "5",
+              "sync.topics.configs.enabled": "true",
+              "source.cluster.ssl.truststore.type": "PEM",
+              "target.cluster.ssl.truststore.type": "PEM",
+              "source.cluster.ssl.truststore.location": "/opt/kafka/connect-certs/ca/ca.crt",
+              "target.cluster.ssl.truststore.location": "/opt/kafka/connect-certs/ca/ca.crt",
+              JAAS_CONFIG_SOURCE
+              JAAS_CONFIG_TARGET
+              "source.cluster.security.protocol": "SECURITY_PROTOCOL",
+              "target.cluster.security.protocol": "SECURITY_PROTOCOL",
+              "source.cluster.sasl.mechanism": "SASL_MECHANISM",
+              "target.cluster.sasl.mechanism": "SASL_MECHANISM",
+              "offset-syncs.topic.replication.factor": 1
+            }
+          }
+          EOF
+
+          sed -i "s/CONNECTOR_NAME/$CONNECTOR_NAME/g" /tmp/mm2-conf.json
+          sed -i "s/SASL_MECHANISM/$SASL_MECHANISM/g" /tmp/mm2-conf.json
+          sed -i "s/SECURITY_PROTOCOL/$SECURITY_PROTOCOL/g" /tmp/mm2-conf.json
+          set +x
+          sed -i "s/JAAS_CONFIG_SOURCE/$JAAS_CONFIG_SOURCE/g" /tmp/mm2-conf.json
+          sed -i "s/JAAS_CONFIG_TARGET/$JAAS_CONFIG_TARGET/g" /tmp/mm2-conf.json
+          set -x
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  -H 'Content-Type: application/json' http://redpanda-connectors:8083/connectors -d @/tmp/mm2-conf.json
+
+          # The rpk topic consume could fail for the first few times as kafka connect needs
+          # to spawn the task and copy one message from the source topic. To solve this race condition
+          # the retry should be implemented in bash for rpk topic consume or other mechanism that
+          # can confirm source connectors started its execution. As a fast fix fixed 30 second fix is added.
+          sleep 30
+
+          rpk topic consume source.test-topic -n 1 | grep "Test message!"
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  -X DELETE http://redpanda-connectors:8083/connectors/$CONNECTOR_NAME
+
+          curl  -svm3 --fail --retry "120" --retry-max-time "120" --retry-all-errors -o - -w "\nstatus=%{http_code} %{redirect_url} size=%{size_download} time=%{time_total} content-type=\"%{content_type}\"\n"  http://redpanda-connectors:8083/connectors
+
+          rpk topic delete test-topic source.test-topic mm2-offset-syncs.test-only.internal
+      volumeMounts:
+        - mountPath: /redpanda-certs
+          name: redpanda-ca
+        - mountPath: /tmp
+          name: rp-connect-tmp
+  volumes:
+    - name: redpanda-ca
+      secret:
+        defaultMode: 0444
+        secretName: redpanda-default-cert
+    - emptyDir:
+        medium: Memory
+        sizeLimit: 5Mi
+      name: rp-connect-tmp
+---
+# Source: redpanda/templates/entry-point.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "-5"
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/component: redpanda
+    app.kubernetes.io/instance: redpanda
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/name: redpanda
+    helm.sh/chart: redpanda-5.9.9
+  name: redpanda-configuration
+  namespace: default
+spec:
+  template:
+    metadata:
+      annotations: {}
+      creationTimestamp: null
+      generateName: redpanda-post-
+      labels:
+        app.kubernetes.io/component: redpanda-post-install
+        app.kubernetes.io/instance: redpanda
+        app.kubernetes.io/name: redpanda
+    spec:
+      affinity: {}
+      automountServiceAccountToken: false
+      containers:
+      - command:
+        - /redpanda-operator
+        - sync-cluster-config
+        - --users-directory
+        - /etc/secrets/users
+        - --redpanda-yaml
+        - /tmp/base-config/redpanda.yaml
+        - --bootstrap-yaml
+        - /tmp/config/.bootstrap.yaml
+        env: []
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v2.2.5-24.2.7
+        name: post-install
+        resources: {}
+        securityContext:
+          runAsGroup: 101
+          runAsUser: 101
+        volumeMounts:
+        - mountPath: /etc/tls/certs/default
+          name: redpanda-default-cert
+        - mountPath: /etc/tls/certs/external
+          name: redpanda-external-cert
+        - mountPath: /tmp/config
+          name: config
+        - mountPath: /tmp/base-config
+          name: base-config
+      imagePullSecrets: null
+      initContainers:
+      - command:
+        - /redpanda-operator
+        - envsubst
+        - /tmp/base-config/bootstrap.yaml
+        - --output
+        - /tmp/config/.bootstrap.yaml
+        env: null
+        image: docker.redpanda.com/redpandadata/redpanda-operator:v2.2.5-24.2.7
+        name: bootstrap-yaml-envsubst
+        resources:
+          limits:
+            cpu: 100m
+            memory: 125Mi
+          requests:
+            cpu: 100m
+            memory: 125Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+        volumeMounts:
+        - mountPath: /tmp/config/
+          name: config
+        - mountPath: /tmp/base-config/
+          name: base-config
+      nodeSelector: {}
+      restartPolicy: Never
+      securityContext:
+        fsGroup: 101
+        fsGroupChangePolicy: OnRootMismatch
+      serviceAccountName: default
+      tolerations: null
+      volumes:
+      - name: redpanda-default-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-default-cert
+      - name: redpanda-external-cert
+        secret:
+          defaultMode: 288
+          secretName: redpanda-external-cert
+      - configMap:
+          name: redpanda
+        name: base-config
+      - emptyDir: {}
+        name: config
 -- testdata/TestTemplate/allowpriviledgeescalation-regression.yaml.golden --
 ---
 # Source: redpanda/templates/entry-point.yaml

--- a/charts/redpanda/testdata/template-cases.txtar
+++ b/charts/redpanda/testdata/template-cases.txtar
@@ -490,3 +490,22 @@ console:
       mountPath: /tmp/role-bindings.yml
       subPath: role-bindings.yml
       readOnly: true
+
+-- all-possible-objects --
+# Enable's all features across redpanda and its subcharts to ensure that every
+# object type possible is present in this test's output for the purpose of
+# keeping redpanda.Types() up to date.
+#
+# ASSERT-NO-ERROR
+# ASSERT-GOLDEN
+console:
+  enabled: true
+  autoscaling:
+    enabled: true
+  ingress:
+    enabled: true
+
+connectors:
+  enabled: true
+  monitoring:
+    enabled: true


### PR DESCRIPTION
This commit adds a `Types` function to the redpanda chart that returns a slice of all possible `kube.Object/runtime.Object/client.Object` implementations that could be returned from various inputs of the redpanda chart.

This function will be utilized by the redpanda operator to aid in garbage collecting objects that have been removed across chart invocations. For example, toggling console on and off will result in a Deployment that needs to be removed.