### PR TITLE
Add missing targetLabels default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -374,6 +374,13 @@
 #### Fixed
 #### Removed
 
+### [0.14.1](https://github.com/redpanda-data/helm-charts/releases/tag/kminion-0.14.1)
+#### Added
+#### Changed
+#### Fixed
+* Add serviceMonitor targetLabels parameter in Values.yaml
+#### Removed
+
 ### [0.14.0](https://github.com/redpanda-data/helm-charts/releases/tag/kminion-0.14.0)
 #### Added
 #### Changed

--- a/charts/kminion/Chart.yaml
+++ b/charts/kminion/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.14.0
+version: 0.14.1
 
 # The app version is the default version of Kminion to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/kminion/README.md
+++ b/charts/kminion/README.md
@@ -6,7 +6,7 @@ tags:
 description: The most popular Open Source Kafka JMX to Prometheus tool by the creators of [Redpanda Console](https://github.com/redpanda-data/console) and Redpanda
 ---
 
-![Version: 0.14.0](https://img.shields.io/badge/Version-0.14.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.8](https://img.shields.io/badge/AppVersion-v2.2.8-informational?style=flat-square)
+![Version: 0.14.1](https://img.shields.io/badge/Version-0.14.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.8](https://img.shields.io/badge/AppVersion-v2.2.8-informational?style=flat-square)
 
 This page describes the official Redpanda KMinion Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/kminion/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 
@@ -248,6 +248,10 @@ The port for kminion metrics endpoint
 ### [serviceMonitor.scrapeTimeout](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=serviceMonitor.scrapeTimeout)
 
 **Default:** `"10s"`
+
+### [serviceMonitor.targetLabels](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=serviceMonitor.targetLabels)
+
+**Default:** `[]`
 
 ### [tests.enabled](https://artifacthub.io/packages/helm/redpanda-data/redpanda?modal=values&path=tests.enabled)
 

--- a/charts/kminion/values.yaml
+++ b/charts/kminion/values.yaml
@@ -149,6 +149,7 @@ customLabels: {}
 serviceMonitor:
   create: false
   additionalLabels: {}
+  targetLabels: []
   honorLabels: false
   scrapeTimeout: 10s
   interval: 15s


### PR DESCRIPTION
serviceMonitor object refers to targetLabels, which does not exist in values.yaml. No harm there, but it should be added to values.yaml with its default empty slice value.