### PR TITLE
pkg/redpanda: fix `firstUser`

### DIFF
--- a/charts/redpanda/secrets.go
+++ b/charts/redpanda/secrets.go
@@ -26,6 +26,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const DefaultSASLMechanism = "SCRAM-SHA-512"
+
 func Secrets(dot *helmette.Dot) []*corev1.Secret {
 	var secrets []*corev1.Secret
 	secrets = append(secrets, SecretSTSLifecycle(dot))
@@ -314,7 +316,7 @@ func SecretConfigWatcher(dot *helmette.Dot) *corev1.Secret {
 			`        continue`,
 			`      fi`,
 			`      echo "Creating user ${USER_NAME}..."`,
-			fmt.Sprintf(`      MECHANISM=${MECHANISM:-%s}`, helmette.Dig(dot.Values.AsMap(), "SCRAM-SHA-512", "auth", "sasl", "mechanism")),
+			fmt.Sprintf(`      MECHANISM=${MECHANISM:-%s}`, helmette.Dig(dot.Values.AsMap(), DefaultSASLMechanism, "auth", "sasl", "mechanism")),
 			`      creation_result=$(rpk acl user create ${USER_NAME} -p ${PASSWORD} --mechanism ${MECHANISM} 2>&1) && creation_result_exit_code=$? || creation_result_exit_code=$?  # On a non-success exit code`,
 			`      if [[ $creation_result_exit_code -ne 0 ]]; then`,
 			`        # Check if the stderr contains "User already exists"`,

--- a/pkg/redpanda/client.go
+++ b/pkg/redpanda/client.go
@@ -314,16 +314,21 @@ func firstUser(data []byte) (user string, password string, mechanism string) {
 
 	for _, line := range strings.Split(file, "\n") {
 		tokens := strings.Split(line, ":")
-		if len(tokens) != 3 {
+
+		switch len(tokens) {
+		case 2:
+			return tokens[0], tokens[1], redpanda.DefaultSASLMechanism
+
+		case 3:
+			if !slices.Contains(supportedSASLMechanisms, tokens[2]) {
+				continue
+			}
+
+			return tokens[0], tokens[1], tokens[2]
+
+		default:
 			continue
 		}
-
-		if !slices.Contains(supportedSASLMechanisms, tokens[2]) {
-			continue
-		}
-
-		user, password, mechanism = tokens[0], tokens[1], tokens[2]
-		return
 	}
 
 	return

--- a/pkg/redpanda/client_test.go
+++ b/pkg/redpanda/client_test.go
@@ -1,0 +1,32 @@
+package redpanda
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFirstUser(t *testing.T) {
+	cases := []struct {
+		In  string
+		Out [3]string
+	}{
+		{
+			In:  "hello:world:SCRAM-SHA-256",
+			Out: [3]string{"hello", "world", "SCRAM-SHA-256"},
+		},
+		{
+			In:  "name:password\n#Intentionally Blank\n",
+			Out: [3]string{"name", "password", "SCRAM-SHA-512"},
+		},
+		{
+			In:  "name:password:SCRAM-MD5-999",
+			Out: [3]string{"", "", ""},
+		},
+	}
+
+	for _, c := range cases {
+		user, password, mechanism := firstUser([]byte(c.In))
+		assert.Equal(t, [3]string{user, password, mechanism}, c.Out)
+	}
+}


### PR DESCRIPTION
Prior to this commit `firstUser` incorrectly required lines of `users.txt` to explicitly specify their SCRAM mechanism. The `config-watcher` side car, however, permits entries to omit the mechanism and will infer a default of `SCRAM-SHA-512`.

Said issue surfaced in a CI test failure from the kuttl test `upgrade-values-check`, which generated the following for `users.txt`:

```yaml
superuser:secretpassword
```

This commit corrects the `firstUser` function's parsing.