### PR TITLE
connect: bumped version to 4.42

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -452,6 +452,10 @@
 #### Removed
 
 ## Connect Chart
+### [3.0.2](https://github.com/redpanda-data/helm-charts/releases/tag/connect-3.0.2)
+#### Changed
+* Bump Connect app version to 4.42.0
+
 ### [3.0.1](https://github.com/redpanda-data/helm-charts/releases/tag/connect-3.0.1)
 #### Added
 * Parameter to configure submitting anonymous telemetry data

--- a/charts/connect/Chart.yaml
+++ b/charts/connect/Chart.yaml
@@ -24,11 +24,11 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 3.0.1
+version: 3.0.2
 
 # The app version is the default version of Redpanda to install.
 # ** NOTE for maintainers: please ensure the artifacthub image annotation is updated before merging
-appVersion: "4.39.0"
+appVersion: "4.42.0"
 
 sources:
   - https://github.com/redpanda-data/helm-charts
@@ -41,6 +41,6 @@ annotations:
       url: https://helm.sh/docs/intro/install/
   artifacthub.io/images: |
     - name: redpanda
-      image: docker.redpanda.com/redpandadata/connect:4.39.0
+      image: docker.redpanda.com/redpandadata/connect:4.42.0
     - name: busybox
       image: busybox:latest

--- a/charts/connect/README.md
+++ b/charts/connect/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Connect Helm chart.
 ---
 
-![Version: 3.0.1](https://img.shields.io/badge/Version-3.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.39.0](https://img.shields.io/badge/AppVersion-4.39.0-informational?style=flat-square)
+![Version: 3.0.2](https://img.shields.io/badge/Version-3.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.42.0](https://img.shields.io/badge/AppVersion-4.42.0-informational?style=flat-square)
 
 Redpanda Connect is a high performance and resilient stream processor, able to connect various sources and sinks in a range of brokering patterns and perform hydration, enrichments, transformations and filters on payloads.
 


### PR DESCRIPTION
Using the current Connect version within the Chart and updated its version to 3.0.2.