### PR TITLE
fix(connect): empty lines and otel example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 #### Added
 #### Changed
 #### Fixed
+* Fixed empty lines after labels when .Values.commonLabels is empty
+* Fixed opentelemetry tracer configuration example, should be open_telemetry_collector
 #### Removed
 
 ### [5.9.15](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.15) - 2024-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 #### Added
 #### Changed
 #### Fixed
-* Fixed empty lines after labels when .Values.commonLabels is empty
-* Fixed opentelemetry tracer configuration example, should be open_telemetry_collector
 #### Removed
 
 ### [5.9.15](https://github.com/redpanda-data/helm-charts/releases/tag/redpanda-5.9.15) - 2024-11-29
@@ -454,6 +452,11 @@
 #### Removed
 
 ## Connect Chart
+### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/connect-FILLMEIN) - YYYY-MM-DD
+#### Fixed
+* Fixed empty lines after labels when .Values.commonLabels is empty
+* Fixed opentelemetry tracer configuration example, should be open_telemetry_collector
+
 ### [3.0.1](https://github.com/redpanda-data/helm-charts/releases/tag/connect-3.0.1)
 #### Added
 * Parameter to configure submitting anonymous telemetry data

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.1
+version: 3.0.2
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.2
+version: 3.0.1
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging

--- a/charts/connect/templates/_helpers.tpl
+++ b/charts/connect/templates/_helpers.tpl
@@ -40,8 +40,8 @@ helm.sh/chart: {{ include "redpanda-connect.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{ with .Values.commonLabels }}
-{{- toYaml . -}}
+{{- if .Values.commonLabels }}
+{{ tpl (toYaml .Values.commonLabels) . }}
 {{- end }}
 {{- end }}
 

--- a/charts/connect/values.yaml
+++ b/charts/connect/values.yaml
@@ -232,7 +232,7 @@ serviceMonitor:
 #   prometheus: {}
 
 # tracing:
-#   openTelemetry:
+#   open_telemetry_collector:
 #     http: []
 #     grpc: []
 #     tags: {}


### PR DESCRIPTION
> [!NOTE]
> This PR backports the changes from https://github.com/redpanda-data/redpanda-connect-helm-chart/pull/100

Changes:
- Fixed empty lines after labels when `.Values.commonLabels` is empty (you can compare with `helm template .`)
- Fixed an error when tracer is configured with `openTelemetry`, should be `open_telemetry_collector` ([source](https://github.com/redpanda-data/connect/blob/main/docs/modules/components/pages/tracers/open_telemetry_collector.adoc#L2))
