### PR TITLE
Add Schema Registry to published rpk profile

### DIFF
--- a/charts/redpanda/templates/_configmap.go.tpl
+++ b/charts/redpanda/templates/_configmap.go.tpl
@@ -106,6 +106,13 @@
 {{- if $_is_returning -}}
 {{- break -}}
 {{- end -}}
+{{- $schemaAdvertisedList := (list ) -}}
+{{- range $_, $i := untilStep (((0 | int) | int)|int) (($values.statefulset.replicas | int)|int) (1|int) -}}
+{{- $schemaAdvertisedList = (concat (default (list ) $schemaAdvertisedList) (list (printf "%s:%d" (get (fromJson (include "redpanda.advertisedHost" (dict "a" (list $dot $i) ))) "r") (((get (fromJson (include "redpanda.advertisedSchemaPort" (dict "a" (list $dot $i) ))) "r") | int) | int)))) -}}
+{{- end -}}
+{{- if $_is_returning -}}
+{{- break -}}
+{{- end -}}
 {{- $kafkaTLS := (get (fromJson (include "redpanda.rpkKafkaClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
 {{- $tmp_tuple_3 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $kafkaTLS "ca_file" (coalesce nil)) ))) "r")) ))) "r") -}}
 {{- $ok_3 := $tmp_tuple_3.T2 -}}
@@ -118,6 +125,12 @@
 {{- if $ok_4 -}}
 {{- $_ := (set $adminTLS "ca_file" "ca.crt") -}}
 {{- end -}}
+{{- $schemaTLS := (get (fromJson (include "redpanda.rpkSchemaRegistryClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- $tmp_tuple_5 := (get (fromJson (include "_shims.compact" (dict "a" (list (get (fromJson (include "_shims.dicttest" (dict "a" (list $schemaTLS "ca_file" (coalesce nil)) ))) "r")) ))) "r") -}}
+{{- $ok_5 := $tmp_tuple_5.T2 -}}
+{{- if $ok_5 -}}
+{{- $_ := (set $schemaTLS "ca_file" "ca.crt") -}}
+{{- end -}}
 {{- $ka := (dict "brokers" $brokerList "tls" (coalesce nil) ) -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $kafkaTLS) ))) "r") | int) (0 | int)) -}}
 {{- $_ := (set $ka "tls" $kafkaTLS) -}}
@@ -126,7 +139,11 @@
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $adminTLS) ))) "r") | int) (0 | int)) -}}
 {{- $_ := (set $aa "tls" $adminTLS) -}}
 {{- end -}}
-{{- $result := (dict "name" (get (fromJson (include "redpanda.getFirstExternalKafkaListener" (dict "a" (list $dot) ))) "r") "kafka_api" $ka "admin_api" $aa ) -}}
+{{- $sa := (dict "addresses" $schemaAdvertisedList "tls" (coalesce nil) ) -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $schemaTLS) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $sa "tls" $schemaTLS) -}}
+{{- end -}}
+{{- $result := (dict "name" (get (fromJson (include "redpanda.getFirstExternalKafkaListener" (dict "a" (list $dot) ))) "r") "kafka_api" $ka "admin_api" $aa "schema_registry" $sa ) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $result) | toJson -}}
 {{- break -}}
@@ -168,6 +185,32 @@
 {{- $externalAdminListenerName := (first $keys) -}}
 {{- $listener := (index $values.listeners.admin.external (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $externalAdminListenerName) ))) "r")) -}}
 {{- $port := (($values.listeners.admin.port | int) | int) -}}
+{{- if (gt (($listener.port | int) | int) (1 | int)) -}}
+{{- $port = (($listener.port | int) | int) -}}
+{{- end -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (1 | int)) -}}
+{{- $port = ((index $listener.advertisedPorts $i) | int) -}}
+{{- else -}}{{- if (eq ((get (fromJson (include "_shims.len" (dict "a" (list $listener.advertisedPorts) ))) "r") | int) (1 | int)) -}}
+{{- $port = ((index $listener.advertisedPorts (0 | int)) | int) -}}
+{{- end -}}
+{{- end -}}
+{{- $_is_returning = true -}}
+{{- (dict "r" $port) | toJson -}}
+{{- break -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "redpanda.advertisedSchemaPort" -}}
+{{- $dot := (index .a 0) -}}
+{{- $i := (index .a 1) -}}
+{{- range $_ := (list 1) -}}
+{{- $_is_returning := false -}}
+{{- $values := $dot.Values.AsMap -}}
+{{- $keys := (keys $values.listeners.schemaRegistry.external) -}}
+{{- $_ := (sortAlpha $keys) -}}
+{{- $externalSchemaListenerName := (first $keys) -}}
+{{- $listener := (index $values.listeners.schemaRegistry.external (get (fromJson (include "_shims.typeassertion" (dict "a" (list "string" $externalSchemaListenerName) ))) "r")) -}}
+{{- $port := (($values.listeners.schemaRegistry.port | int) | int) -}}
 {{- if (gt (($listener.port | int) | int) (1 | int)) -}}
 {{- $port = (($listener.port | int) | int) -}}
 {{- end -}}
