### PR TITLE
feat(connect): add migration guide from old chart

### DIFF
--- a/charts/connect/MIGRATION_FROM_BENTHOS.md
+++ b/charts/connect/MIGRATION_FROM_BENTHOS.md
@@ -1,0 +1,31 @@
+# Migration from Benthos
+
+The options accepted by this chart in version `3.0.0` are backwards compatible with version `2.2.0` of the old Benthos based chart.
+
+## Major Differences
+
+- The default docker image has changed from `jeffail/benthos` to `docker.redpanda.com/redpandadata/connect`
+- The `name` of every resource has changed. Specifically, occurrences of `benthos` have been replaced with `redpanda-connect`
+- The following labels on all resources will have new values:
+	- `helm.sh/chart`
+	- `app.kubernetes.io/name`
+	- `app.kubernetes.io/version`
+- The default `root_path` for the HTTP server is now `/redpanda-connect` instead of `/benthos` which affects the configuration of the Ingress and Service resources
+- The name of the file in the main ConfigMap has changed from `benthos.yaml` to `redpanda-connect.yaml`
+- The name of the Container in the PodSpecs has changed from `benthos` to `connect`
+- The mount path of the config file in the `connect` Container has changed from `/benthos.yaml` to `/redpanda-connect.yaml`
+
+## Migration Process
+
+The best way to switch to the new helm chart is to deploy a new release of the new Redpanda Connect chart along side the existing deployment of Benthos, then uninstall the old release once the new Pods are healthy and you have verified that your configuration is working correctly.
+
+```
+$ helm list -q
+benthos-1730406308
+$ helm repo add https://charts.redpanda.com/
+$ helm install --generate-name -f values.yml redpanda/connect
+... (verify that the new pods are working)
+$ helm uninstall benthos-1730406308
+```
+
+If you cannot run multiple copies of Benthos/Redpanda Connect for whatever reason, you will have to uninstall the old Benthos release before installing the new chart.

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -13,6 +13,10 @@ This page describes the official Redpanda Connect Helm Chart. In particular, thi
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-deploy/).
 
+### Migration from Benthos
+
+If you are coming here from [the old Benthos based chart](https://github.com/redpanda-data/redpanda-connect-helm-chart), please see the [migration guide in this repo](https://github.com/redpanda-data/helm-charts/blob/main/charts/connect/MIGRATION_FROM_BENTHOS.md).
+
 ### Streams mode
 
 When running Redpanda Connect in [streams mode](https://docs.redpanda.com/redpanda-connect/guides/streams_mode/about/), all individual stream configuration files should be combined and placed in a single Kubernetes `ConfigMap`, like so:

--- a/charts/connect/README.md.gotmpl
+++ b/charts/connect/README.md.gotmpl
@@ -14,6 +14,10 @@ This page describes the official Redpanda Connect Helm Chart. In particular, thi
 
 For instructions on how to install and use the chart, including how to override and customize the chart’s values, refer to the [deployment documentation](https://docs.redpanda.com/docs/deploy/deployment-option/self-hosted/kubernetes/kubernetes-deploy/).
 
+### Migration from Benthos
+
+If you are coming here from [the old Benthos based chart](https://github.com/redpanda-data/redpanda-connect-helm-chart), please see the [migration guide in this repo](https://github.com/redpanda-data/helm-charts/blob/main/charts/connect/MIGRATION_FROM_BENTHOS.md).
+
 ### Streams mode
 
 When running Redpanda Connect in [streams mode](https://docs.redpanda.com/redpanda-connect/guides/streams_mode/about/), all individual stream configuration files should be combined and placed in a single Kubernetes `ConfigMap`, like so:


### PR DESCRIPTION
This add instructions for users coming from the old (and soon to be archived) [redpanda-connect-helm-chart repo](https://github.com/redpanda-data/redpanda-connect-helm-chart).