### PR TITLE
Fix TLS params for clients

### DIFF
--- a/pkg/redpanda/client.go
+++ b/pkg/redpanda/client.go
@@ -237,14 +237,43 @@ func authFromDot(dot *helmette.Dot) (username string, password string, mechanism
 	return
 }
 
-func tlsConfigFromDot(dot *helmette.Dot, listener redpanda.InternalTLS) (*tls.Config, error) {
-	cert := listener.Cert
+func certificatesFor(dot *helmette.Dot, cert string) (certSecret, certKey, clientSecret string) {
+	values := helmette.Unwrap[redpanda.Values](dot.Values)
+
 	name := redpanda.Fullname(dot)
+
+	// default to cert manager issued names and tls.crt which is
+	// where cert-manager outputs the root CA
+	certKey = corev1.TLSCertKey
+	certSecret = fmt.Sprintf("%s-%s-root-certificate", name, cert)
+	clientSecret = fmt.Sprintf("%s-client", name)
+
+	if certificate, ok := values.TLS.Certs[cert]; ok {
+		// if this references a non-enabled certificate, just return
+		// the default cert-manager issued names
+		if certificate.Enabled != nil && !*certificate.Enabled {
+			return certSecret, certKey, clientSecret
+		}
+
+		if certificate.ClientSecretRef != nil {
+			clientSecret = certificate.ClientSecretRef.Name
+		}
+		if certificate.SecretRef != nil {
+			certSecret = certificate.SecretRef.Name
+			if certificate.CAEnabled {
+				certKey = "ca.crt"
+			}
+		}
+	}
+	return certSecret, certKey, clientSecret
+}
+
+func tlsConfigFromDot(dot *helmette.Dot, listener redpanda.InternalTLS) (*tls.Config, error) {
 	namespace := dot.Release.Namespace
 	serviceName := redpanda.ServiceName(dot)
-	clientCertName := fmt.Sprintf("%s-client", name)
-	rootCertName := fmt.Sprintf("%s-%s-root-certificate", name, cert)
 	serverName := fmt.Sprintf("%s.%s.svc", serviceName, namespace)
+
+	rootCertName, rootCertKey, clientCertName := certificatesFor(dot, listener.Cert)
 
 	serverTLSError := func(err error) error {
 		return fmt.Errorf("error fetching server root CA %s/%s: %w", namespace, rootCertName, err)
@@ -264,7 +293,7 @@ func tlsConfigFromDot(dot *helmette.Dot, listener redpanda.InternalTLS) (*tls.Co
 		return nil, serverTLSError(ErrServerCertificateNotFound)
 	}
 
-	serverPublicKey, found := serverCert.Data[corev1.TLSCertKey]
+	serverPublicKey, found := serverCert.Data[rootCertKey]
 	if !found {
 		return nil, serverTLSError(ErrServerCertificatePublicKeyNotFound)
 	}
@@ -289,6 +318,7 @@ func tlsConfigFromDot(dot *helmette.Dot, listener redpanda.InternalTLS) (*tls.Co
 			return nil, clientTLSError(ErrServerCertificateNotFound)
 		}
 
+		// we always use tls.crt for client certs
 		clientPublicKey, found := clientCert.Data[corev1.TLSCertKey]
 		if !found {
 			return nil, clientTLSError(ErrClientCertificatePublicKeyNotFound)

--- a/pkg/redpanda/client_test.go
+++ b/pkg/redpanda/client_test.go
@@ -3,7 +3,13 @@ package redpanda
 import (
 	"testing"
 
+	"github.com/redpanda-data/helm-charts/charts/redpanda"
+	"github.com/redpanda-data/helm-charts/pkg/gotohelm/helmette"
+	"github.com/redpanda-data/helm-charts/pkg/kube"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 func TestFirstUser(t *testing.T) {
@@ -28,5 +34,98 @@ func TestFirstUser(t *testing.T) {
 	for _, c := range cases {
 		user, password, mechanism := firstUser([]byte(c.In))
 		assert.Equal(t, [3]string{user, password, mechanism}, c.Out)
+	}
+}
+
+func TestCertificates(t *testing.T) {
+	cases := map[string]struct {
+		Cert                   *redpanda.TLSCert
+		CertificateName        string
+		ExpectedRootCertName   string
+		ExpectedRootCertKey    string
+		ExpectedClientCertName string
+	}{
+		"default": {
+			CertificateName:        "default",
+			ExpectedRootCertName:   "redpanda-default-root-certificate",
+			ExpectedRootCertKey:    "tls.crt",
+			ExpectedClientCertName: "redpanda-client",
+		},
+		"default with non-enabled global cert": {
+			Cert: &redpanda.TLSCert{
+				Enabled: ptr.To(false),
+				SecretRef: &v1.LocalObjectReference{
+					Name: "some-cert",
+				},
+			},
+			CertificateName:        "default",
+			ExpectedRootCertName:   "redpanda-default-root-certificate",
+			ExpectedRootCertKey:    "tls.crt",
+			ExpectedClientCertName: "redpanda-client",
+		},
+		"certificate with secret ref": {
+			Cert: &redpanda.TLSCert{
+				SecretRef: &v1.LocalObjectReference{
+					Name: "some-cert",
+				},
+			},
+			CertificateName:        "default",
+			ExpectedRootCertName:   "some-cert",
+			ExpectedRootCertKey:    "tls.crt",
+			ExpectedClientCertName: "redpanda-client",
+		},
+		"certificate with CA": {
+			Cert: &redpanda.TLSCert{
+				CAEnabled: true,
+				SecretRef: &v1.LocalObjectReference{
+					Name: "some-cert",
+				},
+			},
+			CertificateName:        "default",
+			ExpectedRootCertName:   "some-cert",
+			ExpectedRootCertKey:    "ca.crt",
+			ExpectedClientCertName: "redpanda-client",
+		},
+		"certificate with client certificate": {
+			Cert: &redpanda.TLSCert{
+				CAEnabled: true,
+				SecretRef: &v1.LocalObjectReference{
+					Name: "some-cert",
+				},
+				ClientSecretRef: &v1.LocalObjectReference{
+					Name: "client-cert",
+				},
+			},
+			CertificateName:        "default",
+			ExpectedRootCertName:   "some-cert",
+			ExpectedRootCertKey:    "ca.crt",
+			ExpectedClientCertName: "client-cert",
+		},
+	}
+
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			certMap := redpanda.TLSCertMap{}
+
+			if c.Cert != nil {
+				certMap[c.CertificateName] = *c.Cert
+			}
+
+			dot, err := redpanda.Chart.Dot(kube.Config{}, helmette.Release{
+				Name:      "redpanda",
+				Namespace: "redpanda",
+				Service:   "Helm",
+			}, redpanda.Values{
+				TLS: redpanda.TLS{
+					Certs: certMap,
+				},
+			})
+			require.NoError(t, err)
+
+			actualRootCertName, actualRootCertKey, actualClientCertName := certificatesFor(dot, c.CertificateName)
+			require.Equal(t, c.ExpectedRootCertName, actualRootCertName)
+			require.Equal(t, c.ExpectedRootCertKey, actualRootCertKey)
+			require.Equal(t, c.ExpectedClientCertName, actualClientCertName)
+		})
 	}
 }


### PR DESCRIPTION
Previously TLS configuration for clients using the `pkg/redpanda` subpackage (our operator CRDs when using a `clusterRef`), didn't take into account all of the various configurations for custom TLS configuration per-listener. This fixes that, ensuring that TLS is only configured when it's enabled on the listener itself (or globally and not explicitly disabled), and properly configuring the Kubernetes secrets from which to pull certificate values, whether issued through cert-manager or specified via an explicit `SecretRef`.