### PR TITLE
Cut Redpanda 5.9.10 chart release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@
 #### Added
 #### Changed
 #### Fixed
+#### Removed
+
+### [5.9.10](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.10) - 2024-11-14
+#### Added
+#### Changed
+#### Fixed
 * All occurrence of External Domain execution via tpl function
 * Calculating Service typed LoadBalancer annotation based on external addresses (even single one)
+* Fix connecting to the schema registry via rpk on nodes for versions of rpk that support a node-level rpk stanza.
 #### Removed
 
 ### [5.9.9](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.9) - 2024-10-24

--- a/charts/redpanda/Chart.yaml
+++ b/charts/redpanda/Chart.yaml
@@ -23,7 +23,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 5.9.9
+version: 5.9.10
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/redpanda/README.md
+++ b/charts/redpanda/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Helm chart.
 ---
 
-![Version: 5.9.9](https://img.shields.io/badge/Version-5.9.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.7](https://img.shields.io/badge/AppVersion-v24.2.7-informational?style=flat-square)
+![Version: 5.9.10](https://img.shields.io/badge/Version-5.9.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v24.2.7](https://img.shields.io/badge/AppVersion-v24.2.7-informational?style=flat-square)
 
 This page describes the official Redpanda Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/redpanda/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -48,7 +48,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -141,7 +141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -179,7 +179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -415,7 +415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -446,7 +446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -538,7 +538,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -583,7 +583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -720,7 +720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -742,7 +742,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -1054,7 +1054,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -1080,7 +1080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -1106,7 +1106,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -1144,7 +1144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -1182,7 +1182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -1198,7 +1198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -1215,7 +1215,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -1231,7 +1231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -1275,7 +1275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -1377,7 +1377,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1416,7 +1416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda-sts-lifecycle
   namespace: default
@@ -1511,7 +1511,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda-config-watcher
   namespace: default
@@ -1550,7 +1550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda-configurator
   namespace: default
@@ -1690,7 +1690,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -1716,7 +1716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda-rpk
   namespace: default
@@ -1805,7 +1805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda-external
   namespace: default
@@ -1851,7 +1851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
     testlabel: exercise_common_labels_template
   name: redpanda
@@ -1983,7 +1983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda
   namespace: default
@@ -2006,7 +2006,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
         testlabel: exercise_common_labels_template
     spec:
@@ -2322,7 +2322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     testlabel: exercise_common_labels_template
   name: redpanda-configuration
   namespace: default
@@ -2414,7 +2414,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -2452,7 +2452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -2546,7 +2546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -2584,7 +2584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -2787,7 +2787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -2814,7 +2814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -2902,7 +2902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -2947,7 +2947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -3084,7 +3084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -3106,7 +3106,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -3418,7 +3418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -3444,7 +3444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -3470,7 +3470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -3508,7 +3508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -3546,7 +3546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -3562,7 +3562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -3579,7 +3579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -3595,7 +3595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -3639,7 +3639,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -3741,7 +3741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -3779,7 +3779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -3873,7 +3873,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -3890,7 +3890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -4027,7 +4027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -4074,7 +4074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -4191,7 +4191,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -4216,7 +4216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -4304,7 +4304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -4349,7 +4349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -4495,7 +4495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -4517,7 +4517,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -4875,7 +4875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -4982,7 +4982,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -5020,7 +5020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -5114,7 +5114,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -5131,7 +5131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -5268,7 +5268,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -5315,7 +5315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -5502,7 +5502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -5529,7 +5529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -5617,7 +5617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -5662,7 +5662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -5814,7 +5814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -5836,7 +5836,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -6192,7 +6192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -6218,7 +6218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -6244,7 +6244,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -6282,7 +6282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -6320,7 +6320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -6336,7 +6336,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -6353,7 +6353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -6369,7 +6369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -6413,7 +6413,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -6532,7 +6532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -6572,7 +6572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -6586,7 +6586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -6679,7 +6679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -6717,7 +6717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -6959,7 +6959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -6990,7 +6990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -7057,7 +7057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 rules:
 - apiGroups:
@@ -7079,7 +7079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -7111,7 +7111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7133,7 +7133,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -7180,7 +7180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -7225,7 +7225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -7362,7 +7362,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -7384,7 +7384,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -7717,7 +7717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -7743,7 +7743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -7769,7 +7769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -7807,7 +7807,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -7845,7 +7845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -7861,7 +7861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -7878,7 +7878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -7894,7 +7894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -7938,7 +7938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -8040,7 +8040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -8078,7 +8078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -8171,7 +8171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -8209,7 +8209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -8505,7 +8505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -8535,7 +8535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -8627,7 +8627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -8702,7 +8702,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -8839,7 +8839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -8861,7 +8861,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -9197,7 +9197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-cert2-root-certificate
   namespace: default
 spec:
@@ -9223,7 +9223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -9249,7 +9249,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -9275,7 +9275,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-cert2-cert
   namespace: default
 spec:
@@ -9313,7 +9313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -9351,7 +9351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -9389,7 +9389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-cert2-selfsigned-issuer
   namespace: default
 spec:
@@ -9405,7 +9405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-cert2-root-issuer
   namespace: default
 spec:
@@ -9422,7 +9422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -9438,7 +9438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -9455,7 +9455,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -9471,7 +9471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -9515,7 +9515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -9623,7 +9623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -9661,7 +9661,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -9754,7 +9754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -9792,7 +9792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -10028,7 +10028,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -10059,7 +10059,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -10151,7 +10151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -10196,7 +10196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -10333,7 +10333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -10355,7 +10355,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -10666,7 +10666,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -10692,7 +10692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -10718,7 +10718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -10756,7 +10756,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -10794,7 +10794,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -10810,7 +10810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -10827,7 +10827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -10843,7 +10843,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -10887,7 +10887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -10989,7 +10989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -11027,7 +11027,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -11120,7 +11120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -11158,7 +11158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -11217,7 +11217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -11449,7 +11449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -11480,7 +11480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -11572,7 +11572,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -11617,7 +11617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -11754,7 +11754,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -11776,7 +11776,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -12172,7 +12172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -12198,7 +12198,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -12224,7 +12224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -12262,7 +12262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -12300,7 +12300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -12316,7 +12316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -12333,7 +12333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -12349,7 +12349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -12393,7 +12393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -12495,7 +12495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -12533,7 +12533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -12626,7 +12626,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -12664,7 +12664,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -12900,7 +12900,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -12931,7 +12931,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -13023,7 +13023,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -13068,7 +13068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -13205,7 +13205,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -13227,7 +13227,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -13539,7 +13539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -13565,7 +13565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -13591,7 +13591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -13631,7 +13631,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -13671,7 +13671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -13687,7 +13687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -13704,7 +13704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -13720,7 +13720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -13764,7 +13764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -13866,7 +13866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -13904,7 +13904,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -13997,7 +13997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: some-users
   namespace: default
 stringData:
@@ -14018,7 +14018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -14155,7 +14155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -14214,7 +14214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -14420,7 +14420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -14451,7 +14451,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -14543,7 +14543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -14588,7 +14588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -14740,7 +14740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -14762,7 +14762,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -15118,7 +15118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -15144,7 +15144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -15170,7 +15170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -15208,7 +15208,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -15246,7 +15246,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -15262,7 +15262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -15279,7 +15279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -15295,7 +15295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -15339,7 +15339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -15458,7 +15458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -15496,7 +15496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -15589,7 +15589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -15627,7 +15627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -15863,7 +15863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -15894,7 +15894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -15986,7 +15986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -16031,7 +16031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -16168,7 +16168,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -16190,7 +16190,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -16502,7 +16502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -16528,7 +16528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -16568,7 +16568,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -16584,7 +16584,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -16628,7 +16628,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -16730,7 +16730,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -16768,7 +16768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -16861,7 +16861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -16899,7 +16899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -17135,7 +17135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -17166,7 +17166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -17258,7 +17258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -17304,7 +17304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -17348,7 +17348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -17392,7 +17392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -17527,7 +17527,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -17549,7 +17549,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -17861,7 +17861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -17887,7 +17887,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -17927,7 +17927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -17943,7 +17943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -17987,7 +17987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -18089,7 +18089,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -18127,7 +18127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -18220,7 +18220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -18258,7 +18258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -18429,7 +18429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -18458,7 +18458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -18550,7 +18550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -18595,7 +18595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -18726,7 +18726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -18748,7 +18748,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -19035,7 +19035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     release: prometheus
   name: redpanda
   namespace: default
@@ -19090,7 +19090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -19180,7 +19180,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -19218,7 +19218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -19311,7 +19311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -19349,7 +19349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -19585,7 +19585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -19616,7 +19616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -19708,7 +19708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -19753,7 +19753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -19890,7 +19890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -19912,7 +19912,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -20224,7 +20224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -20250,7 +20250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -20276,7 +20276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -20314,7 +20314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -20352,7 +20352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -20368,7 +20368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -20385,7 +20385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -20401,7 +20401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -20418,7 +20418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     release: prometheus
   name: redpanda
   namespace: default
@@ -20477,7 +20477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -20579,7 +20579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -20617,7 +20617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -20710,7 +20710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -20748,7 +20748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -20984,7 +20984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -21015,7 +21015,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -21082,7 +21082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -21116,7 +21116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 rules:
 - apiGroups:
@@ -21138,7 +21138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -21170,7 +21170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21192,7 +21192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21214,7 +21214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -21236,7 +21236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -21289,7 +21289,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -21337,7 +21337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -21382,7 +21382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -21519,7 +21519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -21541,7 +21541,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -21890,7 +21890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -21916,7 +21916,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -21942,7 +21942,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -21980,7 +21980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -22018,7 +22018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -22034,7 +22034,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -22051,7 +22051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -22067,7 +22067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -22111,7 +22111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -22213,7 +22213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -22251,7 +22251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -22344,7 +22344,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -22382,7 +22382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -22618,7 +22618,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -22649,7 +22649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -22741,7 +22741,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -22786,7 +22786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -22923,7 +22923,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -22945,7 +22945,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -23260,7 +23260,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -23286,7 +23286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -23312,7 +23312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -23350,7 +23350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -23388,7 +23388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -23404,7 +23404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -23421,7 +23421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -23437,7 +23437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -23481,7 +23481,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -23583,7 +23583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -23621,7 +23621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -23714,7 +23714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -23752,7 +23752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -23988,7 +23988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -24019,7 +24019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -24111,7 +24111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -24156,7 +24156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -24293,7 +24293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -24315,7 +24315,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -24627,7 +24627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -24653,7 +24653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -24679,7 +24679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -24719,7 +24719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -24759,7 +24759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -24775,7 +24775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -24792,7 +24792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -24808,7 +24808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -24852,7 +24852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -24954,7 +24954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -24992,7 +24992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -25085,7 +25085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -25123,7 +25123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -25403,7 +25403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -25434,7 +25434,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -25526,7 +25526,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -25571,7 +25571,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -25724,7 +25724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -25746,7 +25746,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -26079,7 +26079,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -26105,7 +26105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -26131,7 +26131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -26169,7 +26169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -26207,7 +26207,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -26223,7 +26223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -26240,7 +26240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -26256,7 +26256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -26300,7 +26300,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -26404,7 +26404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -26442,7 +26442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -26535,7 +26535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -26573,7 +26573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -26854,7 +26854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -26885,7 +26885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -26977,7 +26977,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -27022,7 +27022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -27175,7 +27175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -27197,7 +27197,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -27530,7 +27530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -27556,7 +27556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -27582,7 +27582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -27620,7 +27620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -27658,7 +27658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -27674,7 +27674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -27691,7 +27691,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -27707,7 +27707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -27751,7 +27751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -27855,7 +27855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -27893,7 +27893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -27986,7 +27986,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -28024,7 +28024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -28303,7 +28303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -28334,7 +28334,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -28426,7 +28426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -28471,7 +28471,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -28624,7 +28624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -28646,7 +28646,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -28980,7 +28980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -29006,7 +29006,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -29032,7 +29032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -29070,7 +29070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -29108,7 +29108,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -29124,7 +29124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -29141,7 +29141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -29157,7 +29157,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -29201,7 +29201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -29305,7 +29305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -29343,7 +29343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -29436,7 +29436,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -29474,7 +29474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -29715,7 +29715,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -29746,7 +29746,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -29838,7 +29838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -29883,7 +29883,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -30020,7 +30020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -30042,7 +30042,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -30376,7 +30376,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -30402,7 +30402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -30428,7 +30428,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -30466,7 +30466,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -30504,7 +30504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -30520,7 +30520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -30537,7 +30537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -30553,7 +30553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -30597,7 +30597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -30699,7 +30699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -30737,7 +30737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -30830,7 +30830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -30868,7 +30868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -31148,7 +31148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -31179,7 +31179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -31271,7 +31271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -31316,7 +31316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -31469,7 +31469,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -31491,7 +31491,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -31836,7 +31836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -31862,7 +31862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -31888,7 +31888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -31926,7 +31926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -31964,7 +31964,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -31980,7 +31980,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -31997,7 +31997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -32013,7 +32013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -32057,7 +32057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -32161,7 +32161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -32199,7 +32199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -32292,7 +32292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -32330,7 +32330,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -32611,7 +32611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -32642,7 +32642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -32734,7 +32734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -32779,7 +32779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -32932,7 +32932,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -32954,7 +32954,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -33299,7 +33299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -33325,7 +33325,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -33351,7 +33351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -33389,7 +33389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -33427,7 +33427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -33443,7 +33443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -33460,7 +33460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -33476,7 +33476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -33520,7 +33520,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -33624,7 +33624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -33662,7 +33662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -33755,7 +33755,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -33793,7 +33793,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -34072,7 +34072,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -34103,7 +34103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -34195,7 +34195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -34240,7 +34240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -34393,7 +34393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -34415,7 +34415,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -34762,7 +34762,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -34788,7 +34788,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -34814,7 +34814,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -34852,7 +34852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -34890,7 +34890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -34906,7 +34906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -34923,7 +34923,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -34939,7 +34939,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -34983,7 +34983,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -35087,7 +35087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -35125,7 +35125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -35218,7 +35218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -35256,7 +35256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -35497,7 +35497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -35528,7 +35528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -35620,7 +35620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -35665,7 +35665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -35802,7 +35802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -35824,7 +35824,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -36171,7 +36171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -36197,7 +36197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -36223,7 +36223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -36261,7 +36261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -36299,7 +36299,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -36315,7 +36315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -36332,7 +36332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -36348,7 +36348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -36392,7 +36392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -36494,7 +36494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -36532,7 +36532,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -36625,7 +36625,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -36663,7 +36663,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -36943,7 +36943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -36974,7 +36974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -37066,7 +37066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -37111,7 +37111,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -37264,7 +37264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -37286,7 +37286,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -37631,7 +37631,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -37657,7 +37657,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -37683,7 +37683,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -37721,7 +37721,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -37759,7 +37759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -37775,7 +37775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -37792,7 +37792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -37808,7 +37808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -37852,7 +37852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -37956,7 +37956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -37994,7 +37994,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -38087,7 +38087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -38125,7 +38125,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -38406,7 +38406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -38437,7 +38437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -38529,7 +38529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -38574,7 +38574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -38727,7 +38727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -38749,7 +38749,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -39094,7 +39094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -39120,7 +39120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -39146,7 +39146,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -39184,7 +39184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -39222,7 +39222,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -39238,7 +39238,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -39255,7 +39255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -39271,7 +39271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -39315,7 +39315,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -39419,7 +39419,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -39457,7 +39457,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -39550,7 +39550,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -39588,7 +39588,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -39867,7 +39867,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -39898,7 +39898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -39990,7 +39990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -40035,7 +40035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -40188,7 +40188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -40210,7 +40210,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -40557,7 +40557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -40583,7 +40583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -40609,7 +40609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -40647,7 +40647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -40685,7 +40685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -40701,7 +40701,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -40718,7 +40718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -40734,7 +40734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -40778,7 +40778,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -40882,7 +40882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -40920,7 +40920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -41013,7 +41013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -41051,7 +41051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -41292,7 +41292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -41323,7 +41323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -41415,7 +41415,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -41460,7 +41460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -41597,7 +41597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -41619,7 +41619,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -41966,7 +41966,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -41992,7 +41992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -42018,7 +42018,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -42056,7 +42056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -42094,7 +42094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -42110,7 +42110,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -42127,7 +42127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -42143,7 +42143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -42187,7 +42187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -42289,7 +42289,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -42327,7 +42327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -42420,7 +42420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -42458,7 +42458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -42694,7 +42694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -42725,7 +42725,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -42817,7 +42817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -42862,7 +42862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -42999,7 +42999,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -43021,7 +43021,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -43333,7 +43333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -43359,7 +43359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -43385,7 +43385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -43423,7 +43423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -43461,7 +43461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -43477,7 +43477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -43494,7 +43494,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -43510,7 +43510,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -43554,7 +43554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -43656,7 +43656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -43694,7 +43694,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -43787,7 +43787,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -43825,7 +43825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -44061,7 +44061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -44092,7 +44092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -44184,7 +44184,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -44229,7 +44229,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -44366,7 +44366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -44389,7 +44389,7 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
         azure.workload.identity/use: "true"
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -44701,7 +44701,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -44727,7 +44727,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -44753,7 +44753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -44791,7 +44791,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -44829,7 +44829,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -44845,7 +44845,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -44862,7 +44862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -44878,7 +44878,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -44922,7 +44922,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -45024,7 +45024,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -45062,7 +45062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -45155,7 +45155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -45193,7 +45193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -45429,7 +45429,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -45460,7 +45460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -45552,7 +45552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -45597,7 +45597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -45734,7 +45734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -45756,7 +45756,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -46074,7 +46074,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -46100,7 +46100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -46126,7 +46126,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -46164,7 +46164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -46202,7 +46202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -46218,7 +46218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -46235,7 +46235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -46251,7 +46251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -46295,7 +46295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -46397,7 +46397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -46435,7 +46435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -46528,7 +46528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -46566,7 +46566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -46861,7 +46861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -46893,7 +46893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -46987,7 +46987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -47052,7 +47052,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -47189,7 +47189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -47211,7 +47211,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -47531,7 +47531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -47557,7 +47557,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -47583,7 +47583,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -47621,7 +47621,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -47659,7 +47659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -47675,7 +47675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -47692,7 +47692,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -47708,7 +47708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -47752,7 +47752,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -47854,7 +47854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -47895,7 +47895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -47988,7 +47988,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -48026,7 +48026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -48262,7 +48262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -48293,7 +48293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -48385,7 +48385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -48433,7 +48433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -48573,7 +48573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -48598,7 +48598,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
         redpanda.com/testing: "true"
         redpanda.com/testing-samples: sample
@@ -48919,7 +48919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -48945,7 +48945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -48971,7 +48971,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -49009,7 +49009,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -49047,7 +49047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -49063,7 +49063,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -49080,7 +49080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -49096,7 +49096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -49140,7 +49140,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -49242,7 +49242,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -49280,7 +49280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -49373,7 +49373,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -49411,7 +49411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -49647,7 +49647,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -49678,7 +49678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -49745,7 +49745,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -49779,7 +49779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 rules:
 - apiGroups:
@@ -49801,7 +49801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -49833,7 +49833,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49855,7 +49855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49877,7 +49877,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -49899,7 +49899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -49952,7 +49952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -50000,7 +50000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -50045,7 +50045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -50182,7 +50182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -50204,7 +50204,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -50565,7 +50565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -50591,7 +50591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -50617,7 +50617,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -50655,7 +50655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -50693,7 +50693,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -50709,7 +50709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -50726,7 +50726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -50742,7 +50742,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -50786,7 +50786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -50888,7 +50888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -50926,7 +50926,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -51019,7 +51019,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -51057,7 +51057,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -51116,7 +51116,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -51348,7 +51348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -51379,7 +51379,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -51446,7 +51446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -51480,7 +51480,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -51502,7 +51502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -51555,7 +51555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -51603,7 +51603,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -51648,7 +51648,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -51785,7 +51785,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -51807,7 +51807,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -52160,7 +52160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -52186,7 +52186,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -52212,7 +52212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -52250,7 +52250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -52288,7 +52288,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -52304,7 +52304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -52321,7 +52321,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -52337,7 +52337,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -52381,7 +52381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -52483,7 +52483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -52521,7 +52521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -52614,7 +52614,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -52652,7 +52652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -52888,7 +52888,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -52919,7 +52919,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -53060,7 +53060,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -53105,7 +53105,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -53406,7 +53406,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -53428,7 +53428,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -53740,7 +53740,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -53766,7 +53766,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -53792,7 +53792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -53830,7 +53830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -53868,7 +53868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -53884,7 +53884,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -53901,7 +53901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -53917,7 +53917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -54094,7 +54094,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -54196,7 +54196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -54234,7 +54234,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -54327,7 +54327,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -54365,7 +54365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -54601,7 +54601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -54632,7 +54632,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -54724,7 +54724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -54769,7 +54769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -54906,7 +54906,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -54928,7 +54928,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -55240,7 +55240,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -55266,7 +55266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -55292,7 +55292,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -55332,7 +55332,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -55372,7 +55372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -55388,7 +55388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -55405,7 +55405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -55421,7 +55421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -55465,7 +55465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -55567,7 +55567,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -55606,7 +55606,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -55699,7 +55699,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -55737,7 +55737,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -55973,7 +55973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -56004,7 +56004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -56096,7 +56096,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: change-name-external
   namespace: default
 spec:
@@ -56143,7 +56143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "true"
   name: change-name
   namespace: default
@@ -56281,7 +56281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -56304,7 +56304,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
         test: test
     spec:
@@ -56619,7 +56619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -56645,7 +56645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -56671,7 +56671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -56709,7 +56709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -56747,7 +56747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -56763,7 +56763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -56780,7 +56780,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -56796,7 +56796,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -56813,7 +56813,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -56871,7 +56871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -56973,7 +56973,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -57011,7 +57011,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -57104,7 +57104,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -57142,7 +57142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -57378,7 +57378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -57409,7 +57409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -57501,7 +57501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -57546,7 +57546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -57683,7 +57683,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -57705,7 +57705,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -58032,7 +58032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -58058,7 +58058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -58084,7 +58084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -58122,7 +58122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -58160,7 +58160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -58176,7 +58176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -58193,7 +58193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -58209,7 +58209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -58253,7 +58253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -58374,7 +58374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -58412,7 +58412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -58505,7 +58505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -58543,7 +58543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -58779,7 +58779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -58810,7 +58810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -58902,7 +58902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -58947,7 +58947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -59084,7 +59084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -59106,7 +59106,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -59433,7 +59433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -59459,7 +59459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -59485,7 +59485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -59523,7 +59523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -59561,7 +59561,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -59577,7 +59577,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -59594,7 +59594,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -59610,7 +59610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -59654,7 +59654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -59777,7 +59777,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -59815,7 +59815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -59908,7 +59908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -59946,7 +59946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -60182,7 +60182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -60213,7 +60213,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -60305,7 +60305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -60350,7 +60350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -60487,7 +60487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -60509,7 +60509,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -60823,7 +60823,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -60849,7 +60849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -60875,7 +60875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -60913,7 +60913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -60951,7 +60951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -60967,7 +60967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -60984,7 +60984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -61000,7 +61000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -61044,7 +61044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -61148,7 +61148,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -61170,7 +61170,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -61263,7 +61263,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -61301,7 +61301,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -61519,7 +61519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -61551,7 +61551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -61566,7 +61566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -61611,7 +61611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -61656,7 +61656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -61678,7 +61678,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -62004,7 +62004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -62030,7 +62030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -62056,7 +62056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -62082,7 +62082,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -62120,7 +62120,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -62158,7 +62158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -62196,7 +62196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -62221,7 +62221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -62237,7 +62237,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -62254,7 +62254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -62270,7 +62270,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -62287,7 +62287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -62303,7 +62303,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -62324,7 +62324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -62432,7 +62432,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -62470,7 +62470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -62563,7 +62563,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -62601,7 +62601,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -62837,7 +62837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -62868,7 +62868,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -62960,7 +62960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -63005,7 +63005,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -63142,7 +63142,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -63164,7 +63164,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -63476,7 +63476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -63502,7 +63502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -63528,7 +63528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -63554,7 +63554,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -63580,7 +63580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -63597,7 +63597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -63641,7 +63641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -63743,7 +63743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -63781,7 +63781,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -63874,7 +63874,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -63891,7 +63891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -64028,7 +64028,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -64087,7 +64087,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -64341,7 +64341,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -64372,7 +64372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -64464,7 +64464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -64509,7 +64509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -64677,7 +64677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -64699,7 +64699,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -65055,7 +65055,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -65081,7 +65081,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -65107,7 +65107,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -65145,7 +65145,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -65183,7 +65183,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -65199,7 +65199,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -65216,7 +65216,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -65232,7 +65232,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -65276,7 +65276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -65397,7 +65397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -65435,7 +65435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -65528,7 +65528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -65566,7 +65566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -65840,7 +65840,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -65871,7 +65871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -65963,7 +65963,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -66008,7 +66008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -66161,7 +66161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -66183,7 +66183,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -66495,7 +66495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -66521,7 +66521,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -66547,7 +66547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -66585,7 +66585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -66623,7 +66623,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -66639,7 +66639,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -66656,7 +66656,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -66672,7 +66672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -66716,7 +66716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -66820,7 +66820,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -66858,7 +66858,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -66951,7 +66951,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -66989,7 +66989,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -67225,7 +67225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -67256,7 +67256,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -67348,7 +67348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -67393,7 +67393,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -67535,7 +67535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -67557,7 +67557,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -67869,7 +67869,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -67895,7 +67895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -67921,7 +67921,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -67959,7 +67959,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -67997,7 +67997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -68013,7 +68013,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -68030,7 +68030,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -68046,7 +68046,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -68090,7 +68090,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -68197,7 +68197,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -68235,7 +68235,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -68328,7 +68328,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -68366,7 +68366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -68602,7 +68602,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -68633,7 +68633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -68774,7 +68774,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -68819,7 +68819,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -69147,7 +69147,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -69169,7 +69169,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -69509,7 +69509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -69535,7 +69535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -69561,7 +69561,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -69599,7 +69599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -69637,7 +69637,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -69653,7 +69653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -69670,7 +69670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -69686,7 +69686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -69885,7 +69885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -69987,7 +69987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -70025,7 +70025,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -70118,7 +70118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -70156,7 +70156,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -70392,7 +70392,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -70423,7 +70423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -70515,7 +70515,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -70560,7 +70560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -70697,7 +70697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -70719,7 +70719,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -71032,7 +71032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -71058,7 +71058,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -71084,7 +71084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -71122,7 +71122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -71160,7 +71160,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -71176,7 +71176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -71193,7 +71193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -71209,7 +71209,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -71253,7 +71253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -71356,7 +71356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -71394,7 +71394,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -71487,7 +71487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -71525,7 +71525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -71761,7 +71761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -71792,7 +71792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -71884,7 +71884,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -71929,7 +71929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -72066,7 +72066,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -72088,7 +72088,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -72401,7 +72401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -72427,7 +72427,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -72453,7 +72453,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -72491,7 +72491,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -72529,7 +72529,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -72545,7 +72545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -72562,7 +72562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -72578,7 +72578,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -72622,7 +72622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -72725,7 +72725,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -72763,7 +72763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -72856,7 +72856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -72894,7 +72894,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -73130,7 +73130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -73161,7 +73161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -73253,7 +73253,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -73298,7 +73298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -73435,7 +73435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -73457,7 +73457,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -73769,7 +73769,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -73795,7 +73795,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -73821,7 +73821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -73859,7 +73859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -73897,7 +73897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -73913,7 +73913,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -73930,7 +73930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -73946,7 +73946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -73990,7 +73990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -74092,7 +74092,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -74130,7 +74130,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -74223,7 +74223,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -74261,7 +74261,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -74497,7 +74497,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -74528,7 +74528,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -74620,7 +74620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -74665,7 +74665,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -74809,7 +74809,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -74831,7 +74831,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -75143,7 +75143,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -75169,7 +75169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -75195,7 +75195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -75233,7 +75233,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -75271,7 +75271,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -75287,7 +75287,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -75304,7 +75304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -75320,7 +75320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -75364,7 +75364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -76825,7 +76825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -76863,7 +76863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -76956,7 +76956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-users
   namespace: default
 stringData:
@@ -76976,7 +76976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -77113,7 +77113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -77172,7 +77172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-bootstrap-user
   namespace: default
 stringData:
@@ -77377,7 +77377,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -77408,7 +77408,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -77500,7 +77500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -77545,7 +77545,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -77697,7 +77697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -77719,7 +77719,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -78075,7 +78075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -78101,7 +78101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -78127,7 +78127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -78165,7 +78165,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -78203,7 +78203,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -78219,7 +78219,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -78236,7 +78236,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -78252,7 +78252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -78296,7 +78296,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -78439,7 +78439,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -78477,7 +78477,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -78570,7 +78570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -78608,7 +78608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -78844,7 +78844,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -78875,7 +78875,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -78967,7 +78967,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -79012,7 +79012,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -79149,7 +79149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -79171,7 +79171,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -79483,7 +79483,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -79509,7 +79509,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -79535,7 +79535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -79573,7 +79573,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -79611,7 +79611,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -79627,7 +79627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -79644,7 +79644,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -79660,7 +79660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -79704,7 +79704,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -79806,7 +79806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -79844,7 +79844,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -79937,7 +79937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -79975,7 +79975,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -80248,7 +80248,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -80279,7 +80279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -80371,7 +80371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -80416,7 +80416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -80569,7 +80569,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -80591,7 +80591,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -80903,7 +80903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -80929,7 +80929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -80955,7 +80955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -80993,7 +80993,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -81031,7 +81031,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -81047,7 +81047,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -81064,7 +81064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -81080,7 +81080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -81124,7 +81124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -81228,7 +81228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -81266,7 +81266,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -81359,7 +81359,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -81397,7 +81397,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -81638,7 +81638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -81669,7 +81669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -81761,7 +81761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -81806,7 +81806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -81943,7 +81943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -81965,7 +81965,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -82298,7 +82298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -82324,7 +82324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -82350,7 +82350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -82388,7 +82388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -82426,7 +82426,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -82442,7 +82442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -82459,7 +82459,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -82475,7 +82475,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -82519,7 +82519,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -82633,7 +82633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -82671,7 +82671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -82764,7 +82764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -82802,7 +82802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -83038,7 +83038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -83069,7 +83069,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -83161,7 +83161,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -83206,7 +83206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -83343,7 +83343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -83365,7 +83365,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -83677,7 +83677,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -83703,7 +83703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -83729,7 +83729,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -83767,7 +83767,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -83805,7 +83805,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -83821,7 +83821,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -83838,7 +83838,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -83854,7 +83854,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -83898,7 +83898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -84000,7 +84000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -84038,7 +84038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -84131,7 +84131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -84169,7 +84169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -84442,7 +84442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -84473,7 +84473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -84565,7 +84565,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -84610,7 +84610,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -84763,7 +84763,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -84785,7 +84785,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -85097,7 +85097,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -85123,7 +85123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -85149,7 +85149,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -85187,7 +85187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -85225,7 +85225,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -85241,7 +85241,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -85258,7 +85258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -85274,7 +85274,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -85318,7 +85318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -85422,7 +85422,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -85460,7 +85460,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -85553,7 +85553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -85591,7 +85591,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -85832,7 +85832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -85863,7 +85863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -85955,7 +85955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -86000,7 +86000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -86137,7 +86137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -86159,7 +86159,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -86492,7 +86492,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -86518,7 +86518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -86544,7 +86544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -86582,7 +86582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -86620,7 +86620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -86636,7 +86636,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -86653,7 +86653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -86669,7 +86669,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -86713,7 +86713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -86815,7 +86815,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -86853,7 +86853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -86946,7 +86946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -86984,7 +86984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -87220,7 +87220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -87251,7 +87251,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -87343,7 +87343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -87388,7 +87388,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -87525,7 +87525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -87547,7 +87547,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -87859,7 +87859,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -87885,7 +87885,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -87911,7 +87911,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -87949,7 +87949,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -87987,7 +87987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -88003,7 +88003,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -88020,7 +88020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -88036,7 +88036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -88080,7 +88080,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -88182,7 +88182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -88220,7 +88220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -88313,7 +88313,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -88351,7 +88351,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -88624,7 +88624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -88655,7 +88655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -88747,7 +88747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -88792,7 +88792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -88945,7 +88945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -88967,7 +88967,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -89279,7 +89279,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -89305,7 +89305,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -89331,7 +89331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -89369,7 +89369,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -89407,7 +89407,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -89423,7 +89423,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -89440,7 +89440,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -89456,7 +89456,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -89500,7 +89500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -89604,7 +89604,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -89642,7 +89642,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -89735,7 +89735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -89773,7 +89773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -90014,7 +90014,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -90045,7 +90045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -90137,7 +90137,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -90182,7 +90182,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -90319,7 +90319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -90341,7 +90341,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -90674,7 +90674,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -90700,7 +90700,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -90726,7 +90726,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -90764,7 +90764,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -90802,7 +90802,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -90818,7 +90818,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -90835,7 +90835,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -90851,7 +90851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -90895,7 +90895,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -90997,7 +90997,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -91035,7 +91035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -91128,7 +91128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -91166,7 +91166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -91402,7 +91402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -91433,7 +91433,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -91525,7 +91525,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -91570,7 +91570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -91707,7 +91707,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -91729,7 +91729,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -92041,7 +92041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -92067,7 +92067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -92093,7 +92093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -92131,7 +92131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -92169,7 +92169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -92185,7 +92185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -92202,7 +92202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -92218,7 +92218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -92262,7 +92262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -92364,7 +92364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -92402,7 +92402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -92495,7 +92495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -92533,7 +92533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -92806,7 +92806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -92837,7 +92837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -92929,7 +92929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -92974,7 +92974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -93127,7 +93127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -93149,7 +93149,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -93461,7 +93461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -93487,7 +93487,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -93513,7 +93513,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -93551,7 +93551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -93589,7 +93589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -93605,7 +93605,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -93622,7 +93622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -93638,7 +93638,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -93682,7 +93682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -93786,7 +93786,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -93824,7 +93824,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -93917,7 +93917,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -93955,7 +93955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -94196,7 +94196,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -94227,7 +94227,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -94319,7 +94319,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -94364,7 +94364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -94501,7 +94501,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -94523,7 +94523,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -94856,7 +94856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -94882,7 +94882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -94908,7 +94908,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -94946,7 +94946,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -94984,7 +94984,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -95000,7 +95000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -95017,7 +95017,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -95033,7 +95033,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -95077,7 +95077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -95179,7 +95179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -95217,7 +95217,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -95310,7 +95310,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -95348,7 +95348,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -95585,7 +95585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -95616,7 +95616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -95708,7 +95708,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -95753,7 +95753,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -95890,7 +95890,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -95912,7 +95912,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -96224,7 +96224,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -96250,7 +96250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -96276,7 +96276,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -96314,7 +96314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -96352,7 +96352,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -96368,7 +96368,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -96385,7 +96385,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -96401,7 +96401,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -96445,7 +96445,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -96547,7 +96547,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -96585,7 +96585,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -96678,7 +96678,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -96716,7 +96716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -96990,7 +96990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -97021,7 +97021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -97113,7 +97113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -97158,7 +97158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -97311,7 +97311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -97333,7 +97333,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -97645,7 +97645,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -97671,7 +97671,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -97697,7 +97697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -97735,7 +97735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -97773,7 +97773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -97789,7 +97789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -97806,7 +97806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -97822,7 +97822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -97866,7 +97866,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -97970,7 +97970,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -98008,7 +98008,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -98101,7 +98101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -98139,7 +98139,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -98381,7 +98381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -98412,7 +98412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -98504,7 +98504,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -98549,7 +98549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -98686,7 +98686,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -98708,7 +98708,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -99041,7 +99041,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -99067,7 +99067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -99093,7 +99093,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -99131,7 +99131,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -99169,7 +99169,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -99185,7 +99185,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -99202,7 +99202,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -99218,7 +99218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -99262,7 +99262,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -99364,7 +99364,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -99402,7 +99402,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -99495,7 +99495,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -99533,7 +99533,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -99770,7 +99770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -99801,7 +99801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -99893,7 +99893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -99938,7 +99938,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -100075,7 +100075,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -100097,7 +100097,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -100409,7 +100409,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -100435,7 +100435,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -100461,7 +100461,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -100499,7 +100499,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -100537,7 +100537,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -100553,7 +100553,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -100570,7 +100570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -100586,7 +100586,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -100630,7 +100630,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -100732,7 +100732,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -100770,7 +100770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -100863,7 +100863,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -100901,7 +100901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -101175,7 +101175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -101206,7 +101206,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -101298,7 +101298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -101343,7 +101343,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -101496,7 +101496,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -101518,7 +101518,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -101830,7 +101830,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -101856,7 +101856,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -101882,7 +101882,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -101920,7 +101920,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -101958,7 +101958,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -101974,7 +101974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -101991,7 +101991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -102007,7 +102007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -102051,7 +102051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -102155,7 +102155,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -102193,7 +102193,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -102286,7 +102286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -102324,7 +102324,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -102566,7 +102566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -102597,7 +102597,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -102689,7 +102689,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -102734,7 +102734,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -102871,7 +102871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -102893,7 +102893,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -103226,7 +103226,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -103252,7 +103252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -103278,7 +103278,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -103316,7 +103316,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -103354,7 +103354,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -103370,7 +103370,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -103387,7 +103387,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -103403,7 +103403,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -103447,7 +103447,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -103549,7 +103549,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -103587,7 +103587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -103680,7 +103680,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -103718,7 +103718,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -103954,7 +103954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -103985,7 +103985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -104077,7 +104077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -104122,7 +104122,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -104259,7 +104259,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -104281,7 +104281,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -104620,7 +104620,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -104722,7 +104722,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -104760,7 +104760,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -104853,7 +104853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -104891,7 +104891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -105127,7 +105127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -105158,7 +105158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -105250,7 +105250,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -105295,7 +105295,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -105438,7 +105438,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -105460,7 +105460,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -105799,7 +105799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -105901,7 +105901,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -105941,7 +105941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -105955,7 +105955,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -106048,7 +106048,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -106086,7 +106086,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -106322,7 +106322,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -106353,7 +106353,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -106420,7 +106420,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -106454,7 +106454,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 rules:
 - apiGroups:
@@ -106476,7 +106476,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -106508,7 +106508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -106530,7 +106530,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -106552,7 +106552,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -106574,7 +106574,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -106627,7 +106627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -106675,7 +106675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -106720,7 +106720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -106857,7 +106857,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -106879,7 +106879,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -107228,7 +107228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -107254,7 +107254,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -107280,7 +107280,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -107318,7 +107318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -107356,7 +107356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -107372,7 +107372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -107389,7 +107389,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -107405,7 +107405,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -107449,7 +107449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -107551,7 +107551,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -107589,7 +107589,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -107682,7 +107682,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -107720,7 +107720,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -107956,7 +107956,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -107987,7 +107987,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -108128,7 +108128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -108173,7 +108173,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -108474,7 +108474,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -108496,7 +108496,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -108808,7 +108808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -108834,7 +108834,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -108860,7 +108860,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -108898,7 +108898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -108936,7 +108936,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -108952,7 +108952,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -108969,7 +108969,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -108985,7 +108985,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -109162,7 +109162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -109264,7 +109264,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -109304,7 +109304,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -109318,7 +109318,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -109411,7 +109411,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -109449,7 +109449,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -109685,7 +109685,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -109716,7 +109716,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -109783,7 +109783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -109817,7 +109817,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 rules:
 - apiGroups:
@@ -109839,7 +109839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -109871,7 +109871,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109893,7 +109893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109915,7 +109915,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -109937,7 +109937,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -109990,7 +109990,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -110038,7 +110038,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -110083,7 +110083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -110220,7 +110220,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -110242,7 +110242,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -110570,7 +110570,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -110596,7 +110596,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -110622,7 +110622,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -110660,7 +110660,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -110698,7 +110698,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -110714,7 +110714,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -110731,7 +110731,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -110747,7 +110747,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -110791,7 +110791,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -110893,7 +110893,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -110933,7 +110933,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -110947,7 +110947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -111040,7 +111040,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -111078,7 +111078,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -111314,7 +111314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -111345,7 +111345,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -111412,7 +111412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 rules:
 - apiGroups:
@@ -111446,7 +111446,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 rules:
 - apiGroups:
@@ -111468,7 +111468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 rules:
 - apiGroups:
@@ -111500,7 +111500,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111522,7 +111522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111544,7 +111544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk-bundle
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -111566,7 +111566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 rules:
@@ -111619,7 +111619,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sidecar-controllers
   namespace: default
 roleRef:
@@ -111667,7 +111667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -111712,7 +111712,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -111849,7 +111849,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -111871,7 +111871,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -112221,7 +112221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -112247,7 +112247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -112273,7 +112273,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -112311,7 +112311,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -112349,7 +112349,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -112365,7 +112365,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -112382,7 +112382,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -112398,7 +112398,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -112442,7 +112442,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -112544,7 +112544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -112582,7 +112582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -112675,7 +112675,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -112713,7 +112713,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -112772,7 +112772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-fs-validator
   namespace: default
 stringData:
@@ -113004,7 +113004,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -113035,7 +113035,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -113127,7 +113127,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -113172,7 +113172,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -113309,7 +113309,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -113331,7 +113331,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -113709,7 +113709,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -113735,7 +113735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -113761,7 +113761,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -113799,7 +113799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -113837,7 +113837,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -113853,7 +113853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -113870,7 +113870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -113886,7 +113886,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -113930,7 +113930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -114032,7 +114032,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -114070,7 +114070,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -114163,7 +114163,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -114201,7 +114201,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -114437,7 +114437,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -114468,7 +114468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -114560,7 +114560,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -114607,7 +114607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -114652,7 +114652,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -114697,7 +114697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -114832,7 +114832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -114854,7 +114854,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -115166,7 +115166,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -115192,7 +115192,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -115218,7 +115218,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -115258,7 +115258,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -115298,7 +115298,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -115314,7 +115314,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -115331,7 +115331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -115347,7 +115347,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -115391,7 +115391,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -115493,7 +115493,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -115531,7 +115531,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -115624,7 +115624,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -115662,7 +115662,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -115898,7 +115898,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -115929,7 +115929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -116021,7 +116021,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -116068,7 +116068,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-0
   namespace: default
@@ -116113,7 +116113,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-1
   namespace: default
@@ -116158,7 +116158,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     repdanda.com/type: loadbalancer
   name: lb-redpanda-2
   namespace: default
@@ -116293,7 +116293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -116315,7 +116315,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -116627,7 +116627,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -116653,7 +116653,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -116679,7 +116679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -116719,7 +116719,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -116759,7 +116759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -116775,7 +116775,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -116792,7 +116792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -116808,7 +116808,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -116852,7 +116852,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -116954,7 +116954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -116992,7 +116992,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -117085,7 +117085,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -117123,7 +117123,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -117421,7 +117421,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -117452,7 +117452,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -117544,7 +117544,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -117609,7 +117609,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -117783,7 +117783,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -117805,7 +117805,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -118162,7 +118162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -118188,7 +118188,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -118214,7 +118214,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -118252,7 +118252,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -118290,7 +118290,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -118306,7 +118306,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -118323,7 +118323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -118339,7 +118339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -118383,7 +118383,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -118485,7 +118485,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -118523,7 +118523,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -118616,7 +118616,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -118654,7 +118654,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -118897,7 +118897,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -118930,7 +118930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -119022,7 +119022,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -119067,7 +119067,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -119210,7 +119210,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -119232,7 +119232,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -119556,7 +119556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -119582,7 +119582,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -119608,7 +119608,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-root-certificate
   namespace: default
 spec:
@@ -119634,7 +119634,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -119672,7 +119672,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -119710,7 +119710,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-cert
   namespace: default
 spec:
@@ -119748,7 +119748,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-client
 spec:
   commonName: redpanda-client
@@ -119773,7 +119773,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -119789,7 +119789,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -119806,7 +119806,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -119822,7 +119822,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -119839,7 +119839,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-selfsigned-issuer
   namespace: default
 spec:
@@ -119855,7 +119855,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-kafka-internal-0-root-issuer
   namespace: default
 spec:
@@ -119899,7 +119899,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -120007,7 +120007,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -120045,7 +120045,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -120138,7 +120138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -120176,7 +120176,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -120412,7 +120412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -120443,7 +120443,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -120535,7 +120535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -120580,7 +120580,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -120717,7 +120717,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -120739,7 +120739,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -121051,7 +121051,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -121077,7 +121077,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -121103,7 +121103,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -121141,7 +121141,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -121179,7 +121179,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -121195,7 +121195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -121212,7 +121212,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -121228,7 +121228,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -121272,7 +121272,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -121374,7 +121374,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -121412,7 +121412,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -121505,7 +121505,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -121543,7 +121543,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -121779,7 +121779,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -121810,7 +121810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -121902,7 +121902,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -121947,7 +121947,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -122084,7 +122084,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -122106,7 +122106,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -122418,7 +122418,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -122444,7 +122444,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -122470,7 +122470,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -122508,7 +122508,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -122546,7 +122546,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -122562,7 +122562,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -122579,7 +122579,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -122595,7 +122595,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -122612,7 +122612,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -122670,7 +122670,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -122772,7 +122772,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -122810,7 +122810,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -122903,7 +122903,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -122941,7 +122941,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -123164,7 +123164,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -123194,7 +123194,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -123286,7 +123286,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -123331,7 +123331,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "true"
   name: redpanda
   namespace: default
@@ -123468,7 +123468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -123490,7 +123490,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -123801,7 +123801,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -123827,7 +123827,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -123853,7 +123853,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -123891,7 +123891,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -123929,7 +123929,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -123945,7 +123945,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -123962,7 +123962,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -123978,7 +123978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -123995,7 +123995,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -124049,7 +124049,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -124151,7 +124151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -124189,7 +124189,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -124282,7 +124282,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -124320,7 +124320,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -124556,7 +124556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -124587,7 +124587,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -124679,7 +124679,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -124724,7 +124724,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -124861,7 +124861,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -124883,7 +124883,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -125195,7 +125195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -125221,7 +125221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -125247,7 +125247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -125285,7 +125285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -125323,7 +125323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -125339,7 +125339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -125356,7 +125356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -125372,7 +125372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -125416,7 +125416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -125518,7 +125518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -125556,7 +125556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -125649,7 +125649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -125687,7 +125687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -125960,7 +125960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -125991,7 +125991,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -126083,7 +126083,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -126128,7 +126128,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -126281,7 +126281,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -126303,7 +126303,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -126615,7 +126615,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -126641,7 +126641,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -126667,7 +126667,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -126705,7 +126705,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -126743,7 +126743,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -126759,7 +126759,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -126776,7 +126776,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -126792,7 +126792,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -126836,7 +126836,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -126940,7 +126940,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -126978,7 +126978,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -127071,7 +127071,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -127109,7 +127109,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -127350,7 +127350,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -127381,7 +127381,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -127473,7 +127473,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -127518,7 +127518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -127655,7 +127655,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -127677,7 +127677,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -128010,7 +128010,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -128036,7 +128036,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -128062,7 +128062,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -128100,7 +128100,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -128138,7 +128138,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -128154,7 +128154,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -128171,7 +128171,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -128187,7 +128187,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -128231,7 +128231,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -128333,7 +128333,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -128371,7 +128371,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -128464,7 +128464,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -128502,7 +128502,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -128739,7 +128739,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -128770,7 +128770,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -128862,7 +128862,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -128907,7 +128907,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -129044,7 +129044,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -129066,7 +129066,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -129378,7 +129378,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -129404,7 +129404,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -129430,7 +129430,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -129468,7 +129468,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -129506,7 +129506,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -129522,7 +129522,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -129539,7 +129539,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -129555,7 +129555,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -129599,7 +129599,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -129701,7 +129701,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -129739,7 +129739,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -129832,7 +129832,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -129870,7 +129870,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -130144,7 +130144,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -130175,7 +130175,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -130267,7 +130267,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -130312,7 +130312,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -130465,7 +130465,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -130487,7 +130487,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -130799,7 +130799,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -130825,7 +130825,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -130851,7 +130851,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -130889,7 +130889,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -130927,7 +130927,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -130943,7 +130943,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -130960,7 +130960,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -130976,7 +130976,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -131020,7 +131020,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -131124,7 +131124,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -131162,7 +131162,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -131255,7 +131255,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -131293,7 +131293,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -131535,7 +131535,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -131566,7 +131566,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -131658,7 +131658,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -131703,7 +131703,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -131840,7 +131840,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -131862,7 +131862,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -132195,7 +132195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -132221,7 +132221,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -132247,7 +132247,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -132285,7 +132285,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -132323,7 +132323,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -132339,7 +132339,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -132356,7 +132356,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -132372,7 +132372,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -132416,7 +132416,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -132518,7 +132518,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -132556,7 +132556,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -132649,7 +132649,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -132687,7 +132687,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -132923,7 +132923,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -132954,7 +132954,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -133056,7 +133056,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -133101,7 +133101,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -133245,7 +133245,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -133267,7 +133267,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -133607,7 +133607,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -133633,7 +133633,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -133659,7 +133659,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -133697,7 +133697,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -133735,7 +133735,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -133751,7 +133751,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -133768,7 +133768,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -133784,7 +133784,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -133828,7 +133828,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:
@@ -133930,7 +133930,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -133968,7 +133968,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-sts-lifecycle
   namespace: default
 stringData:
@@ -134061,7 +134061,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-config-watcher
   namespace: default
 stringData:
@@ -134099,7 +134099,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configurator
   namespace: default
 stringData:
@@ -134335,7 +134335,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 ---
@@ -134366,7 +134366,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-rpk
   namespace: default
 ---
@@ -134458,7 +134458,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external
   namespace: default
 spec:
@@ -134503,7 +134503,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
     monitoring.redpanda.com/enabled: "false"
   name: redpanda
   namespace: default
@@ -134640,7 +134640,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda
   namespace: default
 spec:
@@ -134662,7 +134662,7 @@ spec:
         app.kubernetes.io/instance: redpanda
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: redpanda
-        helm.sh/chart: redpanda-5.9.9
+        helm.sh/chart: redpanda-5.9.10
         redpanda.com/poddisruptionbudget: redpanda
     spec:
       affinity:
@@ -134974,7 +134974,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-certificate
   namespace: default
 spec:
@@ -135000,7 +135000,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-certificate
   namespace: default
 spec:
@@ -135026,7 +135026,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-cert
   namespace: default
 spec:
@@ -135064,7 +135064,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-cert
   namespace: default
 spec:
@@ -135102,7 +135102,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-selfsigned-issuer
   namespace: default
 spec:
@@ -135118,7 +135118,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-default-root-issuer
   namespace: default
 spec:
@@ -135135,7 +135135,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-selfsigned-issuer
   namespace: default
 spec:
@@ -135151,7 +135151,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-external-root-issuer
   namespace: default
 spec:
@@ -135195,7 +135195,7 @@ metadata:
     app.kubernetes.io/instance: redpanda
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: redpanda
-    helm.sh/chart: redpanda-5.9.9
+    helm.sh/chart: redpanda-5.9.10
   name: redpanda-configuration
   namespace: default
 spec:


### PR DESCRIPTION
Cuts the release of 5.9.10 since we can't release the operator until we do as test failures are currently occuring on operator pull requests that require a newer version of `helm-charts`.