### PR TITLE
Switch redpanda-operator container image instead of configurator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -275,6 +275,7 @@
 ### [Unreleased](https://github.com/redpanda-data/helm-charts/releases/tag/operator-FILLMEIN) - YYYY-MM-DD
 #### Added
 #### Changed
+* configurator image to redpanda-operator container image
 #### Fixed
 #### Removed
 

--- a/charts/operator/values.yaml
+++ b/charts/operator/values.yaml
@@ -41,7 +41,7 @@ kubeRbacProxy:
 # -- Configuration for the Redpanda configurator, a component for managing Redpanda configuration.
 configurator:
   # -- Sets the repository in which the Redpanda configurator image is available.
-  repository: docker.redpanda.com/redpandadata/configurator
+  repository: docker.redpanda.com/redpandadata/redpanda-operator
   # -- Sets the Redpanda configurator image tag. Uncomment and set a value to use a specific version.
   # tag:
   # -- Sets the `pullPolicy` for the Redpanda configurator image.


### PR DESCRIPTION
Configurator container image can be replaced with redpanda-operator as binary within redpanda-operator can achieve multiple purposes.