@@ -251,19 +294,19 @@
 {{- $values := $dot.Values.AsMap -}}
 {{- $brokerList := (get (fromJson (include "redpanda.BrokerList" (dict "a" (list $dot ($values.statefulset.replicas | int) ($values.listeners.kafka.port | int)) ))) "r") -}}
 {{- $adminTLS := (coalesce nil) -}}
-{{- $tls_5 := (get (fromJson (include "redpanda.rpkAdminAPIClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_5) ))) "r") | int) (0 | int)) -}}
-{{- $adminTLS = $tls_5 -}}
+{{- $tls_6 := (get (fromJson (include "redpanda.rpkAdminAPIClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_6) ))) "r") | int) (0 | int)) -}}
+{{- $adminTLS = $tls_6 -}}
 {{- end -}}
 {{- $brokerTLS := (coalesce nil) -}}
-{{- $tls_6 := (get (fromJson (include "redpanda.rpkKafkaClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_6) ))) "r") | int) (0 | int)) -}}
-{{- $brokerTLS = $tls_6 -}}
+{{- $tls_7 := (get (fromJson (include "redpanda.rpkKafkaClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_7) ))) "r") | int) (0 | int)) -}}
+{{- $brokerTLS = $tls_7 -}}
 {{- end -}}
 {{- $schemaRegistryTLS := (coalesce nil) -}}
-{{- $tls_7 := (get (fromJson (include "redpanda.rpkSchemaRegistryClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_7) ))) "r") | int) (0 | int)) -}}
-{{- $schemaRegistryTLS = $tls_7 -}}
+{{- $tls_8 := (get (fromJson (include "redpanda.rpkSchemaRegistryClientTLSConfiguration" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_8) ))) "r") | int) (0 | int)) -}}
+{{- $schemaRegistryTLS = $tls_8 -}}
 {{- end -}}
 {{- $result := (dict "overprovisioned" (get (fromJson (include "redpanda.RedpandaResources.GetOverProvisionValue" (dict "a" (list $values.resources) ))) "r") "enable_memory_locking" (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.resources.memory.enable_memory_locking false) ))) "r") "additional_start_flags" (get (fromJson (include "redpanda.RedpandaAdditionalStartFlags" (dict "a" (list $dot ((get (fromJson (include "redpanda.RedpandaSMP" (dict "a" (list $dot) ))) "r") | int64)) ))) "r") "kafka_api" (dict "brokers" $brokerList "tls" $brokerTLS ) "admin_api" (dict "addresses" (get (fromJson (include "redpanda.Listeners.AdminList" (dict "a" (list $values.listeners ($values.statefulset.replicas | int) (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) ))) "r") "tls" $adminTLS ) "schema_registry" (dict "addresses" (get (fromJson (include "redpanda.Listeners.SchemaRegistryList" (dict "a" (list $values.listeners ($values.statefulset.replicas | int) (get (fromJson (include "redpanda.Fullname" (dict "a" (list $dot) ))) "r") (get (fromJson (include "redpanda.InternalDomain" (dict "a" (list $dot) ))) "r")) ))) "r") "tls" $schemaRegistryTLS ) ) -}}
 {{- $result = (merge (dict ) $result (get (fromJson (include "redpanda.Tuning.Translate" (dict "a" (list $values.tuning) ))) "r")) -}}
@@ -381,18 +424,18 @@
 {{- $_ := (set $redpanda "kafka_api" (get (fromJson (include "redpanda.KafkaListeners.Listeners" (dict "a" (list $values.listeners.kafka $values.auth) ))) "r")) -}}
 {{- $_ := (set $redpanda "rpc_server" (get (fromJson (include "redpanda.rpcListeners" (dict "a" (list $dot) ))) "r")) -}}
 {{- $_ := (set $redpanda "admin_api_tls" (coalesce nil)) -}}
-{{- $tls_8 := (get (fromJson (include "redpanda.AdminListeners.ListenersTLS" (dict "a" (list $values.listeners.admin $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_8) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $redpanda "admin_api_tls" $tls_8) -}}
+{{- $tls_9 := (get (fromJson (include "redpanda.AdminListeners.ListenersTLS" (dict "a" (list $values.listeners.admin $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_9) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "admin_api_tls" $tls_9) -}}
 {{- end -}}
 {{- $_ := (set $redpanda "kafka_api_tls" (coalesce nil)) -}}
-{{- $tls_9 := (get (fromJson (include "redpanda.KafkaListeners.ListenersTLS" (dict "a" (list $values.listeners.kafka $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_9) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $redpanda "kafka_api_tls" $tls_9) -}}
-{{- end -}}
-{{- $tls_10 := (get (fromJson (include "redpanda.rpcListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- $tls_10 := (get (fromJson (include "redpanda.KafkaListeners.ListenersTLS" (dict "a" (list $values.listeners.kafka $values.tls) ))) "r") -}}
 {{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_10) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $redpanda "rpc_server_tls" $tls_10) -}}
+{{- $_ := (set $redpanda "kafka_api_tls" $tls_10) -}}
+{{- end -}}
+{{- $tls_11 := (get (fromJson (include "redpanda.rpcListenersTLS" (dict "a" (list $dot) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_11) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $redpanda "rpc_server_tls" $tls_11) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -405,9 +448,9 @@
 {{- $pandaProxy := (dict ) -}}
 {{- $_ := (set $pandaProxy "pandaproxy_api" (get (fromJson (include "redpanda.HTTPListeners.Listeners" (dict "a" (list $values.listeners.http (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $_ := (set $pandaProxy "pandaproxy_api_tls" (coalesce nil)) -}}
-{{- $tls_11 := (get (fromJson (include "redpanda.HTTPListeners.ListenersTLS" (dict "a" (list $values.listeners.http $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_11) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $pandaProxy "pandaproxy_api_tls" $tls_11) -}}
+{{- $tls_12 := (get (fromJson (include "redpanda.HTTPListeners.ListenersTLS" (dict "a" (list $values.listeners.http $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_12) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $pandaProxy "pandaproxy_api_tls" $tls_12) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $pandaProxy) | toJson -}}
@@ -423,9 +466,9 @@
 {{- $schemaReg := (dict ) -}}
 {{- $_ := (set $schemaReg "schema_registry_api" (get (fromJson (include "redpanda.SchemaRegistryListeners.Listeners" (dict "a" (list $values.listeners.schemaRegistry (get (fromJson (include "redpanda.Auth.IsSASLEnabled" (dict "a" (list $values.auth) ))) "r")) ))) "r")) -}}
 {{- $_ := (set $schemaReg "schema_registry_api_tls" (coalesce nil)) -}}
-{{- $tls_12 := (get (fromJson (include "redpanda.SchemaRegistryListeners.ListenersTLS" (dict "a" (list $values.listeners.schemaRegistry $values.tls) ))) "r") -}}
-{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_12) ))) "r") | int) (0 | int)) -}}
-{{- $_ := (set $schemaReg "schema_registry_api_tls" $tls_12) -}}
+{{- $tls_13 := (get (fromJson (include "redpanda.SchemaRegistryListeners.ListenersTLS" (dict "a" (list $values.listeners.schemaRegistry $values.tls) ))) "r") -}}
+{{- if (gt ((get (fromJson (include "_shims.len" (dict "a" (list $tls_13) ))) "r") | int) (0 | int)) -}}
+{{- $_ := (set $schemaReg "schema_registry_api_tls" $tls_13) -}}
 {{- end -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" $schemaReg) | toJson -}}

--- a/charts/redpanda/testdata/template-cases.golden.txtar
+++ b/charts/redpanda/testdata/template-cases.golden.txtar
@@ -438,6 +438,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -1708,6 +1715,10 @@ data:
       - redpanda-0:31092
       tls: null
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      tls: null
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -2806,6 +2817,11 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -4208,6 +4224,10 @@ data:
       - redpanda-0:31092
       tls: null
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      tls: null
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -5521,6 +5541,11 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -6982,6 +7007,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -8527,6 +8559,12 @@ data:
       - redpanda-2:31092
       tls: null
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls: null
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -10051,6 +10089,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -11472,6 +11517,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -12923,6 +12975,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-1.my-domain:30081
+      - 127.0.0.1.my-domain:30081
+      - 192.168.0.1.my-domain:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -14443,6 +14502,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -15886,6 +15952,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0.random-domain:30080
+      - redpanda-1.random-domain:30080
+      - redpanda-2.random-domain:30080
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -17158,6 +17231,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0.random-domain:30081
+      - redpanda-1.random-domain:30081
+      - redpanda-2.random-domain:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -18450,6 +18530,12 @@ data:
       - redpanda-2:31092
       tls: null
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls: null
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -19608,6 +19694,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -21007,6 +21100,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -22641,6 +22741,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -24011,6 +24118,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - $PREFIX_TEMPLATE.my-domain:30081
+      - $PREFIX_TEMPLATE.my-domain:30081
+      - $PREFIX_TEMPLATE.my-domain:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -25426,6 +25540,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -26877,6 +26998,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -28326,6 +28454,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -29738,6 +29873,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -31171,6 +31313,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -32634,6 +32783,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -34095,6 +34251,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -35520,6 +35683,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -36966,6 +37136,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -38429,6 +38606,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -39890,6 +40074,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -41315,6 +41506,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -42717,6 +42915,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -44084,6 +44289,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -45452,6 +45664,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -46885,6 +47104,14 @@ data:
       - redpanda-3:31092
       tls: null
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      - redpanda-3:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -48285,6 +48512,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -49670,6 +49904,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -51371,6 +51612,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -52911,6 +53159,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -54624,6 +54879,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0.REDPANDAREDPANDAREDPANDA-testing:30081
+      - redpanda-1.REDPANDAREDPANDAREDPANDA-testing:30081
+      - redpanda-2.REDPANDAREDPANDAREDPANDA-testing:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -55996,6 +56258,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -57401,6 +57670,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -58802,6 +59078,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -60205,6 +60488,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -61543,6 +61833,13 @@ data:
         cert_file: /etc/tls/certs/redpanda-client/tls.crt
         key_file: /etc/tls/certs/redpanda-client/tls.key
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -62860,6 +63157,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -64364,6 +64668,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -65863,6 +66174,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -67248,6 +67566,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -68625,6 +68950,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -70415,6 +70747,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -71784,6 +72123,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -73153,6 +73499,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -74520,6 +74873,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -77400,6 +77760,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -78867,6 +79234,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -80271,6 +80645,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -81661,6 +82042,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -83061,6 +83449,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -84465,6 +84860,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -85855,6 +86257,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -87243,6 +87652,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -88647,6 +89063,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -90037,6 +90460,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -91425,6 +91855,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -92829,6 +93266,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -94219,6 +94663,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -95608,6 +96059,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -97013,6 +97471,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -98404,6 +98869,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -99793,6 +100265,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -101198,6 +101677,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -102589,6 +103075,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -103977,6 +104470,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -105150,6 +105650,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -106345,6 +106852,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -107979,6 +108493,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -109708,6 +110229,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -111337,6 +111865,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -113027,6 +113562,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -114460,6 +115002,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - rp0.REDPANDAREDPANDAREDPANDA-testing:30081
+      - rp1.REDPANDAREDPANDAREDPANDA-testing:30081
+      - rp2.REDPANDAREDPANDAREDPANDA-testing:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -115921,6 +116470,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - $PREFIX_TEMPLATE.REDPANDAREDPANDAREDPANDA-testing:30081
+      - $PREFIX_TEMPLATE.REDPANDAREDPANDAREDPANDA-testing:30081
+      - $PREFIX_TEMPLATE.REDPANDAREDPANDAREDPANDA-testing:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -117444,6 +118000,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -118922,6 +119485,13 @@ data:
         cert_file: /etc/tls/certs/redpanda-client/tls.crt
         key_file: /etc/tls/certs/redpanda-client/tls.key
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -120435,6 +121005,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -121802,6 +122379,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -123186,6 +123770,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -124579,6 +125170,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -125983,6 +126581,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -127373,6 +127978,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -128762,6 +129374,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -130167,6 +130786,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -131558,6 +132184,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -132946,6 +133579,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null
@@ -134358,6 +134998,13 @@ data:
       tls:
         ca_file: ca.crt
     name: default
+    schema_registry:
+      addresses:
+      - redpanda-0:30081
+      - redpanda-1:30081
+      - redpanda-2:30081
+      tls:
+        ca_file: ca.crt
 kind: ConfigMap
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
This adds schema registry connection info to the `*-rpk` ConfigMap we generate for users.