### PR TITLE
Handle Service Account auto mount with Deployment Spec token auto mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -263,6 +263,13 @@
 #### Fixed
 #### Removed
 
+### [0.4.35](https://github.com/redpanda-data/helm-charts/releases/tag/operator-0.4.35) - 2024-12-04
+#### Added
+#### Changed
+* to always mounting service account token regardless of auto mount property
+#### Fixed
+#### Removed
+
 ### [0.4.34](https://github.com/redpanda-data/helm-charts/releases/tag/operator-0.4.34) - 2024-11-27
 #### Added
 * overriding any PodSpec fields from `PodTemplate`

--- a/charts/operator/Chart.yaml
+++ b/charts/operator/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # The chart version and the app version are not the same and will not track
 # together. The chart version is a semver representation of changes to this
 # chart.
-version: 0.4.34
+version: 0.4.35
 
 # This is the default version of the operator being deployed.
 # ** NOTE for maintainers: please enssure the artifacthub image annotation is updated before merging

--- a/charts/operator/README.md
+++ b/charts/operator/README.md
@@ -3,7 +3,7 @@
 description: Find the default values and descriptions of settings in the Redpanda Operator Helm chart.
 ---
 
-![Version: 0.4.34](https://img.shields.io/badge/Version-0.4.34-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.2-24.3.1](https://img.shields.io/badge/AppVersion-v2.3.2--24.3.1-informational?style=flat-square)
+![Version: 0.4.35](https://img.shields.io/badge/Version-0.4.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.2-24.3.1](https://img.shields.io/badge/AppVersion-v2.3.2--24.3.1-informational?style=flat-square)
 
 This page describes the official Redpanda Operator Helm Chart. In particular, this page describes the contents of the chart’s [`values.yaml` file](https://github.com/redpanda-data/helm-charts/blob/main/charts/operator/values.yaml). Each of the settings is listed and described on this page, along with any default values.
 

--- a/charts/operator/ci/03-enable-automount-values.yaml
+++ b/charts/operator/ci/03-enable-automount-values.yaml
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+serviceAccount:
+  automountServiceAccountToken: true

--- a/charts/operator/deployment.go
+++ b/charts/operator/deployment.go
@@ -147,7 +147,7 @@ func operatorContainers(dot *helmette.Dot, podTerminationGracePeriodSeconds *int
 func kubeRBACProxyVolumeMounts(dot *helmette.Dot) []corev1.VolumeMount {
 	values := helmette.Unwrap[Values](dot.Values)
 
-	if !(values.ServiceAccount.Create && !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false)) {
+	if !values.ServiceAccount.Create {
 		return nil
 	}
 
@@ -259,7 +259,7 @@ func operatorPodVolumes(dot *helmette.Dot) []corev1.Volume {
 
 	vol := []corev1.Volume{}
 
-	if values.ServiceAccount.Create && !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false) {
+	if values.ServiceAccount.Create {
 		vol = append(vol, kubeTokenAPIVolume(ServiceAccountVolumeName))
 	}
 
@@ -335,7 +335,7 @@ func operatorPodVolumesMounts(dot *helmette.Dot) []corev1.VolumeMount {
 
 	volMount := []corev1.VolumeMount{}
 
-	if values.ServiceAccount.Create && !ptr.Deref(values.ServiceAccount.AutomountServiceAccountToken, false) {
+	if values.ServiceAccount.Create {
 		mountName := ServiceAccountVolumeName
 		for _, vol := range operatorPodVolumes(dot) {
 			if strings.HasPrefix(ServiceAccountVolumeName+"-", vol.Name) {

--- a/charts/operator/templates/_deployment.go.tpl
+++ b/charts/operator/templates/_deployment.go.tpl
@@ -32,7 +32,7 @@
 {{- range $_ := (list 1) -}}
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
-{{- if (not ((and $values.serviceAccount.create (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r"))))) -}}
+{{- if (not $values.serviceAccount.create) -}}
 {{- $_is_returning = true -}}
 {{- (dict "r" (coalesce nil)) | toJson -}}
 {{- break -}}
@@ -134,7 +134,7 @@
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $vol := (list ) -}}
-{{- if (and $values.serviceAccount.create (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r"))) -}}
+{{- if $values.serviceAccount.create -}}
 {{- $vol = (concat (default (list ) $vol) (list (get (fromJson (include "operator.kubeTokenAPIVolume" (dict "a" (list "kube-api-access") ))) "r"))) -}}
 {{- end -}}
 {{- if (not $values.webhook.enabled) -}}
@@ -165,7 +165,7 @@
 {{- $_is_returning := false -}}
 {{- $values := $dot.Values.AsMap -}}
 {{- $volMount := (list ) -}}
-{{- if (and $values.serviceAccount.create (not (get (fromJson (include "_shims.ptr_Deref" (dict "a" (list $values.serviceAccount.automountServiceAccountToken false) ))) "r"))) -}}
+{{- if $values.serviceAccount.create -}}
 {{- $mountName := "kube-api-access" -}}
 {{- range $_, $vol := (get (fromJson (include "operator.operatorPodVolumes" (dict "a" (list $dot) ))) "r") -}}
 {{- if (hasPrefix $vol.name (printf "%s%s" "kube-api-access" "-")) -}}

--- a/charts/operator/testdata/template-cases.txtar
+++ b/charts/operator/testdata/template-cases.txtar
@@ -69,3 +69,7 @@ serviceAccount:
 podTemplate:
   spec:
     automountServiceAccountToken: true
+
+-- enabled-service-account-automount-token-in-only-service-account-resource --
+serviceAccount:
+  automountServiceAccountToken: true


### PR DESCRIPTION
The Deployment Spec token auto mount takes precendese over Service Account token
auto mount. Now both token auto mount properties should be set to true in order
to not mount volume